### PR TITLE
Add multiple filename support to format scripts

### DIFF
--- a/bin/json-format
+++ b/bin/json-format
@@ -2,15 +2,15 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [FILE]
+Usage: $(basename "$0") [FILE...]
 
-Format a JSON file using jq.
+Format JSON files using jq.
 
-When FILE is provided, the file is formatted in place. When no FILE is
+When FILEs are provided, each file is formatted in place. When no FILE is
 provided, reads from standard input and writes to standard output.
 
 Arguments:
-  FILE        Path to a JSON file to format (optional)
+  FILE...     Paths to JSON files to format (optional)
 
 Options:
   -h, --help  Display this help message and exit
@@ -20,6 +20,10 @@ Examples:
 # Format a file in place
 
   $(basename "$0") config.json
+
+# Format multiple files
+
+  $(basename "$0") *.json
 
 # Format from stdin to stdout
 
@@ -34,11 +38,6 @@ EOF
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
-fi
-
-if [[ $# -gt 1 ]]; then
-  echo "$(basename "$0"): too many arguments" >&2
-  exit 1
 fi
 
 if [[ $# -eq 0 && -t 0 ]]; then
@@ -56,24 +55,29 @@ FORMAT_CMD="jq ."
 
 if [[ $# -eq 0 ]]; then
 
-# Read from stdin, write to stdout
+  # Read from stdin, write to stdout
 
   $FORMAT_CMD
 else
 
-# Format file in place
+  # Format files in place
 
-  if [[ ! -f "$1" ]]; then
-    echo "$(basename "$0"): $1: No such file or directory" >&2
-    exit 1
-  fi
   TMPFILE=$(mktemp)
   trap 'rm -f -- "$TMPFILE"' EXIT
-  if $FORMAT_CMD < "$1" > "$TMPFILE"; then
-    cat "$TMPFILE" > "$1"
-    echo "$(basename "$0"): $1: formatted"
-  else
-    echo "$(basename "$0"): $1: failed to format" >&2
-    exit 1
-  fi
+  FAILED=0
+  for FILE in "$@"; do
+    if [[ ! -f "$FILE" ]]; then
+      echo "$(basename "$0"): $FILE: No such file or directory" >&2
+      FAILED=1
+      continue
+    fi
+    if $FORMAT_CMD < "$FILE" > "$TMPFILE"; then
+      cat "$TMPFILE" > "$FILE"
+      echo "$(basename "$0"): $FILE: formatted"
+    else
+      echo "$(basename "$0"): $FILE: failed to format" >&2
+      FAILED=1
+    fi
+  done
+  exit $FAILED
 fi

--- a/bin/kotlin-format
+++ b/bin/kotlin-format
@@ -4,18 +4,18 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [FILE]
+Usage: $(basename "$0") [FILE...]
 
-Format a Kotlin file using ktfmt with kotlinlang style.
+Format Kotlin files using ktfmt with kotlinlang style.
 
-When FILE is provided, the file is formatted in place. When no FILE is
+When FILEs are provided, each file is formatted in place. When no FILE is
 provided, reads from standard input and writes to standard output.
 
 The ktfmt jar is automatically downloaded from GitHub on first use and
 cached in \$XDG_DATA_HOME/ktfmt (or ~/.local/share/ktfmt).
 
 Arguments:
-  FILE        Path to a Kotlin file to format (optional)
+  FILE...     Paths to Kotlin files to format (optional)
 
 Options:
   -h, --help  Display this help message and exit
@@ -25,6 +25,10 @@ Examples:
 # Format a file in place
 
   $(basename "$0") Main.kt
+
+# Format multiple files
+
+  $(basename "$0") src/*.kt
 
 # Format from stdin to stdout
 
@@ -39,11 +43,6 @@ EOF
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
-fi
-
-if [[ $# -gt 1 ]]; then
-  echo "$(basename "$0"): too many arguments" >&2
-  exit 1
 fi
 
 if [[ $# -eq 0 && -t 0 ]]; then
@@ -97,16 +96,21 @@ if [[ $# -eq 0 ]]; then
   java -jar "$jar" --kotlinlang-style -
 else
 
-  # Format file in place
+  # Format files in place
 
-  if [[ ! -f "$1" ]]; then
-    echo "$(basename "$0"): $1: No such file or directory" >&2
-    exit 1
-  fi
-  if java -jar "$jar" --kotlinlang-style "$1"; then
-    echo "$(basename "$0"): $1: formatted"
-  else
-    echo "$(basename "$0"): $1: failed to format" >&2
-    exit 1
-  fi
+  FAILED=0
+  for FILE in "$@"; do
+    if [[ ! -f "$FILE" ]]; then
+      echo "$(basename "$0"): $FILE: No such file or directory" >&2
+      FAILED=1
+      continue
+    fi
+    if java -jar "$jar" --kotlinlang-style "$FILE"; then
+      echo "$(basename "$0"): $FILE: formatted"
+    else
+      echo "$(basename "$0"): $FILE: failed to format" >&2
+      FAILED=1
+    fi
+  done
+  exit $FAILED
 fi

--- a/bin/markdown-format
+++ b/bin/markdown-format
@@ -2,15 +2,15 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [FILE]
+Usage: $(basename "$0") [FILE...]
 
-Format a Markdown file using markdownlint-cli2 and prettier.
+Format Markdown files using markdownlint-cli2 and prettier.
 
-When FILE is provided, the file is formatted in place. When no FILE is
+When FILEs are provided, each file is formatted in place. When no FILE is
 provided, reads from standard input and writes to standard output.
 
 Arguments:
-  FILE        Path to a Markdown file to format (optional)
+  FILE...     Paths to Markdown files to format (optional)
 
 Options:
   -h, --help  Display this help message and exit
@@ -20,6 +20,10 @@ Examples:
 # Format a file in place
 
   $(basename "$0") README.md
+
+# Format multiple files
+
+  $(basename "$0") docs/*.md
 
 # Format from stdin to stdout
 
@@ -34,11 +38,6 @@ EOF
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
-fi
-
-if [[ $# -gt 1 ]]; then
-  echo "$(basename "$0"): too many arguments" >&2
-  exit 1
 fi
 
 if [[ $# -eq 0 && -t 0 ]]; then
@@ -78,13 +77,18 @@ if [[ $# -eq 0 ]]; then
   cat "$TMPFILE"
 else
 
-  # Format file in place
+  # Format files in place
 
-  if [[ ! -f "$1" ]]; then
-    echo "$(basename "$0"): $1: No such file or directory" >&2
-    exit 1
-  fi
-  $MARKDOWNLINT --fix "$1" 2>/dev/null
-  $PRETTIER --prose-wrap always --write "$1" 2>/dev/null
-  echo "$(basename "$0"): $1: formatted"
+  FAILED=0
+  for FILE in "$@"; do
+    if [[ ! -f "$FILE" ]]; then
+      echo "$(basename "$0"): $FILE: No such file or directory" >&2
+      FAILED=1
+      continue
+    fi
+    $MARKDOWNLINT --fix "$FILE" 2>/dev/null
+    $PRETTIER --prose-wrap always --write "$FILE" 2>/dev/null
+    echo "$(basename "$0"): $FILE: formatted"
+  done
+  exit $FAILED
 fi

--- a/bin/xml-format
+++ b/bin/xml-format
@@ -2,15 +2,15 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [FILE]
+Usage: $(basename "$0") [FILE...]
 
-Format an XML file using xmllint.
+Format XML files using xmllint.
 
-When FILE is provided, the file is formatted in place. When no FILE is
+When FILEs are provided, each file is formatted in place. When no FILE is
 provided, reads from standard input and writes to standard output.
 
 Arguments:
-  FILE        Path to an XML file to format (optional)
+  FILE...     Paths to XML files to format (optional)
 
 Options:
   -h, --help  Display this help message and exit
@@ -20,6 +20,10 @@ Examples:
 # Format a file in place
 
   $(basename "$0") config.xml
+
+# Format multiple files
+
+  $(basename "$0") *.xml
 
 # Format from stdin to stdout
 
@@ -36,11 +40,6 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
 fi
 
-if [[ $# -gt 1 ]]; then
-  echo "$(basename "$0"): too many arguments" >&2
-  exit 1
-fi
-
 if [[ $# -eq 0 && -t 0 ]]; then
   usage
 fi
@@ -51,24 +50,29 @@ require xmllint
 
 if [[ $# -eq 0 ]]; then
 
-# Read from stdin, write to stdout
+  # Read from stdin, write to stdout
 
   xmllint --format -
 else
 
-# Format file in place
+  # Format files in place
 
-  if [[ ! -f "$1" ]]; then
-    echo "$(basename "$0"): $1: No such file or directory" >&2
-    exit 1
-  fi
   TMPFILE=$(mktemp)
   trap 'rm -f -- "$TMPFILE"' EXIT
-  if xmllint --format "$1" > "$TMPFILE"; then
-    cat "$TMPFILE" > "$1"
-    echo "$(basename "$0"): $1: formatted"
-  else
-    echo "$(basename "$0"): $1: failed to format" >&2
-    exit 1
-  fi
+  FAILED=0
+  for FILE in "$@"; do
+    if [[ ! -f "$FILE" ]]; then
+      echo "$(basename "$0"): $FILE: No such file or directory" >&2
+      FAILED=1
+      continue
+    fi
+    if xmllint --format "$FILE" > "$TMPFILE"; then
+      cat "$TMPFILE" > "$FILE"
+      echo "$(basename "$0"): $FILE: formatted"
+    else
+      echo "$(basename "$0"): $FILE: failed to format" >&2
+      FAILED=1
+    fi
+  done
+  exit $FAILED
 fi


### PR DESCRIPTION
All format scripts (json-format, kotlin-format, markdown-format, xml-format) now accept multiple filenames on the command line. Each file is formatted in place, with individual success/failure messages. Exit code is 0 if all files succeed, 1 if any fail.