### PR TITLE
Review recent commits and code quality

### DIFF
--- a/bin/adb-tile-add
+++ b/bin/adb-tile-add
@@ -45,7 +45,7 @@ COMPONENT_NAME="$1"
 PACKAGE_NAME="${COMPONENT_NAME%%/*}"
 
 # Check if the package is installed
-if ! adb shell pm list packages | grep -q "$PACKAGE_NAME"; then
+if ! adb shell pm list packages | grep -q "^package:${PACKAGE_NAME}$"; then
   echo "Error: Package '$PACKAGE_NAME' not found. Is the app installed?" >&2
   exit 1
 fi

--- a/bin/adb-tile-remove
+++ b/bin/adb-tile-remove
@@ -36,7 +36,7 @@ COMPONENT_NAME="$1"
 PACKAGE_NAME="${COMPONENT_NAME%%/*}"
 
 # Check if the package is installed
-if ! adb shell pm list packages | grep -q "$PACKAGE_NAME"; then
+if ! adb shell pm list packages | grep -q "^package:${PACKAGE_NAME}$"; then
   echo "Error: Package '$PACKAGE_NAME' not found. Is the app installed?" >&2
   exit 1
 fi

--- a/bin/adb-tiles
+++ b/bin/adb-tiles
@@ -26,12 +26,10 @@ require() { hash "$@" || exit 127; }
 
 require adb
 
-# Dump services and filter for lines containing BIND_TILE_PROVIDER and the preceding line which contains the component
+# Dump services and extract component names from lines containing BIND_TILE_PROVIDER
 # Format of dumpsys package services:
-# Service permissions:
-#     ...
 #     package.name/class.name: com.google.android.wearable.permission.BIND_TILE_PROVIDER
-#     ...
+# We extract the component name (before the colon) from matching lines.
 
 adb shell dumpsys package services |
   grep "com.google.android.wearable.permission.BIND_TILE_PROVIDER" |

--- a/bin/packagename-version
+++ b/bin/packagename-version
@@ -38,7 +38,7 @@ if [ -z "$1" ]; then
 fi
 
 # Check if package is installed
-if ! adb shell pm list packages | grep -q "$1"; then
+if ! adb shell pm list packages | grep -q "^package:${1}$"; then
   echo "$(basename "$0"): package '$1' not found" >&2
   exit 1
 fi

--- a/fish/completions/adb-tile-add.fish
+++ b/fish/completions/adb-tile-add.fish
@@ -1,0 +1,4 @@
+# completions for adb-tile-add
+complete -c adb-tile-add -f
+complete -c adb-tile-add -l no-show -d 'Do not show the tile after adding it'
+complete -c adb-tile-add -s h -l help -d 'Display help'


### PR DESCRIPTION
- Anchor package name grep patterns to prevent partial matches (e.g., searching for com.example.app no longer matches com.example)
- Fix misleading comment in adb-tiles about "preceding line"
- Add fish completions for adb-tile-add --no-show option