### PR TITLE
Simplify nodejs-install output and add direnv tip

### DIFF
--- a/bin/nodejs-install
+++ b/bin/nodejs-install
@@ -172,13 +172,6 @@ curl -fL# "$DOWNLOAD_URL" | tar xz --strip-components=1 -C "$TARGET"
 # Clear the trap on success
 trap - EXIT
 
-cat <<EOF
-
-Node.js v$VERSION installed successfully.
-
-Installation directory:
-  $TARGET
-
-Add the following to your PATH:
-  $BINDIR
-EOF
+echo "$TARGET"
+echo ""
+echo "Tip: use direnv to switch Node.js versions. See ~/.direnvrc for usage." >&2


### PR DESCRIPTION
## Summary
Simplified the installation success message to output only the target directory path, and added a tip about using direnv for Node.js version switching.

## Changes
- Replaced verbose multi-line success message with minimal output (just the installation directory path)
- Added a helpful tip directing users to direnv for version management, printed to stderr
- Removed redundant information about PATH configuration from the standard output

## Details
The new output is more concise and machine-friendly, printing only the essential `$TARGET` directory to stdout. The direnv tip is sent to stderr to keep it separate from the primary output while still being visible to users. This change assumes users will reference `~/.direnvrc` for PATH configuration instructions.

https://claude.ai/code/session_01X6oV9ndjXvz9SSu7LZ1AtJ