### PR TITLE
Fix fish prompt appearing on all lines

### DIFF
--- a/fish/functions/fish_prompt.fish
+++ b/fish/functions/fish_prompt.fish
@@ -3,7 +3,12 @@
 # PWD Settings
 set fish_prompt_pwd_dir_length 1
 set fish_prompt_pwd_full_dirs 3
-set fish_transient_prompt yes
+
+# Transient prompts (hide right prompt on non-active lines) requires fish 4.1+
+# fish 4.0.x does not support --final-rendering flag
+if test "$FISH_VERSION" \> "4.0.999"
+    set fish_transient_prompt 1
+end
 
 # Git Logic
 set __fish_git_prompt_showupstream auto


### PR DESCRIPTION
The fish_transient_prompt feature with --final-rendering flag was added in fish 4.1.0, not fish 4.0.x. Without this version check, the right prompt would never disappear on older fish versions because the --final-rendering flag is never passed.