### PR TITLE
Documentation best practices and placement

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -8,6 +8,9 @@ export ANDROID_HOME="${ANDROID_HOME:-$HOME/.local/share/android-sdk}"
 # This ensures we use the correct versions and avoid conflicts with system-installed
 # Android tools. The require() function allows these commands to be satisfied from
 # $ANDROID_HOME paths.
+#
+# For emulator command-line reference, see:
+# https://developer.android.com/studio/run/emulator-commandline
 
 # To find valid versions for build-tools, run:
 # sdkmanager --list | grep "build-tools;"


### PR DESCRIPTION
Add a comment in bin/emumanager pointing to the Android emulator command-line reference documentation to help users find information about emulator command options and usage.