### PR TITLE
Document test runner for multiple directories

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,116 @@
+# Tests
+
+This directory contains tests for scripts in `bin/`. Tests use TAP (Test
+Anything Protocol) format.
+
+## Directory Structure
+
+```
+tests/
+├── README.md
+├── script-name/
+│   ├── test-basic       # TAP test file (executable)
+│   └── fixtures/        # Test data (optional)
+└── another-script/
+    └── test-basic
+```
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+prove tests/*/test-*
+```
+
+Or with verbose output:
+
+```bash
+prove -v tests/*/test-*
+```
+
+### Run a Single Test Suite
+
+```bash
+prove tests/jetpack-resolve/test-*
+```
+
+### Run a Single Test File
+
+```bash
+prove tests/jetpack-resolve/test-basic
+```
+
+Or execute directly:
+
+```bash
+./tests/jetpack-resolve/test-basic
+```
+
+## File Naming Convention
+
+Test files are named `test-*` (e.g., `test-basic`, `test-edge-cases`) rather
+than using the `.t` extension. While `.t` is prove's default extension, the
+`test-*` pattern:
+
+- Works identically with prove via `prove tests/*/test-*`
+- Can be executed directly without prove
+- Is more self-documenting for shell scripts
+
+## Tests with External Dependencies
+
+Some tests require external services or API keys. These tests use TAP's skip
+mechanism to gracefully handle missing dependencies.
+
+### screenshot-compare
+
+Requires `GEMINI_API_KEY` environment variable. Tests are automatically skipped
+if not set:
+
+```bash
+# Without key - tests are skipped
+prove tests/screenshot-compare/test-*
+# Output: skipped: GEMINI_API_KEY not set
+
+# With key - tests run (slow, incurs API costs)
+GEMINI_API_KEY=your-key prove tests/screenshot-compare/test-*
+```
+
+## Writing Tests
+
+Tests should:
+
+1. Output TAP format (plan line `1..N`, then `ok`/`not ok` lines)
+2. Be executable (`chmod +x`)
+3. Use `#!/usr/bin/env bash` shebang
+4. Skip gracefully when dependencies are missing using `1..0 # SKIP reason`
+
+Example test structure:
+
+```bash
+#!/usr/bin/env bash
+
+set -u
+
+# Skip if dependency missing
+if [[ -z "${SOME_API_KEY:-}" ]]; then
+  echo "1..0 # SKIP SOME_API_KEY not set"
+  exit 0
+fi
+
+echo "1..2"
+
+# Test 1
+if some_condition; then
+  echo "ok 1 - description"
+else
+  echo "not ok 1 - description"
+fi
+
+# Test 2
+if other_condition; then
+  echo "ok 2 - another test"
+else
+  echo "not ok 2 - another test"
+fi
+```

--- a/tests/jetpack-resolve/test-basic
+++ b/tests/jetpack-resolve/test-basic
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+# Tests for bin/jetpack-resolve
 
 set -u
 

--- a/tests/screenshot-compare/test-basic
+++ b/tests/screenshot-compare/test-basic
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
+#
+# Tests for bin/screenshot-compare
+#
+# Requirements:
+#   GEMINI_API_KEY - Must be set to a valid Gemini API key
+#
+# These tests call the Gemini API, so they are slow and incur API costs.
+# They are skipped automatically if GEMINI_API_KEY is not set.
 
 set -u
+
+# Skip all tests if GEMINI_API_KEY is not set
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "1..0 # SKIP GEMINI_API_KEY not set"
+  exit 0
+fi
 
 # Setup paths
 SCRIPT_DIR=$(dirname "$0")


### PR DESCRIPTION
- Add tests/README.md with instructions for running all tests or single tests using prove, plus explanation of test-* naming convention
- Add GEMINI_API_KEY skip logic to screenshot-compare tests using TAP's skip mechanism (1..0 # SKIP reason) so missing keys don't fail CI
- Add header comments to test files documenting their purpose and deps