### PR TITLE
Stress test emumanager command-line tool

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -34,6 +34,7 @@ get_default_image_package() {
 
 
 usage() {
+  local exit_code="${1:-0}"
   cat <<EOF
 Usage: $(basename "$0") [COMMAND]
 
@@ -70,7 +71,7 @@ Examples:
   # Check for updates
   $(basename "$0") check-updates
 EOF
-  exit 0
+  exit "$exit_code"
 }
 
 require() {
@@ -351,19 +352,19 @@ start_avd() {
 
   local emulator_path="$ANDROID_HOME/emulator/emulator"
   if [[ ! -f "${emulator_path}" ]]; then
-    echo "$(basename "$0"): emulator not found. Please run --install-emulator first." >&2
+    echo "$(basename "$0"): emulator not found. Please run 'bootstrap' first." >&2
     exit 1
   fi
 
   # Check for platform-tools
   if [[ ! -d "$ANDROID_HOME/platform-tools" ]]; then
-    echo "$(basename "$0"): platform-tools not found. Please run --install-platform-tools first." >&2
+    echo "$(basename "$0"): platform-tools not found. Please run 'bootstrap' first." >&2
     exit 1
   fi
 
   local adb_path="$ANDROID_HOME/platform-tools/adb"
   if [[ ! -f "${adb_path}" ]]; then
-    echo "$(basename "$0"): adb not found. Please run --install-platform-tools first." >&2
+    echo "$(basename "$0"): adb not found. Please run 'bootstrap' first." >&2
     exit 1
   fi
 
@@ -584,6 +585,6 @@ case "$1" in
     ;;
   *)
     echo "$(basename "$0"): unknown command '$1'" >&2
-    usage
+    usage 1
     ;;
 esac


### PR DESCRIPTION
- Fix invalid command returning exit code 0 instead of 1 Modified usage() to accept exit code parameter, defaulting to 0 Unknown commands now call usage with exit code 1

- Fix error messages referencing non-existent commands Changed '--install-emulator' and '--install-platform-tools' references to 'bootstrap' which is the correct command

These fixes address two critical bugs found during stress testing:
1. Invalid commands breaking automation due to wrong exit codes
2. Users being directed to non-existent commands in error messages