### PR TITLE
Add SNAPSHOT version support to jetpack scripts

### DIFF
--- a/bin/jetpack-inspect
+++ b/bin/jetpack-inspect
@@ -12,10 +12,11 @@ to map from a package/class name directly to source code.
 Arguments:
   CLASS_NAME    Fully qualified package/class name
                 (e.g., androidx.core.splashscreen.SplashScreen)
-  VERSION_TYPE  Version type: ALPHA, BETA, RC, STABLE, or LATEST
+  VERSION_TYPE  Version type: ALPHA, BETA, RC, STABLE, LATEST, or SNAPSHOT
                 (optional, defaults to STABLE)
   REPO_URL      Maven repository URL
                 (optional, defaults to Google Maven)
+                For SNAPSHOT, this is ignored and the androidx.dev snapshot repo is used.
 
 Options:
   -h, --help    Display this help message and exit
@@ -25,6 +26,7 @@ Examples:
   $(basename "$0") androidx.core.splashscreen.SplashScreen
   $(basename "$0") androidx.wear.ambient.AmbientLifecycleObserver ALPHA
   $(basename "$0") androidx.lifecycle.ViewModel STABLE
+  $(basename "$0") androidx.glance.wear.tiles.GlanceTileService SNAPSHOT
   pushd "\$($(basename "$0") androidx.wear.tiles.TileService)"
 
 The script resolves the class name to a Maven coordinate, then downloads and

--- a/bin/jetpack-source
+++ b/bin/jetpack-source
@@ -12,9 +12,10 @@ Download and extract source code for one or more Jetpack packages.
 Arguments:
   PACKAGE     One or more package names in the format GROUP_ID:ARTIFACT_ID
               (supports brace expansion, e.g., androidx.pkg:{foo,bar})
