### PR TITLE
Create bash script wrapper for ktfmt tool

### DIFF
--- a/bin/ktfmt
+++ b/bin/ktfmt
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KTFMT_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ktfmt"
+
+# Find existing jar or download latest
+get_jar() {
+  local jar
+  jar=$(find "$KTFMT_DIR" -maxdepth 1 -name 'ktfmt-*-jar-with-dependencies.jar' 2>/dev/null | head -n 1)
+
+  if [[ -n "$jar" ]]; then
+    echo "$jar"
+    return 0
+  fi
+
+  # Download latest release
+  echo "Downloading ktfmt..." >&2
+  mkdir -p "$KTFMT_DIR"
+
+  local url
+  url=$(curl -fsSL https://api.github.com/repos/facebook/ktfmt/releases \
+    | jq -r '.[0].assets[].browser_download_url' \
+    | grep 'jar-with-dependencies\.jar$')
+
+  if [[ -z "$url" ]]; then
+    echo "ktfmt: failed to find download URL" >&2
+    return 1
+  fi
+
+  local filename
+  filename=$(basename "$url")
+  curl -fsSL "$url" -o "$KTFMT_DIR/$filename"
+  echo "Downloaded $filename" >&2
+  echo "$KTFMT_DIR/$filename"
+}
+
+jar=$(get_jar)
+exec java -jar "$jar" "$@"


### PR DESCRIPTION
Downloads the ktfmt jar with dependencies from GitHub releases on first run and caches it in $XDG_DATA_HOME/ktfmt (or ~/.local/share/ktfmt).