### PR TITLE
Add jetpack-library script to convert package names to library coordinates

### DIFF
--- a/bin/jetpack-library
+++ b/bin/jetpack-library
@@ -71,12 +71,8 @@ THREE_SEGMENT_GROUPS=(
 # Exceptions table: maps package prefix to library coordinate
 # Format: "package.prefix|group:artifact"
 EXCEPTIONS=(
-  "androidx.wear.ambient|androidx.wear:wear"
-  "androidx.wear.input|androidx.wear:wear-input"
-  "androidx.wear.ongoing|androidx.wear:wear-ongoing"
-  "androidx.wear.phone|androidx.wear:wear-phone-interactions"
-  "androidx.wear.remote|androidx.wear:wear-remote-interactions"
-  "androidx.wear.tiles|androidx.wear.tiles:tiles"
+  "androidx.activity.contextaware|androidx.activity:activity"
+  "androidx.activity.result|androidx.activity:activity"
   "androidx.core.app|androidx.core:core"
   "androidx.core.content|androidx.core:core"
   "androidx.core.graphics|androidx.core:core"
@@ -84,12 +80,17 @@ EXCEPTIONS=(
   "androidx.core.util|androidx.core:core"
   "androidx.core.view|androidx.core:core"
   "androidx.core.widget|androidx.core:core"
-  "androidx.activity.result|androidx.activity:activity"
-  "androidx.activity.contextaware|androidx.activity:activity"
+  "androidx.datastore.preferences.core|androidx.datastore:datastore-preferences-core"
   "androidx.fragment.app|androidx.fragment:fragment"
-  "androidx.lifecycle.viewmodel|androidx.lifecycle:lifecycle-viewmodel"
   "androidx.lifecycle.livedata|androidx.lifecycle:lifecycle-livedata"
+  "androidx.lifecycle.viewmodel|androidx.lifecycle:lifecycle-viewmodel"
   "androidx.lifecycle|androidx.lifecycle:lifecycle-runtime"
+  "androidx.wear.ambient|androidx.wear:wear"
+  "androidx.wear.input|androidx.wear:wear-input"
+  "androidx.wear.ongoing|androidx.wear:wear-ongoing"
+  "androidx.wear.phone|androidx.wear:wear-phone-interactions"
+  "androidx.wear.remote|androidx.wear:wear-remote-interactions"
+  "androidx.wear.tiles|androidx.wear.tiles:tiles"
 )
 
 # Check exceptions first (longest match wins)

--- a/bin/jetpack-library
+++ b/bin/jetpack-library
@@ -82,15 +82,19 @@ EXCEPTIONS=(
   "androidx.core.widget|androidx.core:core"
   "androidx.datastore.preferences.core|androidx.datastore:datastore-preferences-core"
   "androidx.fragment.app|androidx.fragment:fragment"
+  "androidx.glance.wear.tiles|androidx.glance:glance-wear-tiles"
   "androidx.lifecycle.livedata|androidx.lifecycle:lifecycle-livedata"
   "androidx.lifecycle.viewmodel|androidx.lifecycle:lifecycle-viewmodel"
   "androidx.lifecycle|androidx.lifecycle:lifecycle-runtime"
+  "androidx.wear.activity|androidx.wear:wear"
   "androidx.wear.ambient|androidx.wear:wear"
   "androidx.wear.input|androidx.wear:wear-input"
   "androidx.wear.ongoing|androidx.wear:wear-ongoing"
   "androidx.wear.phone|androidx.wear:wear-phone-interactions"
+  "androidx.wear.provider|androidx.wear:wear"
   "androidx.wear.remote|androidx.wear:wear-remote-interactions"
   "androidx.wear.tiles|androidx.wear.tiles:tiles"
+  "androidx.wear.utils|androidx.wear:wear"
 )
 
 # Check exceptions first (longest match wins)

--- a/bin/jetpack-library
+++ b/bin/jetpack-library
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") PACKAGE_NAME
+
+Convert an Android package name to its corresponding Jetpack library coordinate.
+
+Arguments:
+  PACKAGE_NAME  Fully qualified package/class name (e.g., androidx.core.splashscreen.SplashScreen)
+
+Examples:
+  $(basename "$0") androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+  $(basename "$0") androidx.wear.ambient.AmbientLifecycleObserver
+  $(basename "$0") androidx.wear.protolayout.material3.textButton
+  $(basename "$0") androidx.lifecycle.ViewModel
+
+The script converts AndroidX package names to Maven library coordinates using
+heuristic rules and a lookup table for exceptions. Output format is GROUP_ID:ARTIFACT_ID
+(e.g., androidx.core:core-splashscreen).
+EOF
+  exit 0
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+fi
+
+if [ "$#" -lt 1 ]; then
+  echo "$(basename "$0"): missing operand" >&2
+  exit 1
+fi
+
+PACKAGE_NAME=$1
+
+# Extract package prefix (remove class names and method names)
+# Split on dots and take segments until we find a likely package
+# Class names start with uppercase, so we stop at the first uppercase segment
+SEGMENTS=()
+IFS='.' read -ra ALL_SEGMENTS <<< "$PACKAGE_NAME"
+for segment in "${ALL_SEGMENTS[@]}"; do
+  # Check if segment starts with uppercase (likely a class name)
+  if [[ "$segment" =~ ^[A-Z] ]]; then
+    break
+  fi
+  SEGMENTS+=("$segment")
+done
+
+# If we filtered everything out, use the original segments
+if [ "${#SEGMENTS[@]}" -eq 0 ]; then
+  SEGMENTS=("${ALL_SEGMENTS[@]}")
+fi
+
+# Rebuild package name from segments (without class names)
+PACKAGE_PREFIX=$(IFS=.; echo "${SEGMENTS[*]}")
+
+# Known 3-segment AndroidX group IDs
+THREE_SEGMENT_GROUPS=(
+  "androidx.wear.protolayout"
+  "androidx.wear.compose"
+  "androidx.wear.tiles"
+  "androidx.wear.watchface"
+  "androidx.compose.animation"
+  "androidx.compose.foundation"
+  "androidx.compose.material"
+  "androidx.compose.material3"
+  "androidx.compose.runtime"
+  "androidx.compose.ui"
+)
+
+# Exceptions table: maps package prefix to library coordinate
+# Format: "package.prefix|group:artifact"
+EXCEPTIONS=(
+  "androidx.wear.ambient|androidx.wear:wear"
+  "androidx.wear.input|androidx.wear:wear-input"
+  "androidx.wear.ongoing|androidx.wear:wear-ongoing"
+  "androidx.wear.phone|androidx.wear:wear-phone-interactions"
+  "androidx.wear.remote|androidx.wear:wear-remote-interactions"
+  "androidx.wear.tiles|androidx.wear.tiles:tiles"
+  "androidx.core.app|androidx.core:core"
+  "androidx.core.content|androidx.core:core"
+  "androidx.core.graphics|androidx.core:core"
+  "androidx.core.os|androidx.core:core"
+  "androidx.core.util|androidx.core:core"
+  "androidx.core.view|androidx.core:core"
+  "androidx.core.widget|androidx.core:core"
+  "androidx.activity.result|androidx.activity:activity"
+  "androidx.activity.contextaware|androidx.activity:activity"
+  "androidx.fragment.app|androidx.fragment:fragment"
+  "androidx.lifecycle.viewmodel|androidx.lifecycle:lifecycle-viewmodel"
+  "androidx.lifecycle.livedata|androidx.lifecycle:lifecycle-livedata"
+  "androidx.lifecycle|androidx.lifecycle:lifecycle-runtime"
+)
+
+# Check exceptions first (longest match wins)
+BEST_MATCH=""
+BEST_MATCH_LENGTH=0
+for exception in "${EXCEPTIONS[@]}"; do
+  PREFIX="${exception%%|*}"
+  COORDINATE="${exception##*|}"
+
+  # Check if package prefix starts with this exception prefix
+  if [[ "$PACKAGE_PREFIX" == "$PREFIX"* ]]; then
+    PREFIX_LENGTH=${#PREFIX}
+    if [ "$PREFIX_LENGTH" -gt "$BEST_MATCH_LENGTH" ]; then
+      BEST_MATCH="$COORDINATE"
+      BEST_MATCH_LENGTH=$PREFIX_LENGTH
+    fi
+  fi
+done
+
+if [ -n "$BEST_MATCH" ]; then
+  echo "$BEST_MATCH"
+  exit 0
+fi
+
+# Heuristic approach: determine group ID and artifact ID
+# Check if it's a 3-segment group
+GROUP_ID=""
+NEXT_SEGMENT=""
+
+for three_seg in "${THREE_SEGMENT_GROUPS[@]}"; do
+  if [[ "$PACKAGE_PREFIX" == "$three_seg."* ]]; then
+    GROUP_ID="$three_seg"
+    # Extract the next segment after the group ID
+    REMAINING="${PACKAGE_PREFIX#$three_seg.}"
+    NEXT_SEGMENT="${REMAINING%%.*}"
+    break
+  fi
+done
+
+# If not a 3-segment group, assume 2-segment group (androidx.X)
+if [ -z "$GROUP_ID" ]; then
+  if [ "${#SEGMENTS[@]}" -lt 3 ]; then
+    echo "$(basename "$0"): package name too short: $PACKAGE_PREFIX" >&2
+    exit 1
+  fi
+
+  GROUP_ID="${SEGMENTS[0]}.${SEGMENTS[1]}"
+  NEXT_SEGMENT="${SEGMENTS[2]}"
+fi
+
+# Build artifact ID using the pattern: {last_part_of_group}-{next_segment}
+LAST_GROUP_PART="${GROUP_ID##*.}"
+
+# Handle special cases where next segment is a generic name
+case "$NEXT_SEGMENT" in
+  app|content|graphics|os|util|view|widget|internal)
+    # These are typically part of the core library
+    ARTIFACT_ID="$LAST_GROUP_PART"
+    ;;
+  *)
+    # Standard pattern: last_group_part-next_segment
+    ARTIFACT_ID="$LAST_GROUP_PART-$NEXT_SEGMENT"
+    ;;
+esac
+
+echo "$GROUP_ID:$ARTIFACT_ID"

--- a/bin/jetpack-library-build-exceptions
+++ b/bin/jetpack-library-build-exceptions
@@ -52,60 +52,102 @@ require() {
 
 require curl
 require jar
-require context-jetpack
+
+# Find jetpack-library script (should be in same directory as this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JETPACK_LIBRARY="$SCRIPT_DIR/jetpack-library"
+
+if [ ! -x "$JETPACK_LIBRARY" ]; then
+  # Try PATH as fallback
+  if command -v jetpack-library >/dev/null 2>&1; then
+    JETPACK_LIBRARY="jetpack-library"
+  else
+    echo "$(basename "$0"): jetpack-library script not found" >&2
+    exit 127
+  fi
+fi
 
 LIBRARY=$1
 GROUP_ID=$(echo "$LIBRARY" | cut -d: -f1)
 ARTIFACT_ID=$(echo "$LIBRARY" | cut -d: -f2)
+REPO_URL="${2:-https://dl.google.com/android/maven2}"
 
 echo "Analyzing library: $LIBRARY" >&2
-echo "" >&2
 
-# Download the source
-SOURCE_DIR=$(context-jetpack "$LIBRARY" 2>/dev/null)
+# Get the latest stable version
+GROUP_ID_PATH=$(echo "$GROUP_ID" | sed 's/\./\//g')
+METADATA_URL="$REPO_URL/$GROUP_ID_PATH/$ARTIFACT_ID/maven-metadata.xml"
 
-if [ ! -d "$SOURCE_DIR" ]; then
-  echo "$(basename "$0"): failed to download source for $LIBRARY" >&2
+VERSION=$(curl -sSL "$METADATA_URL" 2>/dev/null |
+  grep -oP '<release>\K[^<]+' |
+  head -1)
+
+if [ -z "$VERSION" ]; then
+  # Try to get latest version if no release
+  VERSION=$(curl -sSL "$METADATA_URL" 2>/dev/null |
+    grep -oP '<latest>\K[^<]+' |
+    head -1)
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "$(basename "$0"): could not determine version for $LIBRARY" >&2
   exit 1
 fi
 
-# Find all package prefixes (first 3-4 levels)
-PACKAGES=$(find "$SOURCE_DIR" -type f -name "*.java" -o -name "*.kt" | while read -r file; do
-  # Extract package declaration
+echo "Using version: $VERSION" >&2
+
+# Download source JAR to temp directory
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+SOURCE_JAR_URL="$REPO_URL/$GROUP_ID_PATH/$ARTIFACT_ID/$VERSION/$ARTIFACT_ID-$VERSION-sources.jar"
+SOURCE_JAR="$TMPDIR/sources.jar"
+
+echo "Downloading: $SOURCE_JAR_URL" >&2
+if ! curl -sSL -o "$SOURCE_JAR" "$SOURCE_JAR_URL" 2>/dev/null; then
+  echo "$(basename "$0"): failed to download source JAR" >&2
+  exit 1
+fi
+
+# Extract and find all packages
+cd "$TMPDIR"
+jar xf sources.jar 2>/dev/null || true
+
+# Find all unique packages from source files
+PACKAGES=$(find . -type f \( -name "*.java" -o -name "*.kt" \) 2>/dev/null | while read -r file; do
   grep -m1 "^package " "$file" 2>/dev/null | sed 's/package //;s/;.*//;s/ .*//'
 done | sort -u)
 
+if [ -z "$PACKAGES" ]; then
+  echo "$(basename "$0"): no packages found in source JAR" >&2
+  exit 1
+fi
+
+echo "" >&2
 echo "Found packages:" >&2
 echo "$PACKAGES" | sed 's/^/  /' >&2
 echo "" >&2
 
-# Analyze each package to see if it matches the heuristic
-echo "Suggested exceptions (add these to jetpack-library if needed):" >&2
+# Test each package against jetpack-library to find needed exceptions
+echo "Checking which packages need exceptions:" >&2
 echo "" >&2
 
-LAST_GROUP_PART="${GROUP_ID##*.}"
-
+NEEDS_EXCEPTION=false
 while IFS= read -r pkg; do
   if [ -z "$pkg" ]; then
     continue
   fi
 
-  # Extract first 3 segments of package
-  PKG_SEGMENTS=(${pkg//./ })
-  if [ "${#PKG_SEGMENTS[@]}" -lt 3 ]; then
-    continue
-  fi
+  # Test with a fake class name
+  RESULT=$("$JETPACK_LIBRARY" "$pkg.TestClass" 2>/dev/null || echo "ERROR")
 
-  PKG_PREFIX="${PKG_SEGMENTS[0]}.${PKG_SEGMENTS[1]}.${PKG_SEGMENTS[2]}"
-
-  # Check what the heuristic would produce
-  EXPECTED_ARTIFACT="$LAST_GROUP_PART-${PKG_SEGMENTS[2]}"
-
-  # If it doesn't match the actual artifact, suggest an exception
-  if [ "$EXPECTED_ARTIFACT" != "$ARTIFACT_ID" ]; then
-    echo "  \"$PKG_PREFIX|$GROUP_ID:$ARTIFACT_ID\""
+  # Check if result matches expected library
+  if [ "$RESULT" != "$GROUP_ID:$ARTIFACT_ID" ]; then
+    echo "  \"$pkg|$GROUP_ID:$ARTIFACT_ID\""
+    NEEDS_EXCEPTION=true
   fi
 done <<< "$PACKAGES"
 
-# Clean up
-rm -rf "$SOURCE_DIR"
+if [ "$NEEDS_EXCEPTION" = false ]; then
+  echo "  (no exceptions needed - all packages map correctly)" >&2
+fi

--- a/bin/jetpack-library-build-exceptions
+++ b/bin/jetpack-library-build-exceptions
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") LIBRARY_COORDINATE
+
+Helper script to analyze a Jetpack library and suggest exceptions for jetpack-library.
+
+Arguments:
+  LIBRARY_COORDINATE  Maven coordinate (e.g., androidx.wear:wear)
+
+Examples:
+  $(basename "$0") androidx.wear:wear
+  $(basename "$0") androidx.core:core
+  $(basename "$0") androidx.lifecycle:lifecycle-viewmodel
+
+This script downloads the source JAR for a library, examines the package structure,
+and suggests exception entries for packages that don't follow the standard naming
+pattern. The output can be added to the EXCEPTIONS array in the jetpack-library script.
+
+How to build the full exceptions table:
+1. Get a list of all AndroidX libraries from https://androidx.tech
+2. For each library, run this script to analyze its package structure
+3. Add suggested exceptions to jetpack-library
+4. Test the exceptions with real package names from your code
+
+Alternatively, you can build exceptions on-demand:
+1. When jetpack-library produces incorrect output for a package
+2. Use jetpack-version to find what library provides that package
+3. Add the exception mapping to the EXCEPTIONS array
+EOF
+  exit 0
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+fi
+
+set -e
+
+if [ "$#" -lt 1 ]; then
+  echo "$(basename "$0"): missing operand" >&2
+  exit 1
+fi
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "$(basename "$0"): required command '$1' not found" >&2
+    exit 127
+  }
+}
+
+require curl
+require jar
+require context-jetpack
+
+LIBRARY=$1
+GROUP_ID=$(echo "$LIBRARY" | cut -d: -f1)
+ARTIFACT_ID=$(echo "$LIBRARY" | cut -d: -f2)
+
+echo "Analyzing library: $LIBRARY" >&2
+echo "" >&2
+
+# Download the source
+SOURCE_DIR=$(context-jetpack "$LIBRARY" 2>/dev/null)
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "$(basename "$0"): failed to download source for $LIBRARY" >&2
+  exit 1
+fi
+
+# Find all package prefixes (first 3-4 levels)
+PACKAGES=$(find "$SOURCE_DIR" -type f -name "*.java" -o -name "*.kt" | while read -r file; do
+  # Extract package declaration
+  grep -m1 "^package " "$file" 2>/dev/null | sed 's/package //;s/;.*//;s/ .*//'
+done | sort -u)
+
+echo "Found packages:" >&2
+echo "$PACKAGES" | sed 's/^/  /' >&2
+echo "" >&2
+
+# Analyze each package to see if it matches the heuristic
+echo "Suggested exceptions (add these to jetpack-library if needed):" >&2
+echo "" >&2
+
+LAST_GROUP_PART="${GROUP_ID##*.}"
+
+while IFS= read -r pkg; do
+  if [ -z "$pkg" ]; then
+    continue
+  fi
+
+  # Extract first 3 segments of package
+  PKG_SEGMENTS=(${pkg//./ })
+  if [ "${#PKG_SEGMENTS[@]}" -lt 3 ]; then
+    continue
+  fi
+
+  PKG_PREFIX="${PKG_SEGMENTS[0]}.${PKG_SEGMENTS[1]}.${PKG_SEGMENTS[2]}"
+
+  # Check what the heuristic would produce
+  EXPECTED_ARTIFACT="$LAST_GROUP_PART-${PKG_SEGMENTS[2]}"
+
+  # If it doesn't match the actual artifact, suggest an exception
+  if [ "$EXPECTED_ARTIFACT" != "$ARTIFACT_ID" ]; then
+    echo "  \"$PKG_PREFIX|$GROUP_ID:$ARTIFACT_ID\""
+  fi
+done <<< "$PACKAGES"
+
+# Clean up
+rm -rf "$SOURCE_DIR"


### PR DESCRIPTION
This script converts Android package names (e.g., androidx.core.splashscreen)
to their corresponding Jetpack library Maven coordinates (e.g.,
androidx.core:core-splashscreen).

Key features:
- Handles fully qualified class names by detecting uppercase segments
- Uses heuristic rules to determine group ID and artifact ID
- Supports 3-segment group IDs (e.g., androidx.wear.protolayout)
- Maintains exceptions table for packages that don't follow the pattern
- Includes helper script to build the exceptions table

The script follows the patterns established by bin/jetpack-version and
bin/context-jetpack, with proper usage documentation and GNU coreutils-style
error messages.