### PR TITLE
Refactor ask command to require PROMPT argument and handle stdin as context

### DIFF
--- a/bin/ask
+++ b/bin/ask
@@ -4,13 +4,16 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [PROMPT]
+Usage: $(basename "$0") PROMPT
 
 Asks a question to the Gemini 3 Flash model and prints a short, paragraph-style
 response (wrapped to 80 columns).
 
 Arguments:
-  PROMPT      The question to ask. If not provided, reads from stdin.
+  PROMPT      The question to ask.
+
+Input:
+  stdin       Optional context to include with the question.
 
 Options:
   -h, --help  Display this help message and exit
@@ -20,7 +23,8 @@ Environment:
 
 Examples:
   $(basename "$0") "What is the capital of Peru?"
-  echo "Explain quantum computing" | $(basename "$0")
+  cat article.md | $(basename "$0") "Summarize this article"
+  $(basename "$0") "Explain this code" < script.sh
 EOF
   exit 0
 }
@@ -40,25 +44,11 @@ if [[ -z "${GEMINI_API_KEY:-}" ]]; then
   exit 1
 fi
 
-# Determine input
-if [[ $# -gt 0 ]]; then
-  USER_PROMPT="$*"
-  # Check if there is also stdin input to use as context
-  if ! [ -t 0 ]; then
-     CONTEXT=$(cat)
-     USER_PROMPT="Context:\n${CONTEXT}\n\nQuestion:\n${USER_PROMPT}"
-  fi
-else
-  # No arguments, read from stdin
-  if [ -t 0 ]; then
-    usage
-  fi
-  USER_PROMPT=$(cat)
-fi
-
-if [[ -z "${USER_PROMPT:-}" ]]; then
+if [[ $# -lt 1 ]]; then
   usage
 fi
+
+USER_PROMPT="$*"
 
 MODEL="gemini-3-flash-preview"
 URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent"
@@ -67,27 +57,52 @@ URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateCo
 SYSTEM_INSTRUCTION="You are a helpful assistant. Provide a short, direct answer (less than 300 characters) in a single full paragraph. Do not use point form, lists, or markdown formatting (like bold or headers). Just plain text."
 
 # Construct the JSON payload
-# We use jq to safely escape strings and construct the JSON
-REQUEST_BODY=$(printf "%s" "$USER_PROMPT" | jq -Rs \
-  --arg system_instruction "$SYSTEM_INSTRUCTION" \
-  '{
-    system_instruction: {
-      parts: [{ text: $system_instruction }]
-    },
-    contents: [
-      {
-        role: "user",
-        parts: [{ text: . }]
+if ! [ -t 0 ]; then
+  # Stdin available — pipe context directly to jq, avoiding shell variable
+  REQUEST_BODY=$(jq -Rs \
+    --arg system_instruction "$SYSTEM_INSTRUCTION" \
+    --arg user_prompt "$USER_PROMPT" \
+    '{
+      system_instruction: {
+        parts: [{ text: $system_instruction }]
+      },
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: ("Context:\n" + . + "\n\nQuestion:\n" + $user_prompt) }]
+        }
+      ],
+      generationConfig: {
+        temperature: 1.0,
+        maxOutputTokens: 2048,
+        thinkingConfig: {
+          thinkingLevel: "low"
+        }
       }
-    ],
-    generationConfig: {
-      temperature: 1.0,
-      maxOutputTokens: 2048,
-      thinkingConfig: {
-        thinkingLevel: "low"
+    }')
+else
+  REQUEST_BODY=$(jq -n \
+    --arg system_instruction "$SYSTEM_INSTRUCTION" \
+    --arg user_prompt "$USER_PROMPT" \
+    '{
+      system_instruction: {
+        parts: [{ text: $system_instruction }]
+      },
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: $user_prompt }]
+        }
+      ],
+      generationConfig: {
+        temperature: 1.0,
+        maxOutputTokens: 2048,
+        thinkingConfig: {
+          thinkingLevel: "low"
+        }
       }
-    }
-  }')
+    }')
+fi
 
 # Execute the request
 RESPONSE=$(echo "${REQUEST_BODY}" | curl -s -X POST \

--- a/bin/uihierarchy-compare
+++ b/bin/uihierarchy-compare
@@ -50,7 +50,7 @@ if [[ -z "${GEMINI_API_KEY:-}" ]]; then
 fi
 
 MODEL="gemini-2.5-flash"
-URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}"
+URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent"
 
 if [[ ! -f "$FILE1_PATH" ]]; then
   echo "$(basename "$0"): $FILE1_PATH: No such file or directory" >&2
@@ -76,6 +76,7 @@ REQUEST_BODY=$(jq -n \
   }')
 
 RESPONSE=$(echo "${REQUEST_BODY}" | curl -s -X POST \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
   -H "Content-Type: application/json" \
   -d @- \
   "${URL}")

--- a/bin/uihierarchy-describe
+++ b/bin/uihierarchy-describe
@@ -48,7 +48,7 @@ if [[ -z "${GEMINI_API_KEY:-}" ]]; then
 fi
 
 MODEL="gemini-2.5-flash"
-URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}"
+URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent"
 
 if [[ ! -f "$FILE_PATH" ]]; then
   echo "$(basename "$0"): $FILE_PATH: No such file or directory" >&2
@@ -68,6 +68,7 @@ REQUEST_BODY=$(jq -n \
   }')
 
 RESPONSE=$(echo "${REQUEST_BODY}" | curl -s -X POST \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
   -H "Content-Type: application/json" \
   -d @- \
   "${URL}")

--- a/fish/completions/ask.fish
+++ b/fish/completions/ask.fish
@@ -1,0 +1,2 @@
+complete -c ask -f
+complete -c ask -s h -l help -d "Display help"


### PR DESCRIPTION
## Summary
This PR refactors the `ask` command to make the PROMPT argument required and treat stdin as optional context to include with the question, rather than as an alternative input source. It also standardizes API key handling across Gemini scripts and adds fish shell completions.

## Key Changes

- **`bin/ask`**: 
  - Changed PROMPT from optional `[PROMPT]` to required `PROMPT` argument
  - Refactored input handling: PROMPT is now always required; stdin (if available) is treated as context to prepend to the question
  - Updated usage documentation and examples to reflect the new behavior
  - Split JSON payload construction into two paths: one for stdin context (using `jq -Rs` to pipe stdin) and one without (using `jq -n`)
  - This avoids storing large context in shell variables, improving memory efficiency

- **`bin/uihierarchy-compare` and `bin/uihierarchy-describe`**:
  - Removed API key from URL query parameter (`?key=${GEMINI_API_KEY}`)
  - Added explicit `x-goog-api-key` header to curl request for consistent API authentication
  - Aligns with security best practices by using headers instead of query parameters

- **`fish/completions/ask.fish`** (new file):
  - Added fish shell completions for the `ask` command
  - Provides help flag completion

## Implementation Details

The refactored `ask` command now follows a clearer contract:
- User provides the question/prompt as command-line arguments (required)
- Optional stdin is automatically prepended as context with "Context:" and "Question:" labels
- This enables intuitive usage patterns like: `cat file.md | ask "Summarize this"` or `ask "Explain this" < script.sh`

https://claude.ai/code/session_01U45QmrsYDahfx5nMJr1Hf8