### PR TITLE
Update

### DIFF
--- a/bin/jetpack-resolve
+++ b/bin/jetpack-resolve
@@ -100,7 +100,6 @@ EXCEPTIONS=(
   "androidx.core.widget|androidx.core:core"
   "androidx.datastore.preferences.core|androidx.datastore:datastore-preferences-core"
   "androidx.fragment.app|androidx.fragment:fragment"
-  "androidx.glance.wear.cache|androidx.glance.wear:wear"
   "androidx.glance.wear.composable|androidx.glance.wear:wear"
   "androidx.glance.wear.parcel.legacy|androidx.glance.wear:wear"
   "androidx.glance.wear.parcel|androidx.glance.wear:wear"


### PR DESCRIPTION
The explicit `androidx.glance.wear.cache` entry is unnecessary since the base `androidx.glance.wear` rule already covers it via longest-prefix matching.