### PR TITLE
Add catalog metadata index for registry skill discovery

### DIFF
--- a/fish/completions/git-skill.fish
+++ b/fish/completions/git-skill.fish
@@ -63,8 +63,10 @@ complete -c git -f -n '__fish_git_skill_using_command remove' -a '(__fish_git_sk
 complete -c git -f -n '__fish_git_skill_using_command rm' -a '(__fish_git_skill_managed_skills)' -d 'Managed skill'
 
 # update
+complete -c git -f -n '__fish_git_skill_using_command update' -a '(__fish_git_skill_catalog)' -d 'Registry skill'
 complete -c git -f -n '__fish_git_skill_using_command update' -a '(__fish_git_skill_managed_skills)' -d 'Managed skill'
 complete -c git -f -n '__fish_git_skill_using_command update' -l all -d 'Update every managed skill'
+complete -c git -f -n '__fish_git_skill_using_command update' -l catalog -d 'Refresh the whole metadata index'
 
 # Complete flags
 complete -c git -f -n '__fish_git_skill_using_command skill' -l help -d 'Display help message and exit'

--- a/skills/skill-select/scripts/git-skill
+++ b/skills/skill-select/scripts/git-skill
@@ -8,6 +8,7 @@
 
 import os
 import sys
+import time
 import shutil
 import tempfile
 import tarfile
@@ -16,9 +17,32 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 
+# Catalog index stub (SKILL.md) freshness: how long a discovered metadata stub
+# is trusted before re-fetching during 'suggest'/'apply'.
+CATALOG_TTL = 7 * 24 * 3600  # 7 days
+# Full-repo freshness on provision: how old a cached repo may be before 'apply'
+# force-refreshes it while adding a registry skill to a workspace.
+PROVISION_TTL = 8 * 3600  # 8 hours
+
+
 def die(msg):
     print(f"git skill: {msg}", file=sys.stderr)
     sys.exit(1)
+
+
+def get_cache_base():
+    return (
+        Path(
+            os.environ.get("SKILL_CACHE_DIR")
+            or os.environ.get("XDG_CACHE_HOME")
+            or "~/.cache"
+        ).expanduser()
+        / "skills"
+    )
+
+
+def get_catalog_dir():
+    return get_cache_base() / "catalog"
 
 
 def cmderr(cmd, msg):
@@ -165,23 +189,45 @@ def rewrite_block(exclude_file, lines):
         temp_path.unlink(missing_ok=True)
 
 
