### PR TITLE
Fix Android emulator device type configuration

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -404,8 +404,27 @@ create_avd() {
   fi
 
   echo "Creating AVD '${avd_name}' with image '${image_package}'..."
-  # TODO: enable different device definitions ("wearos_large_round")
-  echo "no" | "${avdmanager}" create avd -n "${avd_name}" -k "${image_package}" -d "wearos_large_round"
+
+  # Determine device definition based on image type
+  # Extract the tag (3rd field) from the image package
+  # Format: system-images;API_LEVEL;TAG;ARCHITECTURE
+  local image_tag
+  image_tag=$(echo "${image_package}" | awk -F';' '{print $3}')
+
+  # Choose device definition based on image type
+  local device_arg=""
+  if [[ "$image_tag" == *"wear"* ]]; then
+    # Wear OS image - use wearos device definition
+    device_arg="-d wearos_large_round"
+    echo "Detected Wear OS image, using device definition: wearos_large_round"
+  else
+    # Mobile/tablet image - omit -d flag to use avdmanager's default
+    echo "Detected mobile/tablet image, using default device definition"
+  fi
+
+  # Create AVD with appropriate device definition
+  # shellcheck disable=SC2086
+  echo "no" | "${avdmanager}" create avd -n "${avd_name}" -k "${image_package}" ${device_arg}
 }
 
 start_avd() {


### PR DESCRIPTION
…ile and Wear OS images

The create command now automatically detects whether a system image is for Wear OS or mobile/tablet devices and selects an appropriate device definition:

- Wear OS images (tag contains "wear"): uses -d wearos_large_round
- Mobile/tablet images: omits -d flag to use avdmanager's default device profile

This enables the create command to work seamlessly with both Wear OS and mobile images without requiring manual device definition specification.

Fixes the hard-coded "wearos_large_round" limitation that prevented creating mobile AVDs.