### PR TITLE
Improve socrates build reliability and debuggability

### DIFF
--- a/tools/socrates/package.json
+++ b/tools/socrates/package.json
@@ -10,8 +10,9 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "ncc build src/index.ts -o dist",
+    "build": "npm run clean && ncc build src/index.ts -o dist -m esm --source-map",
     "check": "tsc --noEmit",
+    "clean": "rm -rf dist",
     "dev": "tsx src/index.ts",
     "prepare": "npm run build",
     "start": "node dist/index.js"

--- a/tools/socrates/tsconfig.json
+++ b/tools/socrates/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "outDir": "dist",
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- Add explicit ESM output format (-m esm) to avoid module format ambiguity
- Add clean script to remove stale build artifacts before rebuilding
- Add source maps (--source-map) for easier debugging
- Remove unused outDir from tsconfig.json (ncc handles output, tsc only
  used for type checking with --noEmit)

https://claude.ai/code/session_012VdmJvoD6v7XpVsqEdsChx