-  VERSION     Version string: ALPHA, BETA, RC, STABLE, LATEST, or a specific version number
+  VERSION     Version string: ALPHA, BETA, RC, STABLE, LATEST, SNAPSHOT, or a specific version number
               (optional, defaults to STABLE)
   REPO_URL    Maven repository URL (optional, default: https://dl.google.com/android/maven2)
+              For SNAPSHOT, this is ignored and the androidx.dev snapshot repo is used.
 
 Options:
   -h, --help  Display this help message and exit
@@ -25,6 +26,8 @@ Examples:
   $(basename "$0") androidx.wear.tiles:tiles STABLE
   $(basename "$0") androidx.wear.tiles:tiles ALPHA
   $(basename "$0") androidx.wear.tiles:tiles RC
+  $(basename "$0") androidx.wear.tiles:tiles SNAPSHOT
+  $(basename "$0") androidx.glance:glance-wear-tiles SNAPSHOT
   $(basename "$0") androidx.wear.protolayout:protolayout-{expression,material,material3}
   $(basename "$0") com.google.android.horologist:horologist-datalayer STABLE https://repo1.maven.org/maven2
   $(basename "$0") --output /tmp/wear-tiles androidx.wear.tiles:tiles BETA
@@ -114,6 +117,15 @@ if [ "${#PACKAGES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# For SNAPSHOT versions, set up the snapshot repository
+if [ "$VERSION_STRING_UPPER" = "SNAPSHOT" ]; then
+  # Use the "latest" redirect URL which automatically resolves to the current snapshot build
+  # e.g., https://androidx.dev/snapshots/latest/artifacts/repository redirects to
+  #       https://androidx.dev/snapshots/builds/14566697/artifacts/repository
+  REPO_URL="https://androidx.dev/snapshots/latest/artifacts/repository"
+  echo "info: Using AndroidX snapshot repository" >&2
+fi
+
 # Validate all packages before creating directories or downloading
 for PACKAGE_NAME in "${PACKAGES[@]}"; do
   # Validate package name format
@@ -148,17 +160,35 @@ for PACKAGE_NAME in "${PACKAGES[@]}"; do
   ARTIFACT_ID=$(echo "$PACKAGE_NAME" | cut -d: -f2)
   GROUP_ID_PATH=$(echo "$GROUP_ID" | sed 's/\./\//g')
 
-  # Resolve version (use the first package to resolve ALPHA/BETA/RC/STABLE/LATEST)
+  # Resolve version (use the first package to resolve ALPHA/BETA/RC/STABLE/LATEST/SNAPSHOT)
   if [ -z "$VERSION" ]; then
-    if [ "$VERSION_STRING_UPPER" == "ALPHA" ] || [ "$VERSION_STRING_UPPER" == "BETA" ] || [ "$VERSION_STRING_UPPER" == "RC" ] || [ "$VERSION_STRING_UPPER" == "STABLE" ] || [ "$VERSION_STRING_UPPER" == "LATEST" ]; then
+    if [ "$VERSION_STRING_UPPER" == "ALPHA" ] || [ "$VERSION_STRING_UPPER" == "BETA" ] || [ "$VERSION_STRING_UPPER" == "RC" ] || [ "$VERSION_STRING_UPPER" == "STABLE" ] || [ "$VERSION_STRING_UPPER" == "LATEST" ] || [ "$VERSION_STRING_UPPER" == "SNAPSHOT" ]; then
       VERSION=$(jetpack-version "${PACKAGE_NAME}" "$VERSION_STRING_UPPER" "$REPO_URL")
       echo "info: Resolved $VERSION_STRING_UPPER version for ${PACKAGE_NAME} to ${VERSION}" >&2
     else
       VERSION=$VERSION_STRING
     fi
   fi
-  SOURCE_JAR_URL="${REPO_URL}/${GROUP_ID_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}-sources.jar"
-  SOURCE_JAR_FILENAME="${ARTIFACT_ID}-${VERSION}-sources.jar"
+
+  # For SNAPSHOT versions, we need to resolve the timestamped version for the JAR filename
+  # The directory structure uses X.Y.Z-SNAPSHOT but the JAR uses X.Y.Z-TIMESTAMP-N
+  JAR_VERSION="$VERSION"
+  if [[ "$VERSION" =~ -SNAPSHOT$ ]]; then
+    # Fetch the version-specific maven-metadata.xml to get the timestamped version
+    VERSION_METADATA_URL="${REPO_URL}/${GROUP_ID_PATH}/${ARTIFACT_ID}/${VERSION}/maven-metadata.xml"
+    SNAPSHOT_JAR_VERSION=$(curl -sSLf "$VERSION_METADATA_URL" 2>/dev/null |
+      xmllint --xpath "//snapshotVersion[classifier='sources' and extension='jar']/value/text()" - 2>/dev/null || true)
+
+    if [ -n "$SNAPSHOT_JAR_VERSION" ]; then
+      JAR_VERSION="$SNAPSHOT_JAR_VERSION"
+      echo "info: Resolved snapshot JAR version to ${JAR_VERSION}" >&2
+    else
+      echo "$(basename "$0"): warning: could not resolve timestamped version, trying ${VERSION}" >&2
+    fi
+  fi
+
+  SOURCE_JAR_URL="${REPO_URL}/${GROUP_ID_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${JAR_VERSION}-sources.jar"
+  SOURCE_JAR_FILENAME="${ARTIFACT_ID}-${JAR_VERSION}-sources.jar"
 
   echo "info: Downloading ${PACKAGE_NAME} version ${VERSION}" >&2
   if ! curl -sSLf -o "${BUILD_DIR}/${SOURCE_JAR_FILENAME}" "${SOURCE_JAR_URL}"; then
@@ -174,7 +204,7 @@ for PACKAGE_NAME in "${PACKAGES[@]}"; do
 
   # Check for Kotlin Multiplatform platform-specific sources
   # Download the POM to check for platform dependencies (-jvm, -android, etc.)
-  POM_URL="${REPO_URL}/${GROUP_ID_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.pom"
+  POM_URL="${REPO_URL}/${GROUP_ID_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${JAR_VERSION}.pom"
   POM_CONTENT=$(curl -sSLf "${POM_URL}" 2>/dev/null || true)
 
   if [ -n "$POM_CONTENT" ]; then
@@ -186,8 +216,19 @@ for PACKAGE_NAME in "${PACKAGES[@]}"; do
     if [ -n "$PLATFORM_ARTIFACTS" ]; then
       echo "info: Detected Kotlin Multiplatform library, downloading platform-specific sources..." >&2
       for PLATFORM_ARTIFACT in $PLATFORM_ARTIFACTS; do
-        PLATFORM_SOURCE_JAR_URL="${REPO_URL}/${GROUP_ID_PATH}/${PLATFORM_ARTIFACT}/${VERSION}/${PLATFORM_ARTIFACT}-${VERSION}-sources.jar"
-        PLATFORM_SOURCE_JAR_FILENAME="${PLATFORM_ARTIFACT}-${VERSION}-sources.jar"
+        # For SNAPSHOT versions, resolve the timestamped version for each platform artifact
+        PLATFORM_JAR_VERSION="$VERSION"
+        if [[ "$VERSION" =~ -SNAPSHOT$ ]]; then
+          PLATFORM_VERSION_METADATA_URL="${REPO_URL}/${GROUP_ID_PATH}/${PLATFORM_ARTIFACT}/${VERSION}/maven-metadata.xml"
+          PLATFORM_SNAPSHOT_JAR_VERSION=$(curl -sSLf "$PLATFORM_VERSION_METADATA_URL" 2>/dev/null |
+            xmllint --xpath "//snapshotVersion[classifier='sources' and extension='jar']/value/text()" - 2>/dev/null || true)
+          if [ -n "$PLATFORM_SNAPSHOT_JAR_VERSION" ]; then
+            PLATFORM_JAR_VERSION="$PLATFORM_SNAPSHOT_JAR_VERSION"
+          fi
+        fi
+
+        PLATFORM_SOURCE_JAR_URL="${REPO_URL}/${GROUP_ID_PATH}/${PLATFORM_ARTIFACT}/${VERSION}/${PLATFORM_ARTIFACT}-${PLATFORM_JAR_VERSION}-sources.jar"
+        PLATFORM_SOURCE_JAR_FILENAME="${PLATFORM_ARTIFACT}-${PLATFORM_JAR_VERSION}-sources.jar"
 
         # Try to download platform sources (may not exist for all platforms)
         if curl -sSLf -o "${BUILD_DIR}/${PLATFORM_SOURCE_JAR_FILENAME}" "${PLATFORM_SOURCE_JAR_URL}" 2>/dev/null; then

--- a/bin/jetpack-version
+++ b/bin/jetpack-version
@@ -8,16 +8,18 @@ Gets a specific version type for a given Jetpack package.
 
 Arguments:
   PACKAGE_NAME  The package name (e.g., androidx.wear.tiles:tiles)
-  VERSION_TYPE  The version type to retrieve: ALPHA, BETA, RC, STABLE, or LATEST
+  VERSION_TYPE  The version type to retrieve: ALPHA, BETA, RC, STABLE, LATEST, or SNAPSHOT
                 (optional, defaults to STABLE)
   REPO_URL      The Maven repository URL (optional, defaults to Google Maven)
+                For SNAPSHOT, this is ignored and the androidx.dev snapshot repo is used.
 
 Version Types:
-  ALPHA   - Latest alpha version (e.g., 1.2.3-alpha04)
-  BETA    - Latest beta version (e.g., 1.2.3-beta02)
-  RC      - Latest release candidate version (e.g., 1.2.3-rc01)
-  STABLE  - Latest stable release (e.g., 1.2.3, without pre-release suffix)
-  LATEST  - Latest version of any kind (from maven-metadata.xml <latest> tag)
+  ALPHA    - Latest alpha version (e.g., 1.2.3-alpha04)
+  BETA     - Latest beta version (e.g., 1.2.3-beta02)
+  RC       - Latest release candidate version (e.g., 1.2.3-rc01)
+  STABLE   - Latest stable release (e.g., 1.2.3, without pre-release suffix)
+  LATEST   - Latest version of any kind (from maven-metadata.xml <latest> tag)
+  SNAPSHOT - Latest snapshot version from androidx.dev (e.g., 1.0.0-SNAPSHOT)
 
 Examples:
   $(basename "$0") androidx.wear.tiles:tiles
@@ -26,6 +28,7 @@ Examples:
   $(basename "$0") androidx.wear.tiles:tiles BETA
   $(basename "$0") androidx.wear.tiles:tiles RC
   $(basename "$0") androidx.wear.tiles:tiles LATEST
+  $(basename "$0") androidx.wear.tiles:tiles SNAPSHOT
   $(basename "$0") com.google.android.horologist:horologist-datalayer STABLE https://repo1.maven.org/maven2
 EOF
   exit 0
@@ -66,10 +69,10 @@ fi
 
 # Validate version type
 case "$VERSION_TYPE" in
-  ALPHA | BETA | RC | STABLE | LATEST) ;;
+  ALPHA | BETA | RC | STABLE | LATEST | SNAPSHOT) ;;
   *)
