### PR TITLE
Update CLI tools help handling and exit codes

### DIFF
--- a/bin/context
+++ b/bin/context
@@ -544,7 +544,7 @@ EOF
   cat <<EOF
 
 Options:
-  -h, --help    Display this help message and exit
+  --help        Display this help message and exit
   -f, --force   Force cache rebuild (ignore 24h cache)
   --list        List available topics (names only)
 
@@ -558,7 +558,7 @@ Examples:
   $SCRIPT_NAME gemini-api | pbcopy
     Copy context to clipboard (macOS)
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 list_topics() {
@@ -615,8 +615,8 @@ TOPIC=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h | --help)
-      usage
+    --help)
+      usage 0
       ;;
     --list)
       list_topics
@@ -641,7 +641,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$TOPIC" ]]; then
-  usage
+  usage 1 >&2
+fi
+
+if [[ "$TOPIC" == "help" ]]; then
+  usage 0
 fi
 
 # Validate topic

--- a/bin/emumanager
+++ b/bin/emumanager
@@ -276,7 +276,7 @@ Commands:
   update              Update all installed SDK packages to latest versions.
 
 Options:
-  -h, --help          Display this help message and exit
+  --help              Display this help message and exit
 
 Examples:
   # Create a mobile/phone AVD with the latest available image
@@ -350,12 +350,12 @@ require() {
   done
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-  usage
+if [[ "${1:-}" == "help" || "${1:-}" == "--help" ]]; then
+  usage 0
 fi
 
 if [[ -z "${1:-}" ]]; then
-  usage
+  usage 1 >&2
 fi
 
 install_cli_tools() {
@@ -722,6 +722,9 @@ start_avd() {
       --wipe-data)
         wipe_data=1
         shift
+        ;;
+      --help)
+        usage 0
         ;;
       -*)
         echo "$(basename "$0") start: unknown flag '$1'" >&2
@@ -1627,15 +1630,27 @@ bootstrap() {
 
 case "$1" in
   bootstrap)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     bootstrap "${2:-}"
     ;;
   doctor)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     run_doctor
     ;;
   list)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     list_avds "${2:-}"
     ;;
   info)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     if [[ -z "${2:-}" ]]; then
       echo "$(basename "$0") info: AVD name required" >&2
       exit 1
@@ -1643,12 +1658,21 @@ case "$1" in
     info_avd "$2"
     ;;
   images)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     list_images
     ;;
   outdated)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     check_outdated
     ;;
   update)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     update_packages
     ;;
   create)
@@ -1693,6 +1717,9 @@ case "$1" in
           device_type="auto"
           shift
           ;;
+        --help)
+          usage 0
+          ;;
         --*)
           echo "$(basename "$0") create: unknown option '$1'" >&2
           echo "Valid options: --mobile, --phone, --wear, --watch, --tv, --auto" >&2
@@ -1724,6 +1751,9 @@ case "$1" in
     start_avd "${@:2}"
     ;;
   stop)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     if [[ -z "${2:-}" ]]; then
       echo "$(basename "$0") stop: AVD name required" >&2
       exit 1
@@ -1731,6 +1761,9 @@ case "$1" in
     stop_avd "$2"
     ;;
   delete)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     if [[ -z "${2:-}" ]]; then
       echo "$(basename "$0") delete: AVD name required" >&2
       exit 1
@@ -1738,6 +1771,9 @@ case "$1" in
     delete_avd "$2"
     ;;
   download)
+    if [[ "${2:-}" == "--help" ]]; then
+      usage 0
+    fi
     if [[ -z "${2:-}" ]]; then
       echo "$(basename "$0") download: image name required" >&2
       exit 1

--- a/bin/jetpack
+++ b/bin/jetpack
@@ -85,7 +85,7 @@ Commands:
   resolve-exceptions  Find missing exceptions for the resolve command
 
 Options:
-  -h, --help          Display this help message
+  --help              Display this help message
 
 Run '$SCRIPT_NAME <command> --help' for more information on a command.
 
