### PR TITLE
feat(emumanager): Add device type switches to create command

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -25,7 +25,8 @@ get_host_arch() {
       echo "arm64-v8a"
       ;;
     x86_64)
-      echo "x86_64"
+      # Android SDK uses "x8664" not "x86_64" (no underscore)
+      echo "x8664"
       ;;
     *)
       echo "$(basename "$0"): Unsupported architecture: $(uname -m)" >&2
@@ -82,13 +83,13 @@ get_latest_image_for_type() {
       prefer_pattern="android-wear-signed"
       ;;
     tv)
-      # Future support for Android TV / Google TV
+      # Android TV / Google TV devices
       tag_patterns="android-tv|google-tv"
       exclude_patterns=""
       prefer_pattern="google-tv"
       ;;
     auto)
-      # Future support for Android Automotive
+      # Android Automotive devices
       tag_patterns="android-automotive"
       exclude_patterns="distant-display"  # Exclude distant display variants
       prefer_pattern="android-automotive-playstore"
@@ -116,7 +117,8 @@ get_latest_image_for_type() {
     package=$(echo "$line" | awk -F'|' '{print $1}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
     # Skip if not a system-image for our architecture
-    if [[ ! "$package" =~ system-images.*${arch} ]]; then
+    # Architecture must be the last field in the package path
+    if [[ ! "$package" =~ ;${arch}$ ]]; then
       continue
     fi
 

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -101,13 +101,14 @@ get_latest_image_for_type() {
   esac
 
   # Find matching images and extract the one with the highest API level
-  # Version priority: CANARY > letter codenames (Baklava) > dotted numeric (36.1) > numeric (36)
+  # Only consider numeric versions (e.g., 35, 36, 36.1)
+  # Skip CANARY and letter codename versions (e.g., Baklava)
   local best_image=""
-  local best_version_type=0  # 0=none, 1=numeric, 2=dotted, 3=codename, 4=canary
-  local best_version_value=""
+  local best_major=0
+  local best_minor=0
   local preferred_image=""
-  local preferred_version_type=0
-  local preferred_version_value=""
+  local preferred_major=0
+  local preferred_minor=0
 
   while IFS= read -r line; do
     # Extract package path
@@ -135,106 +136,42 @@ get_latest_image_for_type() {
     local version_string
     version_string=$(echo "$api_part" | sed 's/android-//')
 
-    # Determine version type and comparable value
-    local version_type=0
-    local version_value=""
-
-    if [[ "$version_string" == "CANARY" ]]; then
-      # CANARY is always highest priority
-      version_type=4
-      version_value="CANARY"
-    elif [[ "$version_string" =~ ^[0-9]+\.[0-9]+-.*$ ]]; then
-      # Dotted version with suffix (e.g., "36.0-Baklava") - treat as codename
-      version_type=3
-      version_value="$version_string"
-    elif [[ "$version_string" =~ ^[A-Z][a-z]+ ]]; then
-      # Letter codename (e.g., "Baklava", "Baklava-ext19")
-      version_type=3
-      version_value="$version_string"
-    elif [[ "$version_string" =~ ^[0-9]+\.[0-9]+$ ]]; then
-      # Dotted numeric (e.g., "36.1")
-      version_type=2
-      version_value="$version_string"
-    elif [[ "$version_string" =~ ^[0-9]+$ ]]; then
-      # Pure numeric (e.g., "35", "36")
-      version_type=1
-      version_value="$version_string"
-    else
-      # Unknown format, skip
+    # Only accept numeric versions (with optional decimal point)
+    # Skip CANARY, letter codenames (Baklava), and versions with suffixes (36.0-Baklava)
+    if ! [[ "$version_string" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
       continue
     fi
 
-    # Helper function to compare versions within the same type
+    # Parse major and minor version
+    local major minor
+    major=$(echo "$version_string" | cut -d'.' -f1)
+    minor=$(echo "$version_string" | cut -d'.' -f2 2>/dev/null || echo "0")
+
+    # Compare versions: prefer higher major, then higher minor
     local is_better=false
-
-    if [[ $version_type -gt $best_version_type ]]; then
-      # Higher type always wins
+    if [[ $major -gt $best_major ]] || \
+       [[ $major -eq $best_major && $minor -gt $best_minor ]]; then
       is_better=true
-    elif [[ $version_type -eq $best_version_type ]]; then
-      # Same type, compare values
-      case $version_type in
-        1|2)
-          # Numeric or dotted numeric - compare as numbers
-          local current_major current_minor best_major best_minor
-          current_major=$(echo "$version_value" | cut -d'.' -f1)
-          current_minor=$(echo "$version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
-          best_major=$(echo "$best_version_value" | cut -d'.' -f1)
-          best_minor=$(echo "$best_version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
-
-          if [[ $current_major -gt $best_major ]] || \
-             [[ $current_major -eq $best_major && $current_minor -gt $best_minor ]]; then
-            is_better=true
-          fi
-          ;;
-        3|4)
-          # Codename or CANARY - use alphabetical (Baklava > 36.0-Baklava in practice)
-          # For codenames, just take the first one we find (they're typically equivalent)
-          # unless it's clearly newer (has -ext suffix with higher number)
-          if [[ "$version_value" > "$best_version_value" ]]; then
-            is_better=true
-          fi
-          ;;
-      esac
     fi
 
     # Update best if this is better
     if [[ "$is_better" == "true" ]]; then
-      best_version_type=$version_type
-      best_version_value="$version_value"
+      best_major=$major
+      best_minor=$minor
       best_image="$package"
     fi
 
     # Track preferred variant separately (same comparison logic)
     if [[ -n "$prefer_pattern" ]] && echo "$package" | grep -qE "$prefer_pattern" 2>/dev/null; then
       local is_preferred_better=false
-
-      if [[ $version_type -gt $preferred_version_type ]]; then
+      if [[ $major -gt $preferred_major ]] || \
+         [[ $major -eq $preferred_major && $minor -gt $preferred_minor ]]; then
         is_preferred_better=true
-      elif [[ $version_type -eq $preferred_version_type ]]; then
-        case $version_type in
-          1|2)
-            local current_major current_minor pref_major pref_minor
-            current_major=$(echo "$version_value" | cut -d'.' -f1)
-            current_minor=$(echo "$version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
-            pref_major=$(echo "$preferred_version_value" | cut -d'.' -f1)
-            pref_minor=$(echo "$preferred_version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
-
-            if [[ $current_major -gt $pref_major ]] || \
-               [[ $current_major -eq $pref_major && $current_minor -gt $pref_minor ]]; then
-              is_preferred_better=true
-            fi
-            ;;
-          3|4)
-            if [[ "$version_value" > "$preferred_version_value" ]]; then
-              is_preferred_better=true
-            fi
-            ;;
-        esac
       fi
 
       if [[ "$is_preferred_better" == "true" ]]; then
-        preferred_version_type=$version_type
-        preferred_version_value="$version_value"
+        preferred_major=$major
+        preferred_minor=$minor
         preferred_image="$package"
       fi
     fi

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -95,8 +95,7 @@ get_latest_image_for_type() {
       ;;
     *)
       echo "$(basename "$0"): Unknown device type: $device_type" >&2
-      echo "Supported types: mobile, wear" >&2
-      echo "Future support planned for: tv, auto" >&2
+      echo "Supported types: mobile, wear, tv, auto" >&2
       exit 1
       ;;
   esac
@@ -189,6 +188,8 @@ Commands:
                       Device type options:
                         --mobile, --phone    Create mobile/phone device (latest API)
                         --wear, --watch      Create Wear OS device (latest API)
+                        --tv                 Create Android/Google TV device (latest API)
+                        --auto               Create Android Automotive device (latest API)
                       If no device type or image is specified, defaults to mobile/phone.
                       If a specific image is provided, it overrides device type.
   start <name> [--cold-boot|--wipe-data]
@@ -211,6 +212,12 @@ Examples:
 
   # Create a Wear OS AVD with the latest available image
   $(basename "$0") create my_watch --wear
+
+  # Create an Android/Google TV AVD with the latest available image
+  $(basename "$0") create my_tv --tv
+
+  # Create an Android Automotive AVD with the latest available image
+  $(basename "$0") create my_car --auto
 
   # Create a new AVD with the default image (mobile/phone)
   $(basename "$0") create my_default_avd
@@ -1241,18 +1248,24 @@ case "$1" in
           shift
           ;;
         --tv)
-          echo "$(basename "$0") create: TV device type not yet supported" >&2
-          echo "This feature is planned for future implementation" >&2
-          exit 1
+          if [[ -n "$device_type" ]]; then
+            echo "$(basename "$0") create: multiple device types specified" >&2
+            exit 1
+          fi
+          device_type="tv"
+          shift
           ;;
         --auto)
-          echo "$(basename "$0") create: Automotive device type not yet supported" >&2
-          echo "This feature is planned for future implementation" >&2
-          exit 1
+          if [[ -n "$device_type" ]]; then
+            echo "$(basename "$0") create: multiple device types specified" >&2
+            exit 1
+          fi
+          device_type="auto"
+          shift
           ;;
         --*)
           echo "$(basename "$0") create: unknown option '$1'" >&2
-          echo "Valid options: --mobile, --phone, --wear, --watch" >&2
+          echo "Valid options: --mobile, --phone, --wear, --watch, --tv, --auto" >&2
           exit 1
           ;;
         *)

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -101,10 +101,13 @@ get_latest_image_for_type() {
   esac
 
   # Find matching images and extract the one with the highest API level
+  # Version priority: CANARY > letter codenames (Baklava) > dotted numeric (36.1) > numeric (36)
   local best_image=""
-  local best_api=0
+  local best_version_type=0  # 0=none, 1=numeric, 2=dotted, 3=codename, 4=canary
+  local best_version_value=""
   local preferred_image=""
-  local preferred_api=0
+  local preferred_version_type=0
+  local preferred_version_value=""
 
   while IFS= read -r line; do
     # Extract package path
@@ -126,29 +129,114 @@ get_latest_image_for_type() {
       continue
     fi
 
-    # Extract API level (second field in package path)
+    # Extract API level/version (second field in package path)
     local api_part
     api_part=$(echo "$package" | awk -F';' '{print $2}')
-    local api_level
-    api_level=$(echo "$api_part" | sed 's/android-//' | sed 's/-.*//')
+    local version_string
+    version_string=$(echo "$api_part" | sed 's/android-//')
 
-    # Skip if not a numeric API level
-    if ! [[ "$api_level" =~ ^[0-9]+$ ]]; then
+    # Determine version type and comparable value
+    local version_type=0
+    local version_value=""
+
+    if [[ "$version_string" == "CANARY" ]]; then
+      # CANARY is always highest priority
+      version_type=4
+      version_value="CANARY"
+    elif [[ "$version_string" =~ ^[0-9]+\.[0-9]+-.*$ ]]; then
+      # Dotted version with suffix (e.g., "36.0-Baklava") - treat as codename
+      version_type=3
+      version_value="$version_string"
+    elif [[ "$version_string" =~ ^[A-Z][a-z]+ ]]; then
+      # Letter codename (e.g., "Baklava", "Baklava-ext19")
+      version_type=3
+      version_value="$version_string"
+    elif [[ "$version_string" =~ ^[0-9]+\.[0-9]+$ ]]; then
+      # Dotted numeric (e.g., "36.1")
+      version_type=2
+      version_value="$version_string"
+    elif [[ "$version_string" =~ ^[0-9]+$ ]]; then
+      # Pure numeric (e.g., "35", "36")
+      version_type=1
+      version_value="$version_string"
+    else
+      # Unknown format, skip
       continue
     fi
 
-    # Track preferred variant separately
-    if [[ -n "$prefer_pattern" ]] && echo "$package" | grep -qE "$prefer_pattern" 2>/dev/null; then
-      if [[ $api_level -gt $preferred_api ]]; then
-        preferred_api=$api_level
-        preferred_image="$package"
-      fi
+    # Helper function to compare versions within the same type
+    local is_better=false
+
+    if [[ $version_type -gt $best_version_type ]]; then
+      # Higher type always wins
+      is_better=true
+    elif [[ $version_type -eq $best_version_type ]]; then
+      # Same type, compare values
+      case $version_type in
+        1|2)
+          # Numeric or dotted numeric - compare as numbers
+          local current_major current_minor best_major best_minor
+          current_major=$(echo "$version_value" | cut -d'.' -f1)
+          current_minor=$(echo "$version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
+          best_major=$(echo "$best_version_value" | cut -d'.' -f1)
+          best_minor=$(echo "$best_version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
+
+          if [[ $current_major -gt $best_major ]] || \
+             [[ $current_major -eq $best_major && $current_minor -gt $best_minor ]]; then
+            is_better=true
+          fi
+          ;;
+        3|4)
+          # Codename or CANARY - use alphabetical (Baklava > 36.0-Baklava in practice)
+          # For codenames, just take the first one we find (they're typically equivalent)
+          # unless it's clearly newer (has -ext suffix with higher number)
+          if [[ "$version_value" > "$best_version_value" ]]; then
+            is_better=true
+          fi
+          ;;
+      esac
     fi
 
-    # Update best if this is higher
-    if [[ $api_level -gt $best_api ]]; then
-      best_api=$api_level
+    # Update best if this is better
+    if [[ "$is_better" == "true" ]]; then
+      best_version_type=$version_type
+      best_version_value="$version_value"
       best_image="$package"
+    fi
+
+    # Track preferred variant separately (same comparison logic)
+    if [[ -n "$prefer_pattern" ]] && echo "$package" | grep -qE "$prefer_pattern" 2>/dev/null; then
+      local is_preferred_better=false
+
+      if [[ $version_type -gt $preferred_version_type ]]; then
+        is_preferred_better=true
+      elif [[ $version_type -eq $preferred_version_type ]]; then
+        case $version_type in
+          1|2)
+            local current_major current_minor pref_major pref_minor
+            current_major=$(echo "$version_value" | cut -d'.' -f1)
+            current_minor=$(echo "$version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
+            pref_major=$(echo "$preferred_version_value" | cut -d'.' -f1)
+            pref_minor=$(echo "$preferred_version_value" | cut -d'.' -f2 2>/dev/null || echo "0")
+
+            if [[ $current_major -gt $pref_major ]] || \
+               [[ $current_major -eq $pref_major && $current_minor -gt $pref_minor ]]; then
+              is_preferred_better=true
+            fi
+            ;;
+          3|4)
+            if [[ "$version_value" > "$preferred_version_value" ]]; then
+              is_preferred_better=true
+            fi
+            ;;
+        esac
+      fi
+
+      if [[ "$is_preferred_better" == "true" ]]; then
+        preferred_version_type=$version_type
+        preferred_version_value="$version_value"
+        preferred_image="$package"
+      fi
     fi
   done < <(echo "$all_packages" | grep "system-images;android-" || true)
 

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -35,9 +35,8 @@ get_host_arch() {
 }
 
 get_default_image_package() {
-  local arch
-  arch=$(get_host_arch)
-  echo "system-images;${ANDROID_PLATFORM_VERSION};android-wear-signed;${arch}"
+  # Default to mobile/phone device type
+  get_latest_image_for_type "mobile"
 }
 
 # Get the latest available image for a specific device type
@@ -190,7 +189,7 @@ Commands:
                       Device type options:
                         --mobile, --phone    Create mobile/phone device (latest API)
                         --wear, --watch      Create Wear OS device (latest API)
-                      If no device type or image is specified, defaults to Wear OS.
+                      If no device type or image is specified, defaults to mobile/phone.
                       If a specific image is provided, it overrides device type.
   start <name> [--cold-boot|--wipe-data]
                       Start the specified AVD.
@@ -213,7 +212,7 @@ Examples:
   # Create a Wear OS AVD with the latest available image
   $(basename "$0") create my_watch --wear
 
-  # Create a new AVD with the default image (Wear OS)
+  # Create a new AVD with the default image (mobile/phone)
   $(basename "$0") create my_default_avd
 
   # Create a new AVD with a specific image

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -40,6 +40,137 @@ get_default_image_package() {
   echo "system-images;${ANDROID_PLATFORM_VERSION};android-wear-signed;${arch}"
 }
 
+# Get the latest available image for a specific device type
+# Usage: get_latest_image_for_type <device_type>
+# Device types: mobile, wear, tv, auto
+get_latest_image_for_type() {
+  local device_type="$1"
+  local arch
+  arch=$(get_host_arch)
+
+  local sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+  if [[ ! -f "$sdkmanager" ]]; then
+    echo "$(basename "$0"): sdkmanager not found. Please run 'bootstrap' first." >&2
+    exit 1
+  fi
+
+  # Get all available packages
+  local all_packages
+  if ! all_packages=$(timeout 120 "$sdkmanager" --list 2>&1); then
+    echo "$(basename "$0"): Failed to list available packages" >&2
+    exit 1
+  fi
+
+  # Define patterns for each device type
+  # This design allows for easy addition of new device types in the future
+  local tag_patterns
+  local exclude_patterns
+  local prefer_pattern=""
+
+  case "$device_type" in
+    mobile)
+      # Prefer googleapisplaystore for Google Play support
+      # Also accept googleapis as fallback
+      # Exclude specialized variants (wear, tv, automotive, desktop, tablet, xr, atd, ps16k)
+      tag_patterns="googleapisplaystore|googleapis"
+      exclude_patterns="wear|tv|automotive|desktop|tablet|xr|atd|ps16k"
+      prefer_pattern="googleapisplaystore"
+      ;;
+    wear)
+      # Accept both signed and unsigned Wear OS images
+      tag_patterns="android-wear"
+      exclude_patterns="cn"  # Exclude China-specific variants
+      prefer_pattern="android-wear-signed"
+      ;;
+    tv)
+      # Future support for Android TV / Google TV
+      tag_patterns="android-tv|google-tv"
+      exclude_patterns=""
+      prefer_pattern="google-tv"
+      ;;
+    auto)
+      # Future support for Android Automotive
+      tag_patterns="android-automotive"
+      exclude_patterns="distant-display"  # Exclude distant display variants
+      prefer_pattern="android-automotive-playstore"
+      ;;
+    *)
+      echo "$(basename "$0"): Unknown device type: $device_type" >&2
+      echo "Supported types: mobile, wear" >&2
+      echo "Future support planned for: tv, auto" >&2
+      exit 1
+      ;;
+  esac
+
+  # Find matching images and extract the one with the highest API level
+  local best_image=""
+  local best_api=0
+  local preferred_image=""
+  local preferred_api=0
+
+  while IFS= read -r line; do
+    # Extract package path
+    local package
+    package=$(echo "$line" | awk -F'|' '{print $1}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    # Skip if not a system-image for our architecture
+    if [[ ! "$package" =~ system-images.*${arch} ]]; then
+      continue
+    fi
+
+    # Check if it matches our tag patterns
+    if ! echo "$package" | grep -qE ";(${tag_patterns});" 2>/dev/null; then
+      continue
+    fi
+
+    # Check if it should be excluded
+    if [[ -n "$exclude_patterns" ]] && echo "$package" | grep -qE "$exclude_patterns" 2>/dev/null; then
+      continue
+    fi
+
+    # Extract API level (second field in package path)
+    local api_part
+    api_part=$(echo "$package" | awk -F';' '{print $2}')
+    local api_level
+    api_level=$(echo "$api_part" | sed 's/android-//' | sed 's/-.*//')
+
+    # Skip if not a numeric API level
+    if ! [[ "$api_level" =~ ^[0-9]+$ ]]; then
+      continue
+    fi
+
+    # Track preferred variant separately
+    if [[ -n "$prefer_pattern" ]] && echo "$package" | grep -qE "$prefer_pattern" 2>/dev/null; then
+      if [[ $api_level -gt $preferred_api ]]; then
+        preferred_api=$api_level
+        preferred_image="$package"
+      fi
+    fi
+
+    # Update best if this is higher
+    if [[ $api_level -gt $best_api ]]; then
+      best_api=$api_level
+      best_image="$package"
+    fi
+  done < <(echo "$all_packages" | grep "system-images;android-" || true)
+
+  # Prefer the preferred variant if available, otherwise use best
+  local selected_image=""
+  if [[ -n "$preferred_image" ]]; then
+    selected_image="$preferred_image"
+  elif [[ -n "$best_image" ]]; then
+    selected_image="$best_image"
+  fi
+
+  if [[ -z "$selected_image" ]]; then
+    echo "$(basename "$0"): No suitable $device_type image found for architecture $arch" >&2
+    echo "Try running: $(basename "$0") images" >&2
+    exit 1
+  fi
+
+  echo "$selected_image"
+}
+
 usage() {
   local exit_code="${1:-0}"
   cat <<EOF
@@ -54,8 +185,13 @@ Commands:
   bootstrap           Bootstrap SDK environment for emulator management.
   list                List all available AVDs.
   info <name>         Show detailed information about an AVD.
-  create <name> [image] Create a new Wear OS AVD.
-                      Defaults to image: $(get_default_image_package)
+  create <name> [options] [image]
+                      Create a new AVD with the specified device type or image.
+                      Device type options:
+                        --mobile, --phone    Create mobile/phone device (latest API)
+                        --wear, --watch      Create Wear OS device (latest API)
+                      If no device type or image is specified, defaults to Wear OS.
+                      If a specific image is provided, it overrides device type.
   start <name> [--cold-boot|--wipe-data]
                       Start the specified AVD.
                       --cold-boot: Perform a cold boot (bypass Quick Boot snapshots)
@@ -71,7 +207,13 @@ Options:
   -h, --help          Display this help message and exit
 
 Examples:
-  # Create a new AVD with the default image
+  # Create a mobile/phone AVD with the latest available image
+  $(basename "$0") create my_phone --mobile
+
+  # Create a Wear OS AVD with the latest available image
+  $(basename "$0") create my_watch --wear
+
+  # Create a new AVD with the default image (Wear OS)
   $(basename "$0") create my_default_avd
 
   # Create a new AVD with a specific image
@@ -376,7 +518,8 @@ create_avd() {
   require avdmanager
 
   local avd_name="$1"
-  local image_package="$2"
+  local device_type="$2"
+  local image_package="$3"
 
   local sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
   local avdmanager="$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager"
@@ -386,9 +529,16 @@ create_avd() {
     return 0
   fi
 
-  if [[ -z "$image_package" ]]; then
+  # Determine image package based on device type or use specified image
+  if [[ -n "$image_package" ]]; then
+    echo "Using specified image: ${image_package}"
+  elif [[ -n "$device_type" ]]; then
+    echo "Finding latest ${device_type} image..."
+    image_package=$(get_latest_image_for_type "$device_type")
+    echo "Selected image: ${image_package}"
+  else
     image_package=$(get_default_image_package)
-    echo "No image specified, using default: ${image_package}"
+    echo "No device type or image specified, using default: ${image_package}"
   fi
 
   # Check if the image is installed, and install it if it's not
@@ -1066,15 +1216,67 @@ case "$1" in
     update_packages
     ;;
   create)
-    if [[ -n "${4:-}" ]]; then
-      echo "$(basename "$0") create: too many arguments" >&2
-      exit 1
-    fi
-    if [[ -z "${2:-}" ]]; then
+    # Parse create command arguments
+    # Supports: create <name> [--mobile|--phone|--wear|--watch] [image]
+    avd_name=""
+    device_type=""
+    image_package=""
+    shift # skip "create"
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --mobile|--phone)
+          if [[ -n "$device_type" ]]; then
+            echo "$(basename "$0") create: multiple device types specified" >&2
+            exit 1
+          fi
+          device_type="mobile"
+          shift
+          ;;
+        --wear|--watch)
+          if [[ -n "$device_type" ]]; then
+            echo "$(basename "$0") create: multiple device types specified" >&2
+            exit 1
+          fi
+          device_type="wear"
+          shift
+          ;;
+        --tv)
+          echo "$(basename "$0") create: TV device type not yet supported" >&2
+          echo "This feature is planned for future implementation" >&2
+          exit 1
+          ;;
+        --auto)
+          echo "$(basename "$0") create: Automotive device type not yet supported" >&2
+          echo "This feature is planned for future implementation" >&2
+          exit 1
+          ;;
+        --*)
+          echo "$(basename "$0") create: unknown option '$1'" >&2
+          echo "Valid options: --mobile, --phone, --wear, --watch" >&2
+          exit 1
+          ;;
+        *)
+          # Non-flag argument
+          if [[ -z "$avd_name" ]]; then
+            avd_name="$1"
+          elif [[ -z "$image_package" ]]; then
+            image_package="$1"
+          else
+            echo "$(basename "$0") create: too many arguments" >&2
+            exit 1
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    if [[ -z "$avd_name" ]]; then
       echo "$(basename "$0") create: AVD name required" >&2
       exit 1
     fi
-    create_avd "$2" "${3:-}"
+
+    create_avd "$avd_name" "$device_type" "$image_package"
     ;;
   start)
     start_avd "${@:2}"


### PR DESCRIPTION
Add --mobile/--phone and --wear/--watch switches to the create command
that automatically select the latest available system image for the
specified device type.

Changes:
- Add get_latest_image_for_type() function to find latest image by device type
- Update create_avd() to accept device_type parameter
- Add argument parsing for device type switches (--mobile, --phone, --wear, --watch)
- Update help text with new options and examples
- Include extensible design for future device types (TV, Auto)
- Add validation for unsupported device types with helpful error messages

The implementation intelligently matches images based on device type:
- Mobile: Prefers googleapisplaystore, excludes specialized variants
- Wear: Prefers android-wear-signed, excludes China-specific variants
- TV/Auto: Defined but not yet enabled (returns helpful error message)

Examples:
  emumanager create my_phone --mobile
  emumanager create my_watch --wear