### PR TITLE
Review skill guidelines for ADB and Jetpack

### DIFF
--- a/etc/prompts/adb-skill.md
+++ b/etc/prompts/adb-skill.md
@@ -117,6 +117,13 @@ description: >
   dumpsys, or device debugging.
 ```
 
+**Compatibility requirements (recommended):**
+
+- Max 500 characters
+- Include if the skill has external dependencies or environment requirements
+- Mention required command-line tools, network access needs, or target platforms
+- Example: `compatibility: Requires adb. Some scripts require magick (ImageMagick), aapt, or scrcpy. Designed for filesystem-based agents with bash access.`
+
 For maximum compatibility across skill loaders, prefer a single-line
 `description:` value and avoid YAML block scalars like `description: |` (some
 implementations treat multi-line descriptions inconsistently). If you need line
@@ -273,6 +280,7 @@ Before finalizing, verify:
 - [ ] Skill directory exists at `etc/skills/adb/`
 - [ ] `SKILL.md` has valid frontmatter matching the spec
 - [ ] Description is in third person and includes trigger phrases
+- [ ] Compatibility field lists required tools and environment (adb, magick, etc.)
 - [ ] `SKILL.md` body is under 500 lines
 - [ ] `scripts/` contains symlinks to all `bin/adb-*`, `bin/wearableservice-*`,
       and `bin/packagename` scripts

--- a/etc/prompts/jetpack-skill.md
+++ b/etc/prompts/jetpack-skill.md
@@ -101,6 +101,13 @@ description: >
   AndroidX class implementations.
 ```
 
+**Compatibility requirements (recommended):**
+
+- Max 500 characters
+- Include if the skill has external dependencies or environment requirements
+- Mention required command-line tools, network access needs, or target platforms
+- Example: `compatibility: Requires curl, xmllint (libxml2-utils), jar (JDK). Needs network access to dl.google.com and androidx.dev.`
+
 For maximum compatibility across skill loaders, prefer a single-line
 `description:` value and avoid YAML block scalars like `description: |` (some
 implementations treat multi-line descriptions inconsistently). If you need line
@@ -303,6 +310,7 @@ Before finalizing, verify:
 - [ ] Skill directory exists at `etc/skills/jetpack/`
 - [ ] `SKILL.md` has valid frontmatter matching the spec
 - [ ] Description is in third person and includes trigger phrases
+- [ ] Compatibility field lists required tools (curl, xmllint, jar) and network access
 - [ ] `SKILL.md` body is under 500 lines
 - [ ] `scripts/` contains a symlink to `bin/jetpack`
 - [ ] Script is executable (`chmod +x`)

--- a/etc/skills/adb/SKILL.md
+++ b/etc/skills/adb/SKILL.md
@@ -6,6 +6,9 @@ description: >
   inspection, package operations, and device configuration. Use when working
   with adb, Android devices, Wear OS watches, tiles, wearable data layer,
   dumpsys, or device debugging.
+compatibility: >
+  Requires adb. Some scripts require magick (ImageMagick), aapt, or scrcpy.
+  Designed for filesystem-based agents with bash access.
 ---
 
 # Android ADB

--- a/etc/skills/jetpack/SKILL.md
+++ b/etc/skills/jetpack/SKILL.md
@@ -7,6 +7,9 @@ description: >
   androidx libraries, resolving Maven coordinates, downloading Jetpack source
   code, checking library versions (alpha/beta/stable/snapshot), or inspecting
   AndroidX class implementations.
+compatibility: >
+  Requires curl, xmllint (libxml2-utils), jar (JDK). Needs network access to
+  dl.google.com and androidx.dev.
 ---
 
 # Jetpack Library Utilities


### PR DESCRIPTION
Add the optional `compatibility` frontmatter field to both skills to document their external dependencies (adb, magick, curl, xmllint, etc.) and environment requirements.

Also update the skill creation prompts to include guidance on the compatibility field, making it more likely to be included when generating new skills from these templates.