### PR TITLE
Fix error message for missing package

### DIFF
--- a/bin/context-jetpack
+++ b/bin/context-jetpack
@@ -130,7 +130,10 @@ for PACKAGE_NAME in "${PACKAGES[@]}"; do
   SOURCE_JAR_FILENAME="${ARTIFACT_ID}-${VERSION}-sources.jar"
 
   echo "info: Downloading ${PACKAGE_NAME} version ${VERSION}" >&2
-  curl -sSL -o "${BUILD_DIR}/${SOURCE_JAR_FILENAME}" "${SOURCE_JAR_URL}"
+  if ! curl -sSLf -o "${BUILD_DIR}/${SOURCE_JAR_FILENAME}" "${SOURCE_JAR_URL}"; then
+    echo "$(basename "$0"): failed to download source JAR for ${PACKAGE_NAME} version ${VERSION} from ${SOURCE_JAR_URL}" >&2
+    exit 1
+  fi
 
   (
     cd "${BUILD_DIR}"

--- a/bin/jetpack-version
+++ b/bin/jetpack-version
@@ -76,9 +76,15 @@ ARTIFACT_ID=$(echo "$PACKAGE_NAME" | cut -d: -f2)
 GROUP_ID_PATH=$(echo "$GROUP_ID" | sed 's/\./\//g')
 METADATA_URL="$REPO_URL/$GROUP_ID_PATH/$ARTIFACT_ID/maven-metadata.xml"
 
+# Check if the package exists
+if ! curl -sSLf "$METADATA_URL" > /dev/null 2>&1; then
+  echo "$(basename "$0"): package '$PACKAGE_NAME' not found at $METADATA_URL" >&2
+  exit 1
+fi
+
 case "$VERSION_TYPE" in
   ALPHA)
-    VERSION=$(curl -sSL "$METADATA_URL" |
+    VERSION=$(curl -sSLf "$METADATA_URL" |
       xmllint --xpath "//version/text()" - |
       tr ' ' '\n' |
       grep -E '^[0-9]+\.[0-9]+\.[0-9]+-alpha[0-9]+$' |
@@ -92,7 +98,7 @@ case "$VERSION_TYPE" in
     ;;
 
   BETA)
-    VERSION=$(curl -sSL "$METADATA_URL" |
+    VERSION=$(curl -sSLf "$METADATA_URL" |
       xmllint --xpath "//version/text()" - |
       tr ' ' '\n' |
       grep -E '^[0-9]+\.[0-9]+\.[0-9]+-beta[0-9]+$' |
@@ -106,7 +112,7 @@ case "$VERSION_TYPE" in
     ;;
 
   RC)
-    VERSION=$(curl -sSL "$METADATA_URL" |
+    VERSION=$(curl -sSLf "$METADATA_URL" |
       xmllint --xpath "//version/text()" - |
       tr ' ' '\n' |
       grep -E '^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$' |
@@ -120,7 +126,7 @@ case "$VERSION_TYPE" in
     ;;
 
   STABLE)
-    VERSION=$(curl -sSL "$METADATA_URL" |
+    VERSION=$(curl -sSLf "$METADATA_URL" |
       xmllint --xpath "//version/text()" - |
       tr ' ' '\n' |
       grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' |
@@ -128,7 +134,7 @@ case "$VERSION_TYPE" in
       tail -n 1)
 
     if [[ -z "$VERSION" ]]; then
-      VERSION=$(curl -sSL "$METADATA_URL" |
+      VERSION=$(curl -sSLf "$METADATA_URL" |
         xmllint --xpath "//version/text()" - |
         tr ' ' '\n' |
         sort -V |
@@ -142,7 +148,7 @@ case "$VERSION_TYPE" in
     ;;
 
   LATEST)
-    VERSION=$(curl -sSL "$METADATA_URL" |
+    VERSION=$(curl -sSLf "$METADATA_URL" |
       xmllint --xpath "//versioning/latest/text()" -)
 
     if [[ -z "$VERSION" ]]; then


### PR DESCRIPTION
Added curl's --fail flag to both jetpack-version and context-jetpack scripts to properly handle HTTP 404 errors when packages don't exist.

Changes:
- jetpack-version: Added upfront check for package existence before processing version queries. All curl commands now use --fail flag.
- context-jetpack: Added error handling for source JAR downloads with --fail flag and clear error message.

Previously, these scripts would output ugly xmllint errors when curl received HTML error pages from 404 responses. Now they exit cleanly with informative error messages.