### PR TITLE
fix(bash): Fix Android Studio shell environment loading on macOS

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -1,8 +1,5 @@
 # -*- sh -*-
 
-# Might also need to avoid fish if INTELLIJ_ENVIRONMENT_READER is present; see
-# https://youtrack.jetbrains.com/articles/SUPPORT-A-1727/Shell-Environment-Loading
-
 is_interactive() { [[ $- == *i* ]]; }
 
 if is_interactive; then
@@ -12,7 +9,17 @@ if is_interactive; then
     FISH=$(env PATH="$HOME/local/bin:/opt/homebrew/bin:$PATH" which fish)
 
     if [[ -x "$FISH" ]]; then
-      exec env SHELL="$FISH" "$FISH" -i
+      # If bash was invoked with -c 'command' (e.g., Android Studio's printenv),
+      # pass the command to fish so it runs in fish's environment after fish config.
+      # See https://youtrack.jetbrains.com/articles/SUPPORT-A-1727/Shell-Environment-Loading
+      if [[ -n "${BASH_EXECUTION_STRING-}" ]]; then
+        exec env SHELL="$FISH" "$FISH" -i -c "$BASH_EXECUTION_STRING"
+      else
+        exec env SHELL="$FISH" "$FISH" -i
+      fi
     fi
 
 fi
+
+# If we reach here, fish wasn't found. Source bashrc for PATH and environment setup.
+[[ -r "$HOME/.bashrc" ]] && . "$HOME/.bashrc"


### PR DESCRIPTION
Android Studio runs `/bin/bash -l -i -c 'printenv'` to capture the shell environment. Previously, .bash_profile would exec to fish but discard the command, causing printenv to never run.

Solution: Detect when bash is invoked with -c and pass the command through to fish using `fish -i -c "$BASH_EXECUTION_STRING"`. This ensures:

1. Fish's initialization scripts run (fish/config.fish)
2. The command executes in fish's environment
3. Android Studio captures the actual environment variables set by fish

This preserves the bash->fish handoff while allowing Android Studio to correctly read the fish environment that would be present in a normal terminal session.

Related: https://youtrack.jetbrains.com/articles/SUPPORT-A-1727/Shell-Environment-Loading