-    echo "$(basename "$0"): invalid version type '$1'" >&2
-    echo "Valid types: ALPHA, BETA, RC, STABLE, LATEST" >&2
+    echo "$(basename "$0"): invalid version type '$VERSION_TYPE'" >&2
+    echo "Valid types: ALPHA, BETA, RC, STABLE, LATEST, SNAPSHOT" >&2
     exit 1
     ;;
 esac
@@ -77,6 +80,39 @@ esac
 GROUP_ID=$(echo "$PACKAGE_NAME" | cut -d: -f1)
 ARTIFACT_ID=$(echo "$PACKAGE_NAME" | cut -d: -f2)
 GROUP_ID_PATH=$(echo "$GROUP_ID" | sed 's/\./\//g')
+
+# Handle SNAPSHOT separately since it uses a different repository
+if [ "$VERSION_TYPE" = "SNAPSHOT" ]; then
+  # Use the "latest" redirect URL which automatically resolves to the current snapshot build
+  # e.g., https://androidx.dev/snapshots/latest/artifacts/repository redirects to
+  #       https://androidx.dev/snapshots/builds/14566697/artifacts/repository
+  SNAPSHOT_REPO_URL="https://androidx.dev/snapshots/latest/artifacts/repository"
+  METADATA_URL="$SNAPSHOT_REPO_URL/$GROUP_ID_PATH/$ARTIFACT_ID/maven-metadata.xml"
+
+  # Check if the package exists in snapshot repository
+  if ! curl -sSLf "$METADATA_URL" >/dev/null 2>&1; then
+    echo "$(basename "$0"): failed to fetch $METADATA_URL" >&2
+    echo "$(basename "$0"): package may not exist in snapshot builds" >&2
+    exit 1
+  fi
+
+  # Get the latest SNAPSHOT version
+  VERSION=$(curl -sSLf "$METADATA_URL" |
+    xmllint --xpath "//version/text()" - |
+    tr ' ' '\n' |
+    grep -E '\-SNAPSHOT$' |
+    sort -V |
+    tail -n 1)
+
+  if [[ -z "$VERSION" ]]; then
+    echo "$(basename "$0"): no snapshot version found at $METADATA_URL" >&2
+    exit 1
+  fi
+
+  echo "$VERSION"
+  exit 0
+fi
+
 METADATA_URL="$REPO_URL/$GROUP_ID_PATH/$ARTIFACT_ID/maven-metadata.xml"
 
 # Check if the package exists


### PR DESCRIPTION
Add support for downloading source code from AndroidX snapshot builds at androidx.dev. This enables accessing libraries that are only available in snapshot form (e.g., androidx.glance:glance-wear-tiles).

Changes:
- Add SNAPSHOT version type to jetpack-version, jetpack-source, and jetpack-inspect
- Use the redirect URL https://androidx.dev/snapshots/latest/artifacts/repository which automatically resolves to the current build (e.g., builds/14566697)
- Handle timestamped JAR filenames in snapshot repositories (e.g., artifact-1.0.0-20251210.085303-1-sources.jar)