### PR TITLE
Review e.fish commit and source filename handling

### DIFF
--- a/fish/functions/e.fish
+++ b/fish/functions/e.fish
@@ -30,20 +30,11 @@ function e -d 'Edit file, searching in a few different places'
 
         case function
 
-            set -l type_output (type $name)
-            set -l def_line (string match -r '# Defined in .*' $type_output)
-
-            if test -n "$def_line"
-                set -l func_file (string replace '# Defined in ' '' $def_line | string trim)
-                # Further clean the path to remove potential line number and column info
-                set func_file (echo $func_file | string match -r '^[^ @]+')
-                if test -f "$func_file"
-                    eval $EDITOR "$func_file"
-                else
-                    echo "error: file '$func_file' for function '$name' not found"
-                end
+            set -l func_file (type -p $name)
+            if test -n "$func_file" -a -f "$func_file"
+                eval $EDITOR "$func_file"
             else
-                echo "error: could not determine file for function '$name'"
+                echo "error: function '$name' is interactively defined or file not found"
             end
 
         case '*'


### PR DESCRIPTION
Replace fragile parsing of `type` output for the "# Defined in ..." line with the dedicated `type -p` flag, which directly returns the file path for functions loaded from disk.

This is more robust (uses a dedicated API rather than parsing human- readable text) and consistent with how the script already handles the `file` case.