### PR TITLE
Fix jetpack-resolve unbound variable error

### DIFF
--- a/bin/apk-launcher-icon-extract
+++ b/bin/apk-launcher-icon-extract
@@ -59,6 +59,10 @@ while getopts "o:h-" opt; do
 done
 shift $((OPTIND - 1))
 
+if [ -z "${1:-}" ]; then
+  usage
+fi
+
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
 fi
@@ -71,10 +75,6 @@ require unzip
 require apktool
 require xmllint
 require xpath
-
-if [ -z "$1" ]; then
-  usage
-fi
 
 function match_vector() {
   GLOB="$1"

--- a/bin/jetpack-resolve
+++ b/bin/jetpack-resolve
@@ -23,11 +23,11 @@ EOF
   exit 0
 }
 
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+if [ "$#" -lt 1 ]; then
   usage
 fi
 
-if [ "$#" -lt 1 ]; then
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
 fi
 


### PR DESCRIPTION
Fixed bug in jetpack-resolve and apk-launcher-icon-extract where running without arguments produced "$1: unbound variable" error due to set -u flag.

Both scripts checked for help flags before validating that arguments exist. Moved argument count check before accessing $1 to prevent the error.