### PR TITLE
Fix adb device waiting bug in emumanager

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -335,6 +335,40 @@ download_image() {
   fi
 }
 
+find_available_emulator_port() {
+  # Find an available port for starting an emulator.
+  # This is necessary to ensure we can wait for the specific device we're starting,
+  # rather than relying on ANDROID_SERIAL which may point to a different device.
+  # Emulator ports must be even numbers between 5554 and 5584.
+  local adb_path="$ANDROID_HOME/platform-tools/adb"
+
+  # Get list of currently used emulator ports from adb devices
+  local used_ports
+  used_ports=$("${adb_path}" devices 2>/dev/null | grep "emulator-" | awk '{print $1}' | sed 's/emulator-//' || true)
+
+  # Try ports from 5554 to 5584 (even numbers only)
+  for port in $(seq 5554 2 5584); do
+    local port_in_use=false
+
+    # Check if this port is in the list of used ports
+    for used_port in $used_ports; do
+      if [[ "$port" == "$used_port" ]]; then
+        port_in_use=true
+        break
+      fi
+    done
+
+    if [[ "$port_in_use" == false ]]; then
+      echo "$port"
+      return 0
+    fi
+  done
+
+  # If we get here, all ports are in use
+  echo "$(basename "$0"): No available emulator ports (5554-5584)" >&2
+  exit 1
+}
+
 create_avd() {
   bootstrap
   require avdmanager
@@ -449,18 +483,23 @@ start_avd() {
     fi
   fi
 
-  echo "Starting AVD '${avd_name}'..."
+  # Find an available port to avoid conflicts with ANDROID_SERIAL
+  local emulator_port
+  emulator_port=$(find_available_emulator_port)
+  local emulator_serial="emulator-${emulator_port}"
+
+  echo "Starting AVD '${avd_name}' on port ${emulator_port} (serial: ${emulator_serial})..."
   local emulator_log
   emulator_log=$(mktemp)
-  nohup "${emulator_path}" -avd "${avd_name}" -no-snapshot-load > "${emulator_log}" 2>&1 &
+  nohup "${emulator_path}" -avd "${avd_name}" -port "${emulator_port}" -no-snapshot-load > "${emulator_log}" 2>&1 &
 
   echo ""
   echo "To debug emulator issues, run this command:"
-  echo "  ${emulator_path} -avd '${avd_name}' -no-snapshot-load -verbose -show-kernel -no-audio"
+  echo "  ${emulator_path} -avd '${avd_name}' -port ${emulator_port} -no-snapshot-load -verbose -show-kernel -no-audio"
   echo ""
 
-  echo "Waiting for device to connect (timeout: 120s)..."
-  if ! timeout 120 "${adb_path}" wait-for-device; then
+  echo "Waiting for device ${emulator_serial} to connect (timeout: 120s)..."
+  if ! timeout 120 "${adb_path}" -s "${emulator_serial}" wait-for-device; then
     echo "$(basename "$0"): Timeout waiting for device to connect" >&2
     echo "The emulator may still be starting. Check with: ${adb_path} devices" >&2
     echo "Or debug with the command shown above" >&2
@@ -471,7 +510,7 @@ start_avd() {
     exit 1
   fi
   rm -f "${emulator_log}"
-  echo "Device connected."
+  echo "Device ${emulator_serial} connected."
 }
 
 stop_avd() {


### PR DESCRIPTION
The start command had a bug where `adb wait-for-device` would wait for the wrong device when ANDROID_SERIAL environment variable is set. This could cause the command to hang indefinitely or wait for a different device than the one being started.

Solution:
- Added find_available_emulator_port() function to find an available emulator port (5554-5584, even numbers only)
- Modified start_avd() to explicitly start the emulator with a specific port using the -port option
- Changed adb wait-for-device to use -s flag to wait for the specific emulator serial (emulator-<port>)

This ensures we always wait for the correct device being started, regardless of what ANDROID_SERIAL is set to.

The mapping from AVD name to adb device name is now deterministic because we control the port assignment.