### PR TITLE
Fix hardware detection inconsistency in emumanager

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -747,7 +747,7 @@ start_avd() {
       acceleration_ok=false
     fi
   elif [[ "$(uname -s)" == "Darwin" ]]; then
-    if ! sysctl -a | grep -q "kern.hv_support: 1"; then
+    if [[ "$(sysctl -n kern.hv.supported 2>/dev/null)" -ne 1 ]]; then
       acceleration_ok=false
     fi
   fi


### PR DESCRIPTION
The start command was checking kern.hv_support (incorrect key) while the doctor command was checking kern.hv.supported (correct key). This caused start to incorrectly report hardware acceleration unavailable even when HVF was enabled.

Both commands now use the same sysctl key: kern.hv.supported