### PR TITLE
Test e.fish command completion accuracy

### DIFF
--- a/fish/completions/e.fish
+++ b/fish/completions/e.fish
@@ -1,1 +1,6 @@
-complete -c e -a (string replace -r '.*/' '' $HOME/.config/fish/functions/*.fish $HOME/.dotfiles/bin/* | string replace -r '\.fish$' '' | string join ' ')
+# Complete with fish function names
+complete -c e -f -a "(functions -n)"
+
+# Complete with scripts from dotfiles bin directory
+# (Filtering text files across all of PATH would be too slow)
+complete -c e -f -a "(printf '%s\n' $HOME/.dotfiles/bin/* 2>/dev/null | xargs -n1 basename 2>/dev/null)"


### PR DESCRIPTION
The old completions hardcoded two specific paths:
- $HOME/.config/fish/functions/*.fish
- $HOME/.dotfiles/bin/*

The function path was wrong - it didn't match what `e` finds via `type -q` which searches all of $fish_function_path.

Now completions use:
- `functions -n` for all fish function names (from any path)
- $HOME/.dotfiles/bin/* for scripts (unchanged, but filtering all of PATH for text files would be too slow)

This ensures "e fo<TAB>" completes "foo" whenever "e foo" would work.