### PR TITLE
Fix "e" completion too many arguments bug

### DIFF
--- a/fish/completions/e.fish
+++ b/fish/completions/e.fish
@@ -1,1 +1,1 @@
-complete -c e -a (string replace -r '.*/(.*)\.fish\$' '$1' $HOME/.config/fish/functions/*.fish)
+complete -c e -a (string replace -r '.*/(.*)\.fish$' '$1' $HOME/.config/fish/functions/*.fish)


### PR DESCRIPTION
The regex used \$ which in fish single quotes is a literal backslash and dollar sign, not end-of-string anchor. This caused the regex to never match, resulting in "too many arguments" errors on tab completion.