### PR TITLE
Improve shell script robustness and error handling

### DIFF
--- a/bin/context
+++ b/bin/context
@@ -11,7 +11,7 @@ if ((BASH_VERSINFO[0] < 4)); then
   exit 1
 fi
 
-set -eo pipefail
+set -euo pipefail
 
 SCRIPT_NAME=$(basename "$0")
 

--- a/bin/jetpack
+++ b/bin/jetpack
@@ -535,7 +535,7 @@ Version Specifiers:
                Find build IDs at: https://androidx.dev/snapshots/builds
 
 Options:
-  -h, --help    Display this help message
+  --help        Display this help message
   --output DIR  Specify output directory (default: create temporary directory)
 
 Examples:
@@ -808,7 +808,7 @@ Version Specifiers:
                Find build IDs at: https://androidx.dev/snapshots/builds
 
 Options:
-  -h, --help    Display this help message
+  --help        Display this help message
   --output DIR  Specify output directory (default: create temporary directory)
 
 Examples:

--- a/bin/packagename
+++ b/bin/packagename
@@ -4,7 +4,7 @@
 #
 # A collection of adb-based utilities for working with Android packages.
 
-set -e
+set -euo pipefail
 
 SCRIPT_NAME=$(basename "$0")
 
@@ -24,7 +24,7 @@ require() {
 # =============================================================================
 
 cmd_clear_cache() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME clear-cache PACKAGE" >&2
     echo "" >&2
@@ -35,7 +35,7 @@ cmd_clear_cache() {
 }
 
 cmd_dumpsys() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME dumpsys PACKAGE" >&2
     echo "" >&2
@@ -46,7 +46,7 @@ cmd_dumpsys() {
 }
 
 cmd_force_stop() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME force-stop PACKAGE" >&2
     echo "" >&2
@@ -57,7 +57,7 @@ cmd_force_stop() {
 }
 
 cmd_jobscheduler() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME jobscheduler PACKAGE" >&2
     echo "" >&2
@@ -68,7 +68,7 @@ cmd_jobscheduler() {
 }
 
 cmd_launch() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME launch PACKAGE" >&2
     echo "" >&2
@@ -80,7 +80,7 @@ cmd_launch() {
 }
 
 cmd_logcat() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME logcat PACKAGE" >&2
     echo "" >&2
@@ -97,7 +97,7 @@ cmd_logcat() {
 }
 
 cmd_permissions() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME permissions PACKAGE" >&2
     echo "" >&2
@@ -108,7 +108,7 @@ cmd_permissions() {
 }
 
 cmd_pid() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME pid PACKAGE" >&2
     echo "" >&2
@@ -119,7 +119,7 @@ cmd_pid() {
 }
 
 cmd_playstore() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME playstore PACKAGE" >&2
     echo "" >&2
@@ -130,7 +130,7 @@ cmd_playstore() {
 }
 
 cmd_profile_generate() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME profile-generate PACKAGE" >&2
     echo "" >&2
@@ -141,7 +141,7 @@ cmd_profile_generate() {
 }
 
 cmd_profile_status() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME profile-status PACKAGE" >&2
     echo "" >&2
@@ -152,7 +152,7 @@ cmd_profile_status() {
 }
 
 cmd_pull() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME pull PACKAGE" >&2
     echo "" >&2
@@ -169,7 +169,7 @@ cmd_pull() {
 }
 
 cmd_reset_permissions() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME reset-permissions PACKAGE" >&2
     echo "" >&2
@@ -180,7 +180,7 @@ cmd_reset_permissions() {
 }
 
 cmd_services() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME services PACKAGE" >&2
     echo "" >&2
@@ -191,7 +191,7 @@ cmd_services() {
 }
 
 cmd_services_dumpsys() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME services-dumpsys PACKAGE" >&2
     echo "" >&2
@@ -213,7 +213,7 @@ cmd_services_dumpsys() {
 }
 
 cmd_settings() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME settings PACKAGE" >&2
     echo "" >&2
@@ -224,7 +224,7 @@ cmd_settings() {
 }
 
 cmd_tiles() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME tiles PACKAGE" >&2
     echo "" >&2
@@ -235,7 +235,7 @@ cmd_tiles() {
 }
 
 cmd_uninstall() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME uninstall PACKAGE" >&2
     echo "" >&2
@@ -246,7 +246,7 @@ cmd_uninstall() {
 }
 
 cmd_version() {
-  local package="$1"
+  local package="${1:-}"
   if [ -z "$package" ]; then
     echo "Usage: $SCRIPT_NAME version PACKAGE" >&2
     echo "" >&2
@@ -266,8 +266,8 @@ cmd_version() {
 }
 
 cmd_view() {
-  local package="$1"
-  local url="$2"
+  local package="${1:-}"
+  local url="${2:-}"
   if [ -z "$package" ] || [ -z "$url" ]; then
     echo "Usage: $SCRIPT_NAME view PACKAGE URL" >&2
     echo "" >&2

--- a/bin/photo-smart-crop
+++ b/bin/photo-smart-crop
@@ -93,7 +93,14 @@ if [[ ! -f "$INPUT" ]]; then
   exit 1
 fi
 
-require() { hash "$@" || exit 127; }
+require() {
+  for cmd in "$@"; do
+    if ! hash "$cmd" 2>/dev/null; then
+      echo "$(basename "$0"): '$cmd' command not found" >&2
+      exit 127
+    fi
+  done
+}
 
 require curl
 require jq


### PR DESCRIPTION
This PR enhances the reliability and error handling of several shell scripts by implementing stricter bash options and improving variable handling.

## Summary
Updated multiple shell scripts to use stricter error handling options and safer variable assignment patterns to prevent unintended behavior from unset variables and command failures.

## Key Changes

- **Enhanced bash strict mode**: Updated `set -e` to `set -euo pipefail` in `packagename` and `context` scripts to:
  - Catch errors in pipelines (`pipefail`)
  - Fail on undefined variable references (`-u`)
  - Maintain existing exit-on-error behavior (`-e`)

- **Safer variable assignments**: Changed all positional parameter assignments from `local var="$1"` to `local var="${1:-}"` across all command functions in `packagename` script to prevent script failure when variables are unset (due to the new `-u` flag)

- **Improved `require()` function**: Refactored the `require()` function in `photo-smart-crop` from a one-liner to a proper loop that:
  - Checks each required command individually
  - Provides clear error messages when commands are not found
  - Suppresses hash command output with `2>/dev/null`

- **Documentation cleanup**: Removed `-h` short option from help text in `jetpack` script (changed `-h, --help` to `--help`) to align with actual implementation

## Implementation Details
The use of `${var:-}` pattern provides a default empty string when a variable is unset, allowing the subsequent explicit checks (`if [ -z "$package" ]`) to handle missing arguments gracefully while still benefiting from the `-u` strict mode for catching other unintended variable references.
