### PR TITLE
Review shellcheck disable directives in adb-tiles

### DIFF
--- a/bin/adb-tiles
+++ b/bin/adb-tiles
@@ -146,10 +146,7 @@ awk -v t_only="$tiles_only" -v w_only="$widgets_only" '
   }
 ' <(
   # Feed the streams with prefixes
-  # shellcheck disable=SC2001
-  echo "$dump_tiles" | sed 's/^/TILE: /'
-  # shellcheck disable=SC2001
-  echo "$action_tiles" | sed 's/^/TILE: /'
-  # shellcheck disable=SC2001
-  echo "$action_widgets" | sed 's/^/WIDGET: /'
+  echo "$dump_tiles" | awk '{print "TILE: " $0}'
+  echo "$action_tiles" | awk '{print "TILE: " $0}'
+  echo "$action_widgets" | awk '{print "WIDGET: " $0}'
 ) | sort | uniq


### PR DESCRIPTION
The SC2001 warnings suggested using bash ${var//search/replace} instead of sed, but this doesn't work for prepending to each line of multi-line strings. Using awk avoids the warning while achieving the same result.