### PR TITLE
Fix false orphaned crashpad_handler process warnings

### DIFF
--- a/bin/emumanager
+++ b/bin/emumanager
@@ -1266,20 +1266,7 @@ run_doctor() {
   local warnings=0
   local errors=0
 
-  # Check for orphaned crashpad_handler processes
-  local crashpad_count
-  crashpad_count=$(pgrep -f 'android-sdk/emulator/crashpad_handler' | grep -c . || true)
-  if [[ "$crashpad_count" -gt 0 ]]; then
-    echo "[WARN] Found $crashpad_count orphaned crashpad_handler processes"
-    echo "       These are leftover crash reporters from previous emulator sessions."
-    echo "       To clean up: pkill -f 'android-sdk/emulator/crashpad_handler'"
-    echo ""
-    warnings=$((warnings + 1))
-  else
-    echo "[OK]   No orphaned crashpad_handler processes"
-  fi
-
-  # Check for orphaned emulator processes
+  # Check for emulator processes first
   local emulator_count
   emulator_count=$(pgrep -f 'emulator/emulator.*-avd' | grep -c . || true)
   if [[ "$emulator_count" -gt 0 ]]; then
@@ -1293,6 +1280,21 @@ run_doctor() {
     echo ""
   else
     echo "[OK]   No emulator processes running"
+  fi
+
+  # Check for orphaned crashpad_handler processes
+  # Note: crashpad_handler is a legitimate process when the emulator is running,
+  # so only warn if we found them without any running emulator processes
+  local crashpad_count
+  crashpad_count=$(pgrep -f 'android-sdk/emulator/crashpad_handler' | grep -c . || true)
+  if [[ "$crashpad_count" -gt 0 && "$emulator_count" -eq 0 ]]; then
+    echo "[WARN] Found $crashpad_count orphaned crashpad_handler processes"
+    echo "       These are leftover crash reporters from previous emulator sessions."
+    echo "       To clean up: pkill -f 'android-sdk/emulator/crashpad_handler'"
+    echo ""
+    warnings=$((warnings + 1))
+  elif [[ "$crashpad_count" -eq 0 && "$emulator_count" -eq 0 ]]; then
+    echo "[OK]   No orphaned crashpad_handler processes"
   fi
 
   # Check disk space for ANDROID_HOME


### PR DESCRIPTION
The doctor command was incorrectly warning about "orphaned crashpad_handler processes" even when the emulator was running. crashpad_handler is the legitimate crash reporter that runs alongside the emulator, so it should only be flagged as orphaned when there are no emulator processes running.

Changes:
- Reorder checks to evaluate emulator processes before crashpad_handler
- Only warn about crashpad_handler if no emulator processes are running
- Add comment explaining the relationship between these processes

Fixes the bug where `emumanager doctor` incorrectly complains about crashpad_handler when the emulator is actually running.