### PR TITLE
Review and apply adb-tile robustness improvements

### DIFF
--- a/bin/adb-tile-remove
+++ b/bin/adb-tile-remove
@@ -32,4 +32,13 @@ require() { hash "$@" || exit 127; }
 
 require adb
 
-adb shell am broadcast -a com.google.android.wearable.app.DEBUG_SURFACE --es operation remove-tile --ecn component "$1"
+COMPONENT_NAME="$1"
+PACKAGE_NAME="${COMPONENT_NAME%%/*}"
+
+# Check if the package is installed
+if ! adb shell pm list packages | grep -q "$PACKAGE_NAME"; then
+  echo "Error: Package '$PACKAGE_NAME' not found. Is the app installed?" >&2
+  exit 1
+fi
+
+adb shell am broadcast -a com.google.android.wearable.app.DEBUG_SURFACE --es operation remove-tile --ecn component "$COMPONENT_NAME"


### PR DESCRIPTION
Apply the same package installation check from adb-tile-add to adb-tile-remove for consistency and better usability.