-def fetch_github(name, repo, ref, subpath):
+def _atomic_replace_dir(src, dest):
+    """Install src as dest atomically, swapping within dest's parent directory.
+
+    Uses sibling temp names (not '.with_suffix', which mangles refs containing
+    dots) and os.replace (which cannot overwrite a non-empty directory) by
+    moving any existing dest aside first. Both renames stay within one
+    directory, so they are atomic and safe under concurrent fetches.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f"{dest.name}.tmp-{os.getpid()}"
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    try:
+        shutil.copytree(src, tmp, symlinks=True)
+        if dest.exists():
+            trash = dest.parent / f"{dest.name}.old-{os.getpid()}"
+            if trash.exists():
+                shutil.rmtree(trash)
+            os.replace(dest, trash)
+            os.replace(tmp, dest)
+            shutil.rmtree(trash, ignore_errors=True)
+        else:
+            os.replace(tmp, dest)
+    finally:
+        if tmp.exists():
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+def fetch_github(name, repo, ref, subpath, force=False):
     import requests
 
     owner, reponame = repo.split("/", 1)
-    cache_base = (
-        Path(
-            os.environ.get("SKILL_CACHE_DIR")
-            or os.environ.get("XDG_CACHE_HOME")
-            or "~/.cache"
-        ).expanduser()
-        / "skills"
-    )
+    cache_base = get_cache_base()
     cachedir = cache_base / owner / reponame / ref
     if subpath:
         cachedir = cachedir / subpath
 
-    if cachedir.is_dir() and any(cachedir.iterdir()):
+    have_cache = cachedir.is_dir() and any(cachedir.iterdir())
+    if not force and have_cache:
         print(
             f"using cached {repo}@{ref} (run 'git skill update {name}' to refresh)",
             file=sys.stderr,
@@ -193,7 +239,12 @@ def fetch_github(name, repo, ref, subpath):
     try:
         r = requests.get(archive_url, stream=True)
         r.raise_for_status()
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
+        # Offline / network failure: fall back to an existing cache so already
+        # provisioned skills keep working; only fail if nothing is cached.
+        if have_cache:
+            print(f"git skill: {archive_url}: {e}; using stale cache", file=sys.stderr)
+            return cachedir
         die(f"failed to fetch {archive_url}: {e}")
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -222,12 +273,125 @@ def fetch_github(name, repo, ref, subpath):
             if not src_dir.is_dir():
                 die(f"path not found in {owner}/{reponame}@{ref}: {subpath}")
 
-        if cachedir.exists():
-            shutil.rmtree(cachedir)
-        cachedir.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(src_dir, cachedir, symlinks=True)
+        _atomic_replace_dir(src_dir, cachedir)
 
     return cachedir
+
+
+def fetch_skill_md(name, repo, ref, subpath, force=False):
+    """Fetch only SKILL.md for a registry entry into a lightweight catalog stub.
+
+    This is the metadata-only discovery path: it lets skill-select see and rank
+    a registry skill without downloading the whole repository. The full repo is
+    materialized lazily on 'add'/provision via fetch_github. Returns the stub
+    directory, or None if SKILL.md could not be obtained and no stub exists.
+    """
+    import requests
+
+    owner, reponame = repo.split("/", 1)
+    catalog_dir = get_catalog_dir()
+    stub = catalog_dir / name
+    meta_dir = catalog_dir / ".meta"
+    meta = meta_dir / name
+    stub_md = stub / "SKILL.md"
+
+    if not force and meta.is_file() and stub_md.is_file():
+        if (time.time() - meta.stat().st_mtime) < CATALOG_TTL:
+            return stub
+
+    sub = f"{subpath}/" if subpath else ""
+    url = f"https://raw.githubusercontent.com/{owner}/{reponame}/{ref}/{sub}SKILL.md"
+    try:
+        r = requests.get(url)
+        r.raise_for_status()
+        content = r.content
+    except requests.exceptions.RequestException as e:
+        # Degrade gracefully: keep any existing stub when offline, and skip
+        # (never die) so one bad entry does not break discovery of the rest.
+        if stub_md.is_file():
+            return stub
+        print(f"git skill: {url}: {e}; skipping {name}", file=sys.stderr)
+        return None
+
+    stub.mkdir(parents=True, exist_ok=True)
+    tmp = stub / f".SKILL.md.tmp-{os.getpid()}"
+    try:
+        tmp.write_bytes(content)
+        os.replace(tmp, stub_md)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    meta.touch()
+    return stub
+
+
+def ensure_catalog_index(registry, force=False):
+    """Populate/refresh the catalog/ index of metadata stubs for registry skills.
+
+    Fetches only SKILL.md per entry (fast, offline-friendly cold start), then
+    garbage-collects stubs whose names are no longer registered. Returns early
+    when the registry is empty so a missing/unreadable config never triggers a
+    destructive GC of an otherwise-populated catalog.
+    """
+    if not registry:
+        return
+
+    catalog_dir = get_catalog_dir()
+    meta_dir = catalog_dir / ".meta"
+    total = len(registry)
+    for i, name in enumerate(sorted(registry), 1):
+        entry = registry[name]
+        meta = meta_dir / name
+        stub_md = catalog_dir / name / "SKILL.md"
+        fresh = (
+            not force
+            and meta.is_file()
+            and stub_md.is_file()
+            and (time.time() - meta.stat().st_mtime) < CATALOG_TTL
+        )
+        if fresh:
+            continue
+        print(f"git skill: [{i}/{total}] indexing {name}...", file=sys.stderr)
+        fetch_skill_md(
+            name, entry["repo"], entry["ref"], entry["subpath"], force=force
+        )
+
+    # Garbage-collect orphaned stubs (registry is non-empty here, so this cannot
+    # wipe a catalog just because a config file went missing).
+    if catalog_dir.is_dir():
+        for item in catalog_dir.iterdir():
+            if item.name.startswith("."):
+                continue
+            if item.name in registry:
+                continue
+            if item.is_symlink() or not item.is_dir():
+                item.unlink()
+            else:
+                shutil.rmtree(item, ignore_errors=True)
+            stale_meta = meta_dir / item.name
+            if stale_meta.exists():
+                stale_meta.unlink()
+
+
+def provision_registry_skill(name, entry):
+    """Ensure a registry skill's full repo is cached and fresh before adding.
+
+    Force-refreshes when the cache is missing or older than PROVISION_TTL so a
+    just-added skill reflects a recent upstream, then leaves fetch_github's own
+    reuse to make the subsequent 'add' a cache hit.
+    """
+    cache_base = get_cache_base()
+    owner, reponame = entry["repo"].split("/", 1)
+    cachedir = cache_base / owner / reponame / entry["ref"]
+    if entry["subpath"]:
+        cachedir = cachedir / entry["subpath"]
+    stale = (
+        not cachedir.is_dir()
+        or not any(cachedir.iterdir())
+        or (time.time() - cachedir.stat().st_mtime) > PROVISION_TTL
+    )
+    fetch_github(name, entry["repo"], entry["ref"], entry["subpath"], force=stale)
 
 
 def resolve_spec(spec, registry, source_dirs):
@@ -473,6 +637,13 @@ def cmd_clean():
 
 
 def cmd_update(names, registry):
+    # 'update --catalog' refreshes the global metadata index (and prunes orphans)
+    # without needing a workspace; handle it before requiring a git repo.
+    if len(names) == 1 and names[0] == "--catalog":
+        ensure_catalog_index(registry, force=True)
+        print("update: refreshed catalog index", file=sys.stderr)
+        return
+
     root, exclude_file = get_git_repo()
 
     dest_dirs_str = os.environ.get("SKILL_DEST_DIRS", ".claude/skills:.agents/skills")
@@ -489,18 +660,33 @@ def cmd_update(names, registry):
                     skills.add(rel[len(d) + 1 :])
         names = sorted(list(skills))
     elif not names:
-        cmderr("update", "skill name or --all required")
+        cmderr("update", "skill name, --all, or --catalog required")
 
-    cache_base = (
-        Path(
-            os.environ.get("SKILL_CACHE_DIR")
-            or os.environ.get("XDG_CACHE_HOME")
-            or "~/.cache"
-        ).expanduser()
-        / "skills"
-    )
+    cache_base = get_cache_base()
 
     for name in names:
+        # Registry entries can be refreshed whether or not they are currently
+        # added: always refresh the lightweight metadata stub, and re-fetch the
+        # full repo in place only when one is already cached (so 'update' never
+        # downloads a whole repo for a skill that was only ever discovered).
+        if name in registry:
+            entry = registry[name]
+            fetch_skill_md(
+                name, entry["repo"], entry["ref"], entry["subpath"], force=True
+            )
+            owner, reponame = entry["repo"].split("/", 1)
+            cachedir = cache_base / owner / reponame / entry["ref"]
+            if entry["subpath"]:
+                cachedir = cachedir / entry["subpath"]
+            if cachedir.is_dir() and any(cachedir.iterdir()):
+                fetch_github(
+                    name, entry["repo"], entry["ref"], entry["subpath"], force=True
+                )
+            print(
+                f"updated {name} from {entry['repo']}@{entry['ref']}", file=sys.stderr
+            )
+            continue
+
         relpath = dest_dirs[0] / name
         if not relpath.is_symlink():
             print(
@@ -520,27 +706,10 @@ def cmd_update(names, registry):
             print(f"update: {name} is local; nothing to update", file=sys.stderr)
             continue
 
-        if name not in registry:
-            print(
-                f"update: {name} has no registry entry; cannot refresh",
-                file=sys.stderr,
-            )
-            continue
-
-        entry = registry[name]
-        repo = entry["repo"]
-        ref = entry["ref"]
-        subpath = entry["subpath"]
-
-        owner, reponame = repo.split("/", 1)
-        cachedir = cache_base / owner / reponame / ref
-        if subpath:
-            cachedir = cachedir / subpath
-        if cachedir.exists():
-            shutil.rmtree(cachedir)
-
-        fetch_github(name, repo, ref, subpath)
-        print(f"updated {name} from {repo}@{ref}", file=sys.stderr)
+        print(
+            f"update: {name} has no registry entry; cannot refresh",
+            file=sys.stderr,
+        )
 
 
 def cmd_resolve(name, registry, source_dirs):
@@ -642,8 +811,10 @@ def cmd_catalog(registry, source_dirs, as_json=False):
                 print(f"  {name}")
 
 
-def cmd_apply(args):
+def cmd_apply(args, registry):
     root, _ = get_git_repo()
+    # Refresh the metadata index so skill-select can see every registry skill.
+    ensure_catalog_index(registry)
     print("git skill: determining skills via skill-select...", file=sys.stderr)
     cmd = ["skill-select", str(root), "--json"] + args
     res = subprocess.run(cmd, capture_output=True, text=True)
@@ -666,11 +837,19 @@ def cmd_apply(args):
         if not name:
             continue
         names.append(name)
-        # Prefer the directory skill-select resolved so we symlink exactly what
-        # it discovered, rather than re-resolving the bare name against the local
-        # namespace (which can be ambiguous when a name exists in several source
-        # dirs). Fall back to the name if no path was provided.
-        specs.append(item.get("path") or name)
+        if name in registry:
+            # Registry skill: materialize the full repo just-in-time and pass the
+            # registry NAME, not the resolved stub/cache path (whose basename can
+            # differ from the registry name when a subpath is set), so 'add'
+            # records it under a name that 'update' can later resolve.
+            provision_registry_skill(name, registry[name])
+            specs.append(name)
+        else:
+            # Local skill: prefer the directory skill-select resolved so we
+            # symlink exactly what it discovered, rather than re-resolving the
+            # bare name against the local namespace (which can be ambiguous when
+            # a name exists in several source dirs).
+            specs.append(item.get("path") or name)
 
     if not specs:
         print("git skill: no skills recommended by skill-select", file=sys.stderr)
@@ -680,8 +859,10 @@ def cmd_apply(args):
     subprocess.run(["git", "skill", "add"] + specs, check=True)
 
 
-def cmd_suggest(args):
+def cmd_suggest(args, registry):
     root, exclude_file = get_git_repo()
+    # Refresh the metadata index so registry skills appear in recommendations.
+    ensure_catalog_index(registry)
     managed = read_managed(exclude_file)
 
     dest_dirs_str = os.environ.get("SKILL_DEST_DIRS", ".claude/skills:.agents/skills")
@@ -741,7 +922,8 @@ def cmd_doctor(registry, source_dirs):
 
     if not all_skills:
         print("git skill: nothing managed")
-        sys.exit(0)
+        rc = catalog_doctor(registry, rc)
+        sys.exit(rc)
 
     print("Skills:")
     for name in all_skills:
@@ -787,7 +969,42 @@ def cmd_doctor(registry, source_dirs):
         if not drift:
             print(f"  ok           {name}")
 
+    rc = catalog_doctor(registry, rc)
     sys.exit(rc)
+
+
+def catalog_doctor(registry, rc):
+    """Read-only catalog index health check. Reports problems, never mutates."""
+    if not registry:
+        return rc
+
+    catalog_dir = get_catalog_dir()
+    meta_dir = catalog_dir / ".meta"
+    issues = []
+    for name in sorted(registry):
+        stub_md = catalog_dir / name / "SKILL.md"
+        meta = meta_dir / name
+        if not stub_md.is_file():
+            issues.append(f"  missing      {name} (not indexed)")
+        elif meta.is_file() and (time.time() - meta.stat().st_mtime) > CATALOG_TTL:
+            issues.append(
+                f"  stale        {name} (index older than {CATALOG_TTL // 86400}d)"
+            )
+    if catalog_dir.is_dir():
+        for item in catalog_dir.iterdir():
+            if item.name.startswith("."):
+                continue
+            if item.name not in registry:
+                issues.append(f"  orphan       {item.name} (no registry entry)")
+
+    if issues:
+        print()
+        print("Catalog:")
+        for line in sorted(issues):
+            print(line)
+        print("                git skill update --catalog")
+        rc = 1
+    return rc
 
 
 def usage():
@@ -806,7 +1023,8 @@ Commands:
   add -           Read skill names from stdin
   remove NAME...  Remove a skill this tool added (alias: rm)
   list            List skills this tool is managing in the current repo
-  update SPEC...  Re-fetch registered catalog entries (--all for every managed skill)
+  update SPEC...  Re-fetch a registered catalog entry; --all for every managed
+                  skill, --catalog to refresh the whole metadata index
   clean           Remove all skills this tool added and its info/exclude block
   doctor          Diagnose drift between desired and on-disk skills (read-only)
   catalog         List registered skills and their sources
@@ -824,6 +1042,15 @@ Skill specs:
   Catalog entries are downloaded once and reused; 'update' re-fetches them. Local skills
   have no upstream, so update skips them.
 
+Discovery:
+  'suggest' and 'apply' index every registered skill into a metadata cache under
+  SKILL_CACHE_DIR/catalog (one SKILL.md per skill) so skill-select can see and
+  rank them without cloning whole repositories. That catalog directory is on the
+  default SKILL_SOURCE_DIRS, the index is cached for a week, and the full repo is
+  downloaded lazily only when a registry skill is actually added. Stubs for names
+  no longer in the registry are pruned automatically. 'update --catalog' refreshes
+  the whole index on demand; 'doctor' reports missing, stale, or orphaned stubs.
+
 Registry:
   Catalog entries map a name to a source. Built-in entries live in this script.
   Add your own (including private/internal repos) without editing it by writing
@@ -833,7 +1060,8 @@ Registry:
 
 Environment:
   SKILL_SOURCE_DIRS  Colon-separated directories searched for skills by name
-                     (default: ~/.dotfiles/skills:~/.private/skills:~/.corp/skills)
+                     (default: ~/.dotfiles/skills:~/.private/skills:~/.corp/skills
+                     plus SKILL_CACHE_DIR/catalog)
   SKILL_DEST_DIRS    Colon-separated list of local repo paths to symlink skills into
                      (default: .claude/skills:.agents/skills)
   SKILL_CACHE_DIR    Where catalog downloads are cached
@@ -874,7 +1102,8 @@ def main():
     if not source_dirs_str:
         home = Path.home()
         source_dirs_str = (
-            f"{home}/.dotfiles/skills:{home}/.private/skills:{home}/.corp/skills"
+            f"{home}/.dotfiles/skills:{home}/.private/skills:"
+            f"{home}/.corp/skills:{get_catalog_dir()}"
         )
     source_dirs = source_dirs_str.split(":")
 
@@ -898,9 +1127,9 @@ def main():
     elif cmd == "clean":
         cmd_clean()
     elif cmd == "apply":
-        cmd_apply(args)
+        cmd_apply(args, registry)
     elif cmd == "suggest":
-        cmd_suggest(args)
+        cmd_suggest(args, registry)
     elif cmd in ("doctor", "status"):
         cmd_doctor(registry, source_dirs)
     else:

--- a/skills/skill-select/scripts/skill-select
+++ b/skills/skill-select/scripts/skill-select
@@ -257,6 +257,26 @@ def main():
         env_dirs = os.environ.get("SKILL_SOURCE_DIRS")
         if env_dirs:
             search_paths.extend([Path(p) for p in env_dirs.split(":")])
+        else:
+            # Mirror git-skill's default layout, including the catalog metadata
+            # cache so registry skills are discoverable out of the box.
+            home = Path.home()
+            cache_base = (
+                Path(
+                    os.environ.get("SKILL_CACHE_DIR")
+                    or os.environ.get("XDG_CACHE_HOME")
+                    or "~/.cache"
+                ).expanduser()
+                / "skills"
+            )
+            search_paths.extend(
+                [
+                    home / ".dotfiles/skills",
+                    home / ".private/skills",
+                    home / ".corp/skills",
+                    cache_base / "catalog",
+                ]
+            )
 
     if not search_paths:
         print(

--- a/tests/git-skill/test-basic
+++ b/tests/git-skill/test-basic
@@ -12,7 +12,7 @@ export PATH="$DIR/../../bin:$PATH"
 export SKILL_SOURCE_DIRS="$DIR/../../skills"
 export XDG_CONFIG_HOME="$DIR/../../etc"
 
-echo "1..11"
+echo "1..14"
 
 # Test 1: --help succeeds and mentions SKILL_SOURCE_DIRS
 if out=$("$BIN" --help 2>&1) && printf '%s' "$out" | grep -q 'SKILL_SOURCE_DIRS'; then
@@ -131,4 +131,50 @@ if grep -q "/\.claude/skills/agent-tools" "$REPO/.git/info/exclude" &&
 	echo "ok 11 - add from subdirectory updates top-level exclude"
 else
 	echo "not ok 11 - add from subdirectory failed to update top-level exclude"
+fi
+
+# The remaining tests exercise the catalog metadata index. They are hermetic:
+# they use a throwaway SKILL_CACHE_DIR and never reach the network (an empty
+# registry short-circuits; doctor is read-only).
+CACHE=$(mktemp -d "/tmp/skill-test-cache.XXXXXX")
+CFG=$(mktemp -d "/tmp/skill-test-cfg.XXXXXX")
+REPO2=$(mktemp -d "/tmp/skill-test-repo2.XXXXXX")
+trap 'rm -rf "$REPO" "$ALT" "$CACHE" "$CFG" "$REPO2"' EXIT
+
+# Test 12: 'update --catalog' with an empty registry must NOT prune the catalog.
+# A missing/unreadable registry yields {} and must never trigger destructive GC.
+mkdir -p "$CACHE/skills/catalog/orphan" "$CACHE/skills/catalog/.meta"
+printf '# orphan\n' >"$CACHE/skills/catalog/orphan/SKILL.md"
+: >"$CACHE/skills/catalog/.meta/orphan"
+SKILL_CACHE_DIR="$CACHE" "$BIN" update --catalog >/dev/null 2>&1
+if [ -d "$CACHE/skills/catalog/orphan" ]; then
+	echo "ok 12 - update --catalog with empty registry preserves catalog (GC guard)"
+else
+	echo "not ok 12 - empty-registry GC wrongly removed a catalog stub"
+fi
+
+# Test 13: doctor flags missing/stale/orphaned stubs when the registry is set.
+mkdir -p "$CFG/skill"
+printf 'foo https://github.com/o/r/tree/main/skills/foo\n' >"$CFG/skill/registry"
+mkdir -p "$CACHE/skills/catalog/foo" "$CACHE/skills/catalog/bar"
+printf '# foo\n' >"$CACHE/skills/catalog/foo/SKILL.md"
+printf '# bar\n' >"$CACHE/skills/catalog/bar/SKILL.md"
+: >"$CACHE/skills/catalog/.meta/foo"
+git -C "$REPO2" init -q
+out=$(cd "$REPO2" && SKILL_CACHE_DIR="$CACHE" XDG_CONFIG_HOME="$CFG" "$BIN" doctor 2>&1)
+rc_doctor=$?
+if [ "$rc_doctor" -ne 0 ] &&
+	printf '%s' "$out" | grep -q 'orphan' &&
+	printf '%s' "$out" | grep -q 'bar'; then
+	echo "ok 13 - doctor flags orphaned catalog stub"
+else
+	echo "not ok 13 - doctor did not flag orphan (rc=$rc_doctor)"
+	printf '%s\n' "$out" | sed 's/^/# /'
+fi
+
+# Test 14: help documents 'update --catalog'
+if "$BIN" --help 2>&1 | grep -q -- '--catalog'; then
+	echo "ok 14 - help documents update --catalog"
+else
+	echo "not ok 14 - help missing --catalog"
 fi

--- a/tests/git-skill/test-basic
+++ b/tests/git-skill/test-basic
@@ -16,16 +16,16 @@ echo "1..14"
 
 # Test 1: --help succeeds and mentions SKILL_SOURCE_DIRS
 if out=$("$BIN" --help 2>&1) && printf '%s' "$out" | grep -q 'SKILL_SOURCE_DIRS'; then
-	echo "ok 1 - --help advertises SKILL_SOURCE_DIRS"
+  echo "ok 1 - --help advertises SKILL_SOURCE_DIRS"
 else
-	echo "not ok 1 - --help missing or doesn't mention SKILL_SOURCE_DIRS"
+  echo "not ok 1 - --help missing or doesn't mention SKILL_SOURCE_DIRS"
 fi
 
 # Test 2: catalog runs without a git repo
 if (cd /tmp && "$BIN" catalog) >/dev/null 2>&1; then
-	echo "ok 2 - catalog runs outside a git work tree"
+  echo "ok 2 - catalog runs outside a git work tree"
 else
-	echo "not ok 2 - catalog failed outside a git work tree"
+  echo "not ok 2 - catalog failed outside a git work tree"
 fi
 
 # Set up a throwaway git repo for the per-repo subcommands.
@@ -35,15 +35,15 @@ git -C "$REPO" init -q
 
 # Test 3: add multiple skills creates symlinks in both destinations
 if (cd "$REPO" && "$BIN" add agent-tools coding-standards technical-writing-style) >/dev/null 2>&1 &&
-	[ -L "$REPO/.claude/skills/agent-tools" ] &&
-	[ -L "$REPO/.agents/skills/agent-tools" ] &&
-	[ -L "$REPO/.claude/skills/coding-standards" ] &&
-	[ -L "$REPO/.agents/skills/coding-standards" ] &&
-	[ -L "$REPO/.claude/skills/technical-writing-style" ] &&
-	[ -L "$REPO/.agents/skills/technical-writing-style" ]; then
-	echo "ok 3 - add multiple skills symlinks into .claude and .agents"
+  [ -L "$REPO/.claude/skills/agent-tools" ] &&
+  [ -L "$REPO/.agents/skills/agent-tools" ] &&
+  [ -L "$REPO/.claude/skills/coding-standards" ] &&
+  [ -L "$REPO/.agents/skills/coding-standards" ] &&
+  [ -L "$REPO/.claude/skills/technical-writing-style" ] &&
+  [ -L "$REPO/.agents/skills/technical-writing-style" ]; then
+  echo "ok 3 - add multiple skills symlinks into .claude and .agents"
 else
-	echo "not ok 3 - add did not create expected symlinks"
+  echo "not ok 3 - add did not create expected symlinks"
 fi
 
 # Test 4: list returns the members sorted/unique with their resolved paths
@@ -56,48 +56,48 @@ $expected_tws"
 
 actual=$(cd "$REPO" && "$BIN" list 2>/dev/null)
 if [ "$actual" = "$expected" ]; then
-	echo "ok 4 - list returns members with resolved paths"
+  echo "ok 4 - list returns members with resolved paths"
 else
-	echo "not ok 4 - list output mismatch"
-	printf '%s\n' "$actual" | sed 's/^/# got: /'
+  echo "not ok 4 - list output mismatch"
+  printf '%s\n' "$actual" | sed 's/^/# got: /'
 fi
 
 # Test 5: managed block recorded in .git/info/exclude
 if [ -f "$REPO/.git/info/exclude" ] && grep -q "skills (managed by 'git-skill')" "$REPO/.git/info/exclude"; then
-	echo "ok 5 - info/exclude contains managed block"
+  echo "ok 5 - info/exclude contains managed block"
 else
-	echo "not ok 5 - info/exclude missing managed block"
+  echo "not ok 5 - info/exclude missing managed block"
 fi
 
 # Test 6: add bogus-skill-name reports an unknown skill error and exits non-zero
 if (cd "$REPO" && "$BIN" add bogus-skill-name) >/dev/null 2>err; then
-	echo "not ok 6 - add bogus-skill-name should have failed"
+  echo "not ok 6 - add bogus-skill-name should have failed"
 else
-	if grep -q "unknown skill 'bogus-skill-name'" err; then
-		echo "ok 6 - add bogus-skill-name reports unknown skill"
-	else
-		echo "not ok 6 - add bogus-skill-name failed but with unexpected message"
-		sed 's/^/# /' err
-	fi
+  if grep -q "unknown skill 'bogus-skill-name'" err; then
+    echo "ok 6 - add bogus-skill-name reports unknown skill"
+  else
+    echo "not ok 6 - add bogus-skill-name failed but with unexpected message"
+    sed 's/^/# /' err
+  fi
 fi
 rm -f err
 
 # Test 7: remove drops the symlink and updates the exclude block
 if (cd "$REPO" && "$BIN" remove coding-standards) >/dev/null 2>&1 &&
-	[ ! -e "$REPO/.claude/skills/coding-standards" ] &&
-	! grep -q "coding-standards" "$REPO/.git/info/exclude"; then
-	echo "ok 7 - remove deletes symlink and exclude entry"
+  [ ! -e "$REPO/.claude/skills/coding-standards" ] &&
+  ! grep -q "coding-standards" "$REPO/.git/info/exclude"; then
+  echo "ok 7 - remove deletes symlink and exclude entry"
 else
-	echo "not ok 7 - remove did not fully clean up"
+  echo "not ok 7 - remove did not fully clean up"
 fi
 
 # Test 8: clean removes everything and clears the managed block
 if (cd "$REPO" && "$BIN" clean) >/dev/null 2>&1 &&
-	[ ! -e "$REPO/.claude/skills/agent-tools" ] &&
-	! grep -q "skills (managed by 'git-skill')" "$REPO/.git/info/exclude"; then
-	echo "ok 8 - clean removes links and managed block"
+  [ ! -e "$REPO/.claude/skills/agent-tools" ] &&
+  ! grep -q "skills (managed by 'git-skill')" "$REPO/.git/info/exclude"; then
+  echo "ok 8 - clean removes links and managed block"
 else
-	echo "not ok 8 - clean left state behind"
+  echo "not ok 8 - clean left state behind"
 fi
 
 # Test 9: add resolves names against SKILL_SOURCE_DIRS overlays
@@ -106,31 +106,31 @@ trap 'rm -rf "$REPO" "$ALT"' EXIT
 mkdir -p "$ALT/custom-skill"
 printf '# custom\n' >"$ALT/custom-skill/SKILL.md"
 SKILL_SOURCE_DIRS="$ALT:$DIR/../../skills" \
-	bash -c 'cd "$1" && "$2" add custom-skill' _ "$REPO" "$BIN" >/dev/null 2>&1
+  bash -c 'cd "$1" && "$2" add custom-skill' _ "$REPO" "$BIN" >/dev/null 2>&1
 if [ -L "$REPO/.claude/skills/custom-skill" ] &&
-	[ "$(readlink "$REPO/.claude/skills/custom-skill")" = "$ALT/custom-skill" ]; then
-	echo "ok 9 - resolves names against SKILL_SOURCE_DIRS"
+  [ "$(readlink "$REPO/.claude/skills/custom-skill")" = "$ALT/custom-skill" ]; then
+  echo "ok 9 - resolves names against SKILL_SOURCE_DIRS"
 else
-	echo "not ok 9 - SKILL_SOURCE_DIRS resolution failed"
+  echo "not ok 9 - SKILL_SOURCE_DIRS resolution failed"
 fi
 
 # Test 10: resolve prints source path; non-existent name exits 1 with no output
 got=$("$BIN" resolve agent-tools 2>/dev/null)
 if [ "$got" = "$DIR/../../skills/agent-tools" ] &&
-	! "$BIN" resolve no-such-skill >/dev/null 2>&1; then
-	echo "ok 10 - resolve returns source path; fails on unknown name"
+  ! "$BIN" resolve no-such-skill >/dev/null 2>&1; then
+  echo "ok 10 - resolve returns source path; fails on unknown name"
 else
-	echo "not ok 10 - resolve misbehaved (got=$got)"
+  echo "not ok 10 - resolve misbehaved (got=$got)"
 fi
 
 # Test 11: add from a subdirectory correctly updates the top-level exclude file
 mkdir -p "$REPO/subdir"
 (cd "$REPO/subdir" && "$BIN" add agent-tools) >/dev/null 2>&1
 if grep -q "/\.claude/skills/agent-tools" "$REPO/.git/info/exclude" &&
-	grep -q "/\.agents/skills/agent-tools" "$REPO/.git/info/exclude"; then
-	echo "ok 11 - add from subdirectory updates top-level exclude"
+  grep -q "/\.agents/skills/agent-tools" "$REPO/.git/info/exclude"; then
+  echo "ok 11 - add from subdirectory updates top-level exclude"
 else
-	echo "not ok 11 - add from subdirectory failed to update top-level exclude"
+  echo "not ok 11 - add from subdirectory failed to update top-level exclude"
 fi
 
 # The remaining tests exercise the catalog metadata index. They are hermetic:
@@ -148,9 +148,9 @@ printf '# orphan\n' >"$CACHE/skills/catalog/orphan/SKILL.md"
 : >"$CACHE/skills/catalog/.meta/orphan"
 SKILL_CACHE_DIR="$CACHE" "$BIN" update --catalog >/dev/null 2>&1
 if [ -d "$CACHE/skills/catalog/orphan" ]; then
-	echo "ok 12 - update --catalog with empty registry preserves catalog (GC guard)"
+  echo "ok 12 - update --catalog with empty registry preserves catalog (GC guard)"
 else
-	echo "not ok 12 - empty-registry GC wrongly removed a catalog stub"
+  echo "not ok 12 - empty-registry GC wrongly removed a catalog stub"
 fi
 
 # Test 13: doctor flags missing/stale/orphaned stubs when the registry is set.
@@ -164,17 +164,17 @@ git -C "$REPO2" init -q
 out=$(cd "$REPO2" && SKILL_CACHE_DIR="$CACHE" XDG_CONFIG_HOME="$CFG" "$BIN" doctor 2>&1)
 rc_doctor=$?
 if [ "$rc_doctor" -ne 0 ] &&
-	printf '%s' "$out" | grep -q 'orphan' &&
-	printf '%s' "$out" | grep -q 'bar'; then
-	echo "ok 13 - doctor flags orphaned catalog stub"
+  printf '%s' "$out" | grep -q 'orphan' &&
+  printf '%s' "$out" | grep -q 'bar'; then
+  echo "ok 13 - doctor flags orphaned catalog stub"
 else
-	echo "not ok 13 - doctor did not flag orphan (rc=$rc_doctor)"
-	printf '%s\n' "$out" | sed 's/^/# /'
+  echo "not ok 13 - doctor did not flag orphan (rc=$rc_doctor)"
+  printf '%s\n' "$out" | sed 's/^/# /'
 fi
 
 # Test 14: help documents 'update --catalog'
 if "$BIN" --help 2>&1 | grep -q -- '--catalog'; then
-	echo "ok 14 - help documents update --catalog"
+  echo "ok 14 - help documents update --catalog"
 else
-	echo "not ok 14 - help missing --catalog"
+  echo "not ok 14 - help missing --catalog"
 fi


### PR DESCRIPTION
## Summary

Makes remote **registry** skills (defined in `~/.config/skill/registry[.d]`) discoverable by `skill-select` and selectable by `git skill apply`/`suggest`, without slow networking on every run, cache corruption under concurrency, or the risk of silently wiping a populated cache.

`git-skill` now maintains a **metadata-only catalog index** under `SKILL_CACHE_DIR/catalog` — one `SKILL.md` stub per registered skill — which is added to the default `SKILL_SOURCE_DIRS`, so `skill-select` discovers registry skills through ordinary directory traversal with no new logic. Discovery fetches only `SKILL.md` (fast cold start, offline-friendly); the full repository is downloaded **lazily**, just-in-time, when a skill is actually added.

This is the clean filesystem seam discussed in the design: `skill-select` stays a dumb offline resolver, `git-skill` owns all fetching/caching.

## What changed

`skills/skill-select/scripts/git-skill` (canonical source; `bin/git-skill` symlinks to it):
- **`fetch_github`** — added a `force` flag, an **atomic sibling-swap install** (`_atomic_replace_dir`, fixing ref-name mangling and `os.replace`-onto-non-empty), and an **offline fallback** that returns a stale cache instead of failing.
- **`fetch_skill_md` + `ensure_catalog_index`** — metadata-only stub fetch with a **7-day TTL** (tracked via `catalog/.meta/<name>` sidecars) and automatic **GC of orphaned stubs**, guarded to return early on an empty registry so a missing/unreadable config can never trigger a destructive prune.
- **`apply`** — provisions registry skills just-in-time (**8-hour** freshness) and passes the **registry name** rather than the resolved path, so skills with a `subpath` are recorded under a name `update` can later resolve.
- **`update`** — `--catalog` refreshes the whole index (+ GC); `update <name>` refreshes a registry entry's stub (and full repo only if already cached).
- **`doctor`** — read-only catalog health: reports missing, stale, and orphaned stubs.

`skills/skill-select/scripts/skill-select`:
- Default search-dir fallback (including the catalog dir) when neither `--search-dirs` nor `SKILL_SOURCE_DIRS` is set. (Behavior change from the old "error if unset".)

`fish/completions/git-skill.fish` — completions for `update --catalog` and registry names.

`tests/git-skill/test-basic` — 3 new **hermetic, network-free** tests (empty-registry GC guard, orphan detection via `doctor`, help text); also reformatted to `shfmt -i 2 -ci` per `shell.md`.

## Naming

Follows `skills/coding-standards/references/cli-tools.md`: reuses the `catalog` noun and the `update` verb instead of introducing `sync`/`refresh` synonyms; GC folds into `update`; `doctor` stays read-only (§5.1/5.2/5.3).

## Testing

- `prove tests/git-skill/test-basic tests/skill-select/test-basic` → 19/19 pass.
- `ruff`, `shfmt -i 2 -ci`, and `fish_indent --check` clean on the changed files (ran the exact CI commands locally).
- Offline smoke tests: default-path stub discovery, graceful 404/offline degradation, and GC pruning the orphan while keeping registered entries.

https://claude.ai/code/session_017j1whnvLZEKUiFH3FJJwoe

---
_Generated by [Claude Code](https://claude.ai/code/session_017j1whnvLZEKUiFH3FJJwoe)_