### PR TITLE
Review commit for correctness

### DIFF
--- a/fish/functions/pbcopy.fish
+++ b/fish/functions/pbcopy.fish
@@ -1,3 +1,25 @@
+# pbcopy - Copy text to the system clipboard
+#
+# Usage:
+#   pbcopy              # Copy from command line (interactive)
+#   echo "text" | pbcopy # Copy from piped input
+#
+# Input Behavior:
+#   - Interactive (stdin is TTY): Copies the current command line selection,
+#     or the entire command line if nothing is selected. Useful as a keybinding.
+#   - Piped input: Copies the piped text. Trailing newlines are stripped for
+#     single-line input but preserved for multi-line input.
+#
+# Output Method:
+#   - Local macOS (not remote, native pbcopy available): Uses the native
+#     macOS pbcopy command for direct clipboard access.
+#   - Remote/SSH or no native pbcopy: Uses OSC 52 escape sequence to copy
+#     via the terminal emulator. Requires terminal support (most modern
+#     terminals like iTerm2, kitty, alacritty support this).
+#   - Falls back with an error if base64 is unavailable or TERM is "dumb".
+#
+# See also: pbclean (paste, clean, and re-copy), pbpaste
+
 function pbcopy
     set -l cmdline
     set -l is_tty_stdin 0


### PR DESCRIPTION
Document the different code paths:
- Input: TTY (interactive command line) vs piped input
- Output: native macOS pbcopy vs OSC 52 escape sequence
- Trailing newline handling for single vs multi-line input