### PR TITLE
Debug Jetpack library after recent commit

### DIFF
--- a/bin/jetpack-resolve-build-exceptions
+++ b/bin/jetpack-resolve-build-exceptions
@@ -4,7 +4,7 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") LIBRARY_COORDINATE
 
-Helper script to analyze a Jetpack library and suggest exceptions for jetpack-library.
+Helper script to analyze a Jetpack library and suggest exceptions for jetpack-resolve.
 
 Arguments:
   LIBRARY_COORDINATE  Maven coordinate (e.g., androidx.wear:wear)
@@ -16,16 +16,16 @@ Examples:
 
 This script downloads the source JAR for a library, examines the package structure,
 and suggests exception entries for packages that don't follow the standard naming
-pattern. The output can be added to the EXCEPTIONS array in the jetpack-library script.
+pattern. The output can be added to the EXCEPTIONS array in the jetpack-resolve script.
 
 How to build the full exceptions table:
 1. Get a list of all AndroidX libraries from https://androidx.tech
 2. For each library, run this script to analyze its package structure
-3. Add suggested exceptions to jetpack-library
+3. Add suggested exceptions to jetpack-resolve
 4. Test the exceptions with real package names from your code
 
 Alternatively, you can build exceptions on-demand:
-1. When jetpack-library produces incorrect output for a package
+1. When jetpack-resolve produces incorrect output for a package
 2. Use jetpack-version to find what library provides that package
 3. Add the exception mapping to the EXCEPTIONS array
 EOF
@@ -53,16 +53,16 @@ require() {
 require curl
 require jar
 
-# Find jetpack-library script (should be in same directory as this script)
+# Find jetpack-resolve script (should be in same directory as this script)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-JETPACK_LIBRARY="$SCRIPT_DIR/jetpack-library"
+JETPACK_RESOLVE="$SCRIPT_DIR/jetpack-resolve"
 
-if [ ! -x "$JETPACK_LIBRARY" ]; then
+if [ ! -x "$JETPACK_RESOLVE" ]; then
   # Try PATH as fallback
-  if command -v jetpack-library >/dev/null 2>&1; then
-    JETPACK_LIBRARY="jetpack-library"
+  if command -v jetpack-resolve >/dev/null 2>&1; then
+    JETPACK_RESOLVE="jetpack-resolve"
   else
-    echo "$(basename "$0"): jetpack-library script not found" >&2
+    echo "$(basename "$0"): jetpack-resolve script not found" >&2
     exit 127
   fi
 fi
@@ -128,7 +128,7 @@ echo "Found packages:" >&2
 echo "$PACKAGES" | sed 's/^/  /' >&2
 echo "" >&2
 
-# Test each package against jetpack-library to find needed exceptions
+# Test each package against jetpack-resolve to find needed exceptions
 echo "Checking which packages need exceptions:" >&2
 echo "" >&2
 
@@ -139,7 +139,7 @@ while IFS= read -r pkg; do
   fi
 
   # Test with a fake class name
-  RESULT=$("$JETPACK_LIBRARY" "$pkg.TestClass" 2>/dev/null || echo "ERROR")
+  RESULT=$("$JETPACK_RESOLVE" "$pkg.TestClass" 2>/dev/null || echo "ERROR")
 
   # Check if result matches expected library
   if [ "$RESULT" != "$GROUP_ID:$ARTIFACT_ID" ]; then


### PR DESCRIPTION
After commit a4f34a8 renamed jetpack-library to jetpack-resolve, the jetpack-library-build-exceptions script broke because it was still trying to call the old script name.

Changes:
- Renamed jetpack-library-build-exceptions to jetpack-resolve-build-exceptions to follow the new naming convention
- Updated all references from jetpack-library to jetpack-resolve in the script
- Updated documentation and comments to reflect the new script name

Fixes the "jetpack-library script not found" error.