### PR TITLE
Reorganize adb-device-properties output for better usability

### DIFF
--- a/bin/adb-device-properties
+++ b/bin/adb-device-properties
@@ -10,16 +10,84 @@ if [ "$(adb get-state 2>/dev/null)" != "device" ]; then
   exit 1
 fi
 
-adb exec-out getprop | grep --color=never "model\|version.sdk\|manufacturer\|hardware\|platform\|revision\|serialno\|product.name\|brand"
+# Function to get a property value
+getprop() {
+  adb exec-out getprop "$1" 2>/dev/null | tr -d '\r'
+}
 
-adb exec-out wm size
-adb exec-out wm density
+# Gather all properties
+SERIAL=$(getprop ro.serialno)
+MANUFACTURER=$(getprop ro.product.manufacturer)
+BRAND=$(getprop ro.product.brand)
+MODEL=$(getprop ro.product.model)
+DEVICE=$(getprop ro.product.device)
+PRODUCT_NAME=$(getprop ro.product.name)
 
-HEIGHT=$(adb exec-out wm size | awk -F'[: x]+' '{print $3}')
-WIDTH=$(adb exec-out wm size | awk -F'[: x]+' '{print $4}')
-DENSITY=$(adb exec-out wm density | tail -1 | awk '{print $NF}') # If DPI overriden in developer settings, we get "Physical density" and "Override density"
+API_LEVEL=$(getprop ro.build.version.sdk)
+ANDROID_VERSION=$(getprop ro.build.version.release)
+BUILD_ID=$(getprop ro.build.id)
+SECURITY_PATCH=$(getprop ro.build.version.security_patch)
+BUILD_TYPE=$(getprop ro.build.type)
 
-HEIGHT_DP=$(echo "scale=2; $HEIGHT * 160 / $DENSITY" | bc)
-WIDTH_DP=$(echo "scale=2; $WIDTH * 160 / $DENSITY" | bc)
+HARDWARE=$(getprop ro.hardware)
+CHIPNAME=$(getprop ro.hardware.chipname)
+PLATFORM=$(getprop ro.board.platform)
+SOC_MANUFACTURER=$(getprop ro.soc.manufacturer)
+SOC_MODEL=$(getprop ro.soc.model)
+ABI=$(getprop ro.product.cpu.abi)
+ABI2=$(getprop ro.product.cpu.abi2)
 
-printf "Dp size: %.0fx%.0f\n" "$HEIGHT_DP" "$WIDTH_DP"
+CHARACTERISTICS=$(getprop ro.build.characteristics)
+
+# Display dimensions
+HEIGHT=$(adb exec-out wm size 2>/dev/null | awk -F'[: x]+' '{print $3}')
+WIDTH=$(adb exec-out wm size 2>/dev/null | awk -F'[: x]+' '{print $4}')
+DENSITY=$(adb exec-out wm density 2>/dev/null | tail -1 | awk '{print $NF}')
+
+# Calculate DP size
+if command -v bc &>/dev/null && [[ -n "$HEIGHT" && -n "$WIDTH" && -n "$DENSITY" ]]; then
+  HEIGHT_DP=$(echo "scale=2; $HEIGHT * 160 / $DENSITY" | bc)
+  WIDTH_DP=$(echo "scale=2; $WIDTH * 160 / $DENSITY" | bc)
+fi
+
+# Output organized information
+echo "Device Information:"
+[[ -n "$MANUFACTURER" ]] && echo "  Manufacturer: $MANUFACTURER"
+[[ -n "$BRAND" ]] && echo "  Brand: $BRAND"
+[[ -n "$MODEL" ]] && echo "  Model: $MODEL"
+[[ -n "$DEVICE" ]] && echo "  Device: $DEVICE"
+[[ -n "$PRODUCT_NAME" ]] && echo "  Product: $PRODUCT_NAME"
+[[ -n "$SERIAL" ]] && echo "  Serial: $SERIAL"
+[[ -n "$CHARACTERISTICS" ]] && echo "  Type: $CHARACTERISTICS"
+
+echo ""
+echo "System Information:"
+[[ -n "$ANDROID_VERSION" ]] && echo "  Android: $ANDROID_VERSION"
+[[ -n "$API_LEVEL" ]] && echo "  API Level: $API_LEVEL"
+[[ -n "$BUILD_ID" ]] && echo "  Build ID: $BUILD_ID"
+[[ -n "$BUILD_TYPE" ]] && echo "  Build Type: $BUILD_TYPE"
+[[ -n "$SECURITY_PATCH" ]] && echo "  Security Patch: $SECURITY_PATCH"
+
+echo ""
+echo "Hardware:"
+[[ -n "$HARDWARE" ]] && echo "  Hardware: $HARDWARE"
+[[ -n "$CHIPNAME" ]] && echo "  Chipset: $CHIPNAME"
+[[ -n "$SOC_MANUFACTURER" && -n "$SOC_MODEL" ]] && echo "  SoC: $SOC_MANUFACTURER $SOC_MODEL"
+[[ -n "$PLATFORM" ]] && echo "  Platform: $PLATFORM"
+if [[ -n "$ABI" ]]; then
+  if [[ -n "$ABI2" ]]; then
+    echo "  ABI: $ABI, $ABI2"
+  else
+    echo "  ABI: $ABI"
+  fi
+fi
+
+if [[ -n "$HEIGHT" && -n "$WIDTH" && -n "$DENSITY" ]]; then
+  echo ""
+  echo "Display:"
+  echo "  Resolution: ${WIDTH}x${HEIGHT} px"
+  echo "  Density: ${DENSITY} dpi"
+  if [[ -n "$HEIGHT_DP" && -n "$WIDTH_DP" ]]; then
+    printf "  Size (dp): %.0fx%.0f\n" "$WIDTH_DP" "$HEIGHT_DP"
+  fi
+fi


### PR DESCRIPTION
- Structure output in clear sections: Device, System, Hardware, Display
- Add API level, Android version, and security patch info
- Include device characteristics (phone/tablet/tv) for identification
- Add chipset, SoC, and ABI information for hardware details
- Use conditional display to only show available properties
- Follow emumanager info output format for consistency