@@ -95,7 +95,7 @@ Examples:
   $SCRIPT_NAME source androidx.wear.tiles:tiles ALPHA
   $SCRIPT_NAME inspect androidx.lifecycle.ViewModel
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 # =============================================================================
@@ -138,11 +138,11 @@ Examples:
   $SCRIPT_NAME version com.google.android.horologist:horologist-datalayer \\
     STABLE https://repo1.maven.org/maven2
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_version() {
-  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  if [[ "${1:-}" == "--help" ]]; then
     usage_version
   fi
 
@@ -331,11 +331,11 @@ The command converts AndroidX package names to Maven library coordinates using
 heuristic rules and a lookup table for exceptions. Output format is
 GROUP_ID:ARTIFACT_ID (e.g., androidx.core:core-splashscreen).
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_resolve() {
-  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  if [[ "${1:-}" == "--help" ]]; then
     usage_resolve
   fi
 
@@ -557,7 +557,7 @@ Examples:
 The command downloads the source JARs, extracts them, and prints the path.
 For Kotlin Multiplatform libraries, platform-specific sources are also downloaded.
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_source() {
@@ -566,7 +566,7 @@ cmd_source() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -h | --help)
+      --help)
         usage_source
         ;;
       --output)
@@ -828,7 +828,7 @@ Examples:
 For Kotlin Multiplatform libraries, both common and platform-specific sources
 are automatically downloaded.
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_inspect() {
@@ -837,7 +837,7 @@ cmd_inspect() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -h | --help)
+      --help)
         usage_inspect
         ;;
       --output)
@@ -910,11 +910,11 @@ exceptions array in the resolve command.
 NOTE: Only supports SNAPSHOT versions from androidx.dev since we typically
 need to find exceptions for new APIs that are not yet stable.
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_resolve_exceptions() {
-  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  if [[ "${1:-}" == "--help" ]]; then
     usage_resolve_exceptions
   fi
 
@@ -1015,12 +1015,23 @@ cmd_resolve_exceptions() {
 # =============================================================================
 
 if [[ $# -lt 1 ]]; then
-  usage
+  usage 1 >&2
 fi
 
 case "$1" in
-  -h | --help)
-    usage
+  help | --help)
+    if [[ -n "${2:-}" ]]; then
+      case "$2" in
+        version) usage_version ;;
+        resolve) usage_resolve ;;
+        source) usage_source ;;
+        inspect) usage_inspect ;;
+        resolve-exceptions) usage_resolve_exceptions ;;
+        *) echo "$SCRIPT_NAME: unknown command '$2'" >&2; usage 1 >&2 ;;
+      esac
+    else
+      usage
+    fi
     ;;
   version)
     shift

--- a/bin/packagename
+++ b/bin/packagename
@@ -368,7 +368,7 @@ EOF
   cat <<EOF
 
 Options:
-  -h, --help    Display this help message and exit
+  --help        Display this help message and exit
   --list        List available commands (names only)
 
 Environment:
@@ -382,7 +382,7 @@ Examples:
   $SCRIPT_NAME view com.android.chrome https://www.google.com
   $SCRIPT_NAME profile-status com.example.app
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 list_commands() {
@@ -397,12 +397,12 @@ list_commands() {
 # =============================================================================
 
 if [[ $# -lt 1 ]]; then
-  usage
+  usage 1 >&2
 fi
 
 case "$1" in
-  -h|--help)
-    usage
+  help|--help)
+    usage 0
     ;;
   --list)
     list_commands
@@ -426,6 +426,10 @@ if ! declare -f "$CMD_FUNC" > /dev/null 2>&1; then
   echo "$SCRIPT_NAME: unknown command: $COMMAND" >&2
   echo "Run '$SCRIPT_NAME --list' to see available commands" >&2
   exit 1
+fi
+
+if [[ "${1:-}" == "--help" ]]; then
+  usage 0
 fi
 
 "$CMD_FUNC" "$@"

--- a/bin/photo-smart-crop
+++ b/bin/photo-smart-crop
@@ -13,7 +13,7 @@ Arguments:
 
 Options:
   --ratio W:H  Aspect ratio for crop (default: 5:3)
-  -h, --help   Display this help message and exit
+  --help       Display this help message and exit
 
 Processing:
   Uses Gemini API to detect people and calculate a crop box with the specified
@@ -39,10 +39,15 @@ EOF
 
 # Parse arguments
 ratio="5:3"
+
+if [[ "${1:-}" == "help" ]]; then
+  usage 0
+fi
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h | --help)
-      usage
+    --help)
+      usage 0
       ;;
     --ratio)
       if [[ $# -lt 2 ]]; then


### PR DESCRIPTION
This PR standardizes the help handling and exit codes for 5 CLI tools in `bin/` to match the project's guidelines. It removes the ambiguous `-h` flag, adds a `help` subcommand, and ensures correct exit codes for success (explicit help) vs failure (implicit usage error).

---
*PR created automatically by Jules for task [2282103420105534775](https://jules.google.com/task/2282103420105534775) started by @ithinkihaveacat*