### PR TITLE
feat(workspace-config): multi-agent permissions and workspace plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,16 @@ require adb
 require apkanalyzer
 ```
 
+#### Safe-Command Declarations
+
+`permission apply` pre-approves every executable in a skill's `scripts/`
+directory for local agents by default. If a script (or one of its subcommands)
+is destructive, irreversible, or otherwise should always prompt, it must be
+listed in that skill's `permissions/unsafe` file (one pattern per line; a bare
+script name suppresses pre-approval entirely, a `script subcommand` line guards
+just that subcommand). When adding or modifying a script with destructive
+behavior, update this file. See `skills/workspace-config/SKILL.md` for details.
+
 #### File Output
 
 If a script produces a new file or directory as output, it must support an

--- a/bin/git-setup
+++ b/bin/git-setup
@@ -6,17 +6,34 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [doctor] [--force]
 
-Configure the current git repository by installing hooks and provisioning skills.
+Set up the current git repository for agent-assisted development.
+Idempotent: re-running refreshes the same files and never duplicates work.
 
-With no command, installs the commit-msg hook (via git-hooks-agent) and
-provisions skills (via skill apply). This is typically invoked
-automatically on 'git clone' by the post-checkout hook from
-~/.dotfiles/etc/git/templates/global.
+With no command, performs three steps:
+
+  1. git-hooks-agent     Installs the commit-msg hook
+                         (writes .git/hooks/commit-msg)
+  2. skill apply         Selects skills relevant to this repository and
+                         symlinks them into the workspace (writes
+                         .claude/skills/, .agents/skills/, .git/info/skills,
+                         and the managed block in .git/info/exclude)
+  3. permission apply    Pre-approves the installed skills' safe commands
+                         for local agents (writes .claude/settings.local.json
+                         and the agy project config under ~/.gemini)
+
+Nothing it writes is tracked by git. Note that 'skill apply' consults an
+LLM to choose skills, so this command needs network access and can take a
+few seconds; all other steps are local and fast.
+
+This is typically invoked automatically on 'git clone' by the
+post-checkout hook from ~/.dotfiles/etc/git/templates/global. Run it
+manually to set up older repositories, or re-run it any time to refresh.
 
 Commands:
   doctor    Diagnose this repository's setup (read-only): delegates to
-            'git-hooks-agent doctor' and 'skill doctor' and exits
-            non-zero if either reports a problem.
+            'git-hooks-agent doctor', 'skill doctor', and
+            'permission doctor', and exits non-zero if any reports a
+            problem.
 
 Options:
   --force   Pass --force to git-hooks-agent (overwrite a foreign commit-msg hook)
@@ -60,6 +77,7 @@ done
 require git
 require git-hooks-agent
 require skill
+require permission
 
 if ! inside=$(git rev-parse --is-inside-work-tree 2>/dev/null) || [ "$inside" != "true" ]; then
   echo "$(basename "$0"): not inside a git work tree (run 'git init' to create one)" >&2
@@ -73,16 +91,18 @@ fi
 root=$(git rev-parse --show-toplevel)
 cd "$root"
 
-# doctor: aggregate the per-domain health checks; exit non-zero if either fails.
+# doctor: aggregate the per-domain health checks; exit non-zero if any fails.
 if [ "$mode" = "doctor" ]; then
   rc=0
   git-hooks-agent doctor || rc=1
   echo
   skill doctor || rc=1
+  echo
+  permission doctor || rc=1
   exit "$rc"
 fi
 
-echo "$(basename "$0"): installing hooks and provisioning skills"
+echo "$(basename "$0"): installing hooks, provisioning skills, and applying permissions"
 
 hook_args=()
 [ "$force" -eq 1 ] && hook_args+=(--force)
@@ -94,3 +114,4 @@ else
 fi
 
 skill apply
+permission apply

--- a/fish/completions/permission.fish
+++ b/fish/completions/permission.fish
@@ -1,0 +1,24 @@
+# Fish completion script for permission
+
+function __fish_permission_patterns
+    permission list 2>/dev/null | string trim | string match -rv '^\[.*\]$|:$'
+end
+
+# Complete subcommands
+complete -f -c permission -n __fish_use_subcommand -a add -d 'Add permission rules'
+complete -f -c permission -n __fish_use_subcommand -a remove -d 'Remove permission rules'
+complete -f -c permission -n __fish_use_subcommand -a rm -d 'Remove permission rules (alias of remove)'
+complete -f -c permission -n __fish_use_subcommand -a list -d 'List permission rules per agent'
+complete -f -c permission -n __fish_use_subcommand -a ls -d 'List permission rules per agent (alias of list)'
+complete -f -c permission -n __fish_use_subcommand -a apply -d 'Pre-approve safe commands from installed skills'
+complete -f -c permission -n __fish_use_subcommand -a clean -d 'Clear all workspace permission rules'
+complete -f -c permission -n __fish_use_subcommand -a doctor -d 'Report missing or drifted rules'
+
+# Options
+complete -f -c permission -l help -d 'Display help and exit'
+complete -x -c permission -l agent -a 'agy claude' -d 'Operate on a single agent backend'
+complete -f -c permission -n '__fish_seen_subcommand_from add' -l deny -d 'Add to the denylist'
+complete -f -c permission -n '__fish_seen_subcommand_from add' -l ask -d 'Add to the ask list (Claude Code only)'
+
+# remove: complete from currently configured patterns
+complete -f -c permission -n '__fish_seen_subcommand_from remove rm' -a '(__fish_permission_patterns)' -d Pattern

--- a/fish/completions/skill.fish
+++ b/fish/completions/skill.fish
@@ -32,6 +32,10 @@ complete -f -c skill -n __fish_use_subcommand -a resolve -d 'Print source path f
 complete -f -c skill -n __fish_use_subcommand -a apply -d 'Provision skills for this workspace via skill-select'
 complete -f -c skill -n __fish_use_subcommand -a suggest -d 'Print skill-select recommendations without installing'
 complete -f -c skill -n __fish_use_subcommand -a doctor -d 'Diagnose drift between desired and on-disk skills'
+complete -f -c skill -n __fish_use_subcommand -a repair -d 'Re-link managed skills and regenerate tracking records'
+
+# list
+complete -c skill -f -n '__fish_seen_subcommand_from list' -l json -d 'Emit JSON (name, path)'
 
 # resolve: source skill names only
 complete -f -c skill -n '__fish_seen_subcommand_from resolve' -a '(__fish_skill_source_skills)' -d Skill

--- a/skills/adb/permissions/unsafe
+++ b/skills/adb/permissions/unsafe
@@ -1,0 +1,8 @@
+# Commands that 'permission apply' must not pre-approve.
+# A bare script name is never allowed (it prompts normally); a
+# "script subcommand" line keeps the script allowed but guards that
+# subcommand (ask on Claude Code, deny on agy).
+adb-settings-theme
+packagename clear-cache
+packagename reset-permissions
+packagename uninstall

--- a/skills/emumanager/permissions/unsafe
+++ b/skills/emumanager/permissions/unsafe
@@ -1,0 +1,2 @@
+# Commands that 'permission apply' must not pre-approve.
+emumanager delete

--- a/skills/workspace-config/SKILL.md
+++ b/skills/workspace-config/SKILL.md
@@ -1,23 +1,86 @@
 ---
 name: workspace-config
-description: Discover and select relevant agent skills, and manage workspace tool execution permissions. Use this to determine which skills apply to a workspace, and to manage allow/deny rules for local agent tool execution.
+description: Discover and select relevant agent skills, and manage workspace tool execution permissions. Use this to determine which skills apply to a workspace, to install or remove skills, and to manage allow/deny/ask rules for local agent tool execution across agents (Claude Code, Antigravity).
 ---
 
-# Skill Select & Skill Manager
+# Workspace Configuration
 
-This skill provides discovery, selection, and management of agent skills for
-your workspace. It consists of two primary tools:
+This skill configures a workspace for agent-assisted development without version
+control ever seeing the configuration. It consists of three tools:
 
-1. **`skill-select`**: The discovery engine. It analyzes your workspace to
-   suggest sensible default skills, or uses LLM-based selection when task
-   context is provided.
-1. **`skill`**: The workspace manager. It installs and tracks skills in your
-   workspace, automatically adapting to your environment (Git, Perforce, or
-   Unmanaged).
+1. **`skill`**: The workspace manager. Installs and tracks skills as untracked
+   symlinks, automatically adapting to the environment (Git, Perforce, or
+   unmanaged directories; more via plugins).
+1. **`skill-select`**: The discovery engine. Analyzes a workspace to suggest
+   sensible default skills, or uses LLM-based selection when task context is
+   provided. Also owns the registry, network, and cache machinery.
+1. **`permission`**: The permission manager. Maintains per-workspace
+   allow/deny/ask rules for every detected local agent, including pre-approving
+   the safe commands declared by installed skills.
+
+`git-setup` ties these together for git repositories: it installs hooks, runs
+`skill apply`, then `permission apply` (and `git-setup doctor` aggregates all
+three doctors). It runs automatically on `git clone` via the global template's
+post-checkout hook.
 
 ______________________________________________________________________
 
-## 1. Discovering Skills (`skill-select`)
+## 1. Managing Skills (`skill`)
+
+The `skill` tool (symlinked in `bin/`) manages agent skills as untracked
+symlinks in your workspace. It automatically detects your environment and
+applies the correct tracking and ignoring mechanism.
+
+```bash
+skill <command> [arguments]
+```
+
+### Supported Environments
+
+- **Git Repositories**: Links skills under `.agents/skills/` and
+  `.claude/skills/`. The authoritative managed list lives in `.git/info/skills`
+  (inside the git dir, so it can never be tracked), and a marker block in
+  `.git/info/exclude` is regenerated from it to keep `git status` clean without
+  dirtying the shared `.gitignore`. If another tool rewrites the exclude file,
+  `skill doctor` detects it and `skill repair` regenerates the block.
+- **Perforce Workspaces**: Links skills under `.agents/skills/` and
+  `.claude/skills/` and tracks them in `.p4-skills-managed` at the client root
+  (untracked files are invisible to Perforce unless reconciled).
+- **Unmanaged Directories**: Works in plain directories without VCS. Tracks
+  skills in a local `.skills-managed` file.
+- **Plugins**: Additional workspace types can be registered by dropping a Python
+  file into `~/.config/skill/plugins/` that defines `register(api)` and calls
+  `api.register_workspace(cls)` with a subclass of `api.Workspace` (see also
+  `api.FileStateMixin`) implementing a `detect()` classmethod. Plugin detectors
+  run before the built-in ones, in sorted filename order.
+
+### Commands
+
+- **`apply`**: Provision recommended skills for this workspace via
+  `skill-select` (idempotent). Consults an LLM, so it needs network access.
+- **`suggest`**: Print recommendations without installing them.
+- **`add SPEC...`**: Add a skill (a local path or a registered catalog entry).
+- **`remove NAME...`** (alias: **`rm`**): Remove a managed skill.
+- **`list [--json]`**: List skills currently managed in this workspace.
+- **`update SPEC...`**: Re-fetch a registered catalog entry (`--all` for all,
+  `--catalog` for the catalog index).
+- **`clean`**: Remove all managed skills and clear tracking records.
+- **`doctor`**: Diagnose drift between desired and on-disk skills (read-only).
+- **`repair`**: Re-link managed skills and regenerate tracking records.
+- **`catalog`**: List all registered skills and their sources.
+- **`resolve NAME`**: Print the source path a skill name would resolve to.
+
+### Environment
+
+- `SKILL_SOURCE_DIRS`: Colon-separated directories searched for skills by name
+  (default: `~/.dotfiles/skills:~/.private/skills:~/.corp/skills` plus the
+  registry cache).
+- `SKILL_DEST_DIRS`: Colon-separated link destinations relative to the workspace
+  root (default: `.claude/skills:.agents/skills`).
+
+______________________________________________________________________
+
+## 2. Discovering Skills (`skill-select`)
 
 Invoke the selection tool via `skill-select` (symlinked in `bin/`):
 
@@ -36,55 +99,20 @@ skill-select [DIR] [OPTIONS]
 
 ______________________________________________________________________
 
-## 2. Managing Skills (`skill`)
-
-The `skill` tool (symlinked in `bin/`) manages agent skills as untracked
-symlinks in your workspace. It automatically detects your environment and
-applies the correct tracking and ignoring mechanism.
-
-```bash
-skill <command> [arguments]
-```
-
-### Supported Environments
-
-- **Git Repositories**: Links skills under `.agents/skills/` and
-  `.claude/skills/`. It automatically updates `.git/info/exclude` to keep your
-  git status clean without dirtying the shared `.gitignore`.
-- **Perforce Workspaces**:
-  - *Centralized Layout*: Links skills under
-    `configs/users/<username>/_agents/skills/` and tracks them in
-    `.p4-skills-managed` in that directory. This is typically used in
-    environments with centralized user configurations.
-  - *Standard Layout*: Links skills under `.agents/skills/` and tracks them in
-    `.p4-skills-managed` at the client root.
-- **Unmanaged Directories**: Works in plain directories without VCS. Links
-  skills under `.agents/skills/` and `.claude/skills/` and tracks them in a
-  local `.skills-managed` file.
-
-### Commands
-
-- **`apply`**: Provision recommended skills for this workspace via
-  `skill-select` (idempotent).
-- **`suggest`**: Print recommendations without installing them.
-- **`add SPEC...`**: Add a skill (a local path or a registered catalog entry).
-- **`remove NAME...`** (alias: **`rm`**): Remove a managed skill.
-- **`list`**: List skills currently managed in this workspace.
-- **`update SPEC...`**: Re-fetch a registered catalog entry (`--all` for all,
-  `--catalog` for catalog index).
-- **`clean`**: Remove all managed skills and clear tracking records.
-- **`doctor`**: Diagnose drift between desired and on-disk skills (read-only).
-- **`catalog`**: List all registered skills and their sources.
-- **`resolve NAME`**: Print the source path a skill name would resolve to.
-
-______________________________________________________________________
-
 ## 3. Managing Workspace Permissions (`permission`)
 
 The `permission` tool (symlinked in `bin/`) manages workspace-specific agent
-tool permissions (allowlists and denylists). It stores configurations in
-`~/.gemini/config/projects/` and maintains workspace mappings in
-`~/.gemini/jetski/cli/cache/projects.json`.
+tool permissions. Rules are written as clean command patterns (e.g.
+`"git show"`); each agent backend translates them to its native syntax:
+
+- **`claude`** (Claude Code): `Bash(pattern:*)` rules in the workspace's
+  `.claude/settings.local.json` (personal settings; the tool ensures the file is
+  git-ignored). Claude Code picks these up without a restart.
+- **`agy`** (Antigravity/jetski): `command(...)` rules in the per-project
+  configuration under `~/.gemini`.
+
+By default every command operates on all detected agents; use `--agent NAME` to
+scope to one.
 
 ```bash
 permission <command> [arguments] [options]
@@ -92,13 +120,40 @@ permission <command> [arguments] [options]
 
 ### Commands
 
-- **`add PATTERN`**: Add a rule pattern to the workspace allowlist
-  (auto-initializes the configuration if needed). Use `--deny` to add to the
-  denylist instead.
-- **`remove PATTERN`** (alias: **`rm`**): Remove a permission rule.
-- **`list`** (alias: **`ls`**): List all workspace-specific allow and deny
-  rules.
+- **`add PATTERN...`**: Add rule patterns to the allowlist (`--deny` for the
+  denylist, `--ask` for Claude Code's always-prompt list). `add -` reads one
+  pattern per line from stdin.
+- **`remove PATTERN...`** (alias: **`rm`**): Remove patterns from all lists.
+- **`list`** (alias: **`ls`**): List rules per agent, as clean patterns.
+- **`apply`**: Pre-approve the safe commands declared by this workspace's
+  installed skills (idempotent; see below).
 - **`clean`**: Clear all permission rules for the workspace.
+- **`doctor`**: Report rules that `apply` would add but that are missing
+  (read-only; exits non-zero on problems).
+
+### Safe-Command Declarations (`permissions/unsafe`)
+
+`permission apply` walks the workspace's installed skills (via
+`skill list --json`) and pre-approves **every executable in each skill's
+`scripts/` directory**, except entries listed in that skill's optional
+`permissions/unsafe` file (one pattern per line, `#` comments):
+
+- A **bare script name** (e.g. `adb-settings-theme`) is never pre-approved; the
+  command prompts normally.
+- A **`script subcommand` line** (e.g. `packagename uninstall`) keeps the
+  blanket allow for the script but guards that subcommand: an `ask` rule on
+  Claude Code, a `deny` rule on agy.
+
+New scripts added to a skill are therefore pre-approved by default; only the
+exceptions need maintaining. The `permission` tool's own mutating subcommands
+(`add`, `remove`, `clean`) are declared unsafe so an agent can never edit its
+own allowlist unprompted.
+
+### Plugins
+
+Extra workspace-root markers (beyond `.git`, `.hg`, `.svn`) can be registered by
+dropping a Python file into `~/.config/permission/plugins/` that defines
+`register(api)` and calls `api.register_root_marker(".marker")`.
 
 See the [Command Index](references/command-index.md) for full help details.
 
@@ -108,11 +163,15 @@ ______________________________________________________________________
 
 ### Default Discovery & Apply (Recommended for new workspaces)
 
-Analyze the current directory and automatically install the recommended skills:
+Analyze the current directory, install the recommended skills, and pre-approve
+their safe commands:
 
 ```bash
 skill apply
+permission apply
 ```
+
+(Or just run `git-setup`, which also installs hooks.)
 
 ### Targeted Discovery (With Context)
 
@@ -132,18 +191,29 @@ skill add coding-standards
 skill add /path/to/custom-skill
 ```
 
-### Listing Managed Skills
-
-See what is currently active in your workspace:
+### Managing Permissions by Hand
 
 ```bash
-skill list
+permission add "git show" "git log"   # allow on every detected agent
+permission add --deny "rm -rf"        # block outright
+permission add --ask "adb-tile-add" --agent claude
+permission list
+```
+
+### Health Checks
+
+```bash
+skill doctor       # symlink/state/exclude drift (read-only)
+permission doctor  # missing pre-approvals (read-only)
+skill repair       # re-link and regenerate tracking records
 ```
 
 ### Cleaning Up
 
-Remove all installed skills and restore the workspace to its original state:
+Remove all installed skills and permission rules, restoring the workspace to its
+original state:
 
 ```bash
 skill clean
+permission clean
 ```

--- a/skills/workspace-config/permissions/unsafe
+++ b/skills/workspace-config/permissions/unsafe
@@ -1,0 +1,6 @@
+# Commands that 'permission apply' must not pre-approve.
+# An agent must never be able to edit its own allowlist unprompted.
+permission add
+permission clean
+permission remove
+permission rm

--- a/skills/workspace-config/references/command-index.md
+++ b/skills/workspace-config/references/command-index.md
@@ -19,7 +19,8 @@ Usage: skill <command> [skill...]
 
 Manage per-workspace agent skills as untracked symlinks. Automatically detects
 whether the current directory is a Git repository, Perforce workspace, or an
-unmanaged directory, and applies the appropriate tracking mechanism.
+unmanaged directory, and applies the appropriate tracking mechanism. Extra
+workspace types can be added via plugins in ~/.config/skill/plugins/.
 
 Commands:
   apply           Provision skills for this workspace via skill-select (idempotent)
@@ -27,11 +28,12 @@ Commands:
   add SPEC...     Add a skill: a local path or a registered catalog entry
   add -           Read skill names from stdin
   remove NAME...  Remove a skill this tool added (alias: rm)
-  list            List skills this tool is managing in the current workspace
+  list [--json]   List skills this tool is managing in the current workspace
   update SPEC...  Re-fetch a registered catalog entry; --all for every managed
                   skill, --catalog to refresh the whole metadata index
   clean           Remove all skills this tool added and clear the tracking record
   doctor          Diagnose drift between desired and on-disk skills (read-only)
+  repair          Re-link managed skills and regenerate tracking records
   catalog         List registered skills and sources
   resolve NAME    Print the source path 'add NAME' would symlink to
 
@@ -92,16 +94,27 @@ The block below is `scripts/permission --help`, kept in sync by
 ```text
 Usage: permission <command> [arguments]
 
-Manage workspace-specific agent permissions.
+Manage per-workspace agent tool permissions (allow/deny/ask rules) across
+all detected local agents. Rules are written as clean command patterns
+(e.g. "git show"); each agent backend translates to its native syntax.
 
 Commands:
-  add             Add a tool permission rule
-  remove          Remove a tool permission rule (alias: rm)
-  list            List permission rules (alias: ls)
-  clean           Clear all workspace-specific permission rules
+  add PATTERN...     Add rule patterns to the allowlist (--deny / --ask
+                     for the other lists); 'add -' reads patterns from stdin
+  remove PATTERN...  Remove rule patterns from all lists (alias: rm)
+  list               List permission rules per agent (alias: ls)
+  apply              Pre-approve the safe commands declared by this
+                     workspace's installed skills (idempotent)
+  clean              Clear all workspace-specific permission rules
+  doctor             Report missing or drifted rules (read-only)
 
 Options:
-  --help          Display this help message and exit
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit
+
+Agents:
+  agy                Antigravity/jetski project config (under ~/.gemini)
+  claude             Claude Code (.claude/settings.local.json, untracked)
 ```
 
 <!-- /generated -->

--- a/skills/workspace-config/scripts/permission
+++ b/skills/workspace-config/scripts/permission
@@ -8,42 +8,87 @@ import os
 import sys
 import json
 import uuid
-import argparse
+import subprocess
 from pathlib import Path
 
-# Paths
-AGENT_CONFIG_HOME = Path(os.environ.get("AGENT_CONFIG_HOME", Path.home() / ".gemini"))
+SKILL_BIN = str(Path(__file__).resolve().parent / "skill")
+
+# Per-agent configuration locations (overridable for testing)
+AGY_CONFIG_HOME = Path(
+    os.environ.get("AGY_CONFIG_HOME")
+    or os.environ.get("AGENT_CONFIG_HOME")  # legacy name
+    or Path.home() / ".gemini"
+)
+CLAUDE_CONFIG_DIR = Path(
+    os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude"
+)
+
+MODES = ("allow", "deny", "ask")
+
+
+def die(msg):
+    print(f"permission: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ==============================================================================
+# Plugins & Workspace Root Detection
+# ==============================================================================
+
+
+class PermissionAPI:
+    """API surface passed to a plugin's register() function.
+
+    Plugins live in $XDG_CONFIG_HOME/permission/plugins/*.py and may register
+    additional workspace-root marker names (directories or files whose
+    presence identifies the root of a workspace when walking up from the
+    current directory).
+    """
+
+    def __init__(self):
+        self.root_markers = [".git", ".hg", ".svn"]
+
+    def register_root_marker(self, marker: str):
+        self.root_markers.append(marker)
+
+
+def load_plugins() -> PermissionAPI:
+    import importlib.util
+
+    api = PermissionAPI()
+    plugins_dir = (
+        Path(os.environ.get("XDG_CONFIG_HOME") or "~/.config").expanduser()
+        / "permission"
+        / "plugins"
+    )
+    if not plugins_dir.is_dir():
+        return api
+    for filepath in sorted(plugins_dir.glob("*.py")):
+        module_name = f"permission_plugin_{filepath.stem}"
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, filepath)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+                if hasattr(module, "register"):
+                    module.register(api)
+        except Exception as e:
+            print(
+                f"permission: warning: failed to load plugin {filepath}: {e}",
+                file=sys.stderr,
+            )
+    return api
 
 
 def get_workspace_root() -> Path:
-    # Walk up to find VCS indicators
+    markers = load_plugins().root_markers
     curr = Path.cwd().resolve()
     for parent in [curr] + list(curr.parents):
-        if (
-            (parent / ".git").is_dir()
-            or (parent / ".citc").is_dir()
-            or (parent / ".hg").is_dir()
-        ):
+        # .git may be a file (worktrees), so check existence, not is_dir.
+        if any((parent / m).exists() for m in markers):
             return parent
     return curr
-
-
-def translate_to_rule(pattern: str) -> str:
-    pattern = pattern.strip()
-
-    # Parse tokens
-    tokens = pattern.split()
-    if not tokens:
-        return ""
-
-    # Format the first token (executable)
-    exec_tok = tokens[0]
-    if exec_tok != "*" and "/" not in exec_tok and not exec_tok.startswith("(?:"):
-        exec_tok = f"(?:.*/)?{exec_tok}"
-
-    tokens[0] = exec_tok
-    rule_content = " ".join(tokens)
-    return f"command({rule_content})"
 
 
 # ==============================================================================
@@ -52,48 +97,80 @@ def translate_to_rule(pattern: str) -> str:
 
 
 class PermissionAdapter:
-    """Interface for agent-specific permission configuration."""
+    """Interface for agent-specific permission configuration.
 
-    def name(self) -> str:
-        raise NotImplementedError
+    Adapters store and translate rules; all CLI-facing input and output uses
+    "clean patterns" (e.g. "git show", "packagename uninstall") and each
+    adapter translates to and from its agent's native rule syntax.
+    """
 
-    def is_active(self, workspace_root: Path) -> bool:
+    name = "?"
+    # Mode used by 'apply' to guard unsafe subcommands: "ask" if the agent
+    # supports prompt-anyway rules, otherwise "deny".
+    guard_mode = "deny"
+
+    def is_available(self) -> bool:
+        """True if this agent appears to be in use on this machine."""
         return False
 
     def is_initialized(self, workspace_root: Path) -> bool:
         return False
 
-    def add(self, workspace_root: Path, pattern: str, is_deny: bool) -> None:
+    def add(self, workspace_root: Path, pattern: str, mode: str) -> bool:
+        """Adds a rule; returns True if newly added, False if already present."""
         raise NotImplementedError
 
-    def remove(self, workspace_root: Path, pattern: str) -> None:
+    def remove(self, workspace_root: Path, pattern: str) -> list[str]:
+        """Removes a pattern from all lists; returns the modes it was found in."""
         raise NotImplementedError
 
-    def list(self, workspace_root: Path) -> tuple[list[str], list[str]]:
-        """Returns a tuple of (allowlist_rules, denylist_rules)."""
-        return [], []
+    def rules(self, workspace_root: Path) -> dict[str, list[str]]:
+        """Returns {mode: [clean patterns]} for the workspace."""
+        return {}
 
     def clean(self, workspace_root: Path) -> None:
         raise NotImplementedError
 
 
 class AgyProjectAdapter(PermissionAdapter):
-    def name(self) -> str:
-        return "agy"
+    """Antigravity/jetski: per-project JSON under ~/.gemini, keyed by a
+    workspace-path cache. Supports allow and deny lists (no ask)."""
+
+    name = "agy"
+    guard_mode = "deny"
 
     def _get_cache_path(self) -> Path:
         # Mapped to the compiled binary's hardcoded caching location
-        return AGENT_CONFIG_HOME / "jetski/cli/cache/projects.json"
+        return AGY_CONFIG_HOME / "jetski/cli/cache/projects.json"
 
     def _get_projects_dir(self) -> Path:
-        return AGENT_CONFIG_HOME / "config/projects"
+        return AGY_CONFIG_HOME / "config/projects"
 
-    def is_active(self, workspace_root: Path) -> bool:
-        return self._get_cache_path().is_file()
+    def is_available(self) -> bool:
+        return AGY_CONFIG_HOME.is_dir()
 
     def is_initialized(self, workspace_root: Path) -> bool:
         project_file = self._get_project_file(workspace_root)
         return project_file is not None and project_file.is_file()
+
+    def translate(self, pattern: str) -> str:
+        tokens = pattern.strip().split()
+        if not tokens:
+            return ""
+        # Allow the executable to be invoked via any path prefix.
+        exec_tok = tokens[0]
+        if exec_tok != "*" and "/" not in exec_tok and not exec_tok.startswith("(?:"):
+            exec_tok = f"(?:.*/)?{exec_tok}"
+        tokens[0] = exec_tok
+        return f"command({' '.join(tokens)})"
+
+    def untranslate(self, rule: str) -> str:
+        inner = rule
+        if inner.startswith("command(") and inner.endswith(")"):
+            inner = inner[len("command(") : -1]
+        if inner.startswith("(?:.*/)?"):
+            inner = inner[len("(?:.*/)?") :]
+        return inner
 
     def _get_project_file(self, workspace_root: Path) -> Path | None:
         cache_path = self._get_cache_path()
@@ -114,7 +191,6 @@ class AgyProjectAdapter(PermissionAdapter):
         cache_path = self._get_cache_path()
         projects_dir = self._get_projects_dir()
 
-        # Ensure parent directories exist
         cache_path.parent.mkdir(parents=True, exist_ok=True)
 
         cache = {}
@@ -137,7 +213,6 @@ class AgyProjectAdapter(PermissionAdapter):
         with open(cache_path, "w", encoding="utf-8") as f:
             json.dump(cache, f, indent=2)
 
-        # Create the project file
         project_path = projects_dir / f"{project_id}.json"
         projects_dir.mkdir(parents=True, exist_ok=True)
         project_data = {
@@ -152,358 +227,639 @@ class AgyProjectAdapter(PermissionAdapter):
             json.dump(project_data, f, indent=2)
 
         print(
-            f"Initialized configuration file for {self.name()}: {workspace_root}",
+            f"[{self.name}] initialized project configuration for {workspace_root}",
             file=sys.stderr,
         )
         return project_path
 
-    def add(self, workspace_root: Path, pattern: str, is_deny: bool) -> None:
-        project_path = self._get_or_create_project_file(workspace_root)
-
-        rule = translate_to_rule(pattern)
-        if not rule:
-            return
-
+    def _load(self, project_path: Path) -> dict:
         try:
             with open(project_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
+                return json.load(f)
         except Exception as e:
-            print(
-                f"[{self.name()}] Error reading project config: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            die(f"[{self.name}] error reading {project_path}: {e}")
 
+    def _save(self, project_path: Path, data: dict) -> None:
+        try:
+            with open(project_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            die(f"[{self.name}] error writing {project_path}: {e}")
+
+    def _grants(self, data: dict) -> dict:
         grants_wrapper = data.setdefault("permissionGrants", {})
         grants = grants_wrapper.setdefault("permissionGrants", {})
         if grants.get("allow") is None:
             grants["allow"] = []
         if grants.get("deny") is None:
             grants["deny"] = []
+        return grants
 
-        target_list = grants["deny"] if is_deny else grants["allow"]
-        if rule not in target_list:
-            target_list.append(rule)
-
-        try:
-            with open(project_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-        except Exception as e:
+    def add(self, workspace_root: Path, pattern: str, mode: str) -> bool:
+        if mode == "ask":
             print(
-                f"[{self.name()}] Error writing project config: {e}",
+                f"[{self.name}] no 'ask' support; skipping: {pattern} "
+                "(use --deny to block outright)",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            return False
+        rule = self.translate(pattern)
+        if not rule:
+            return False
+        project_path = self._get_or_create_project_file(workspace_root)
+        data = self._load(project_path)
+        grants = self._grants(data)
+        target_list = grants["deny"] if mode == "deny" else grants["allow"]
+        if rule in target_list:
+            return False
+        target_list.append(rule)
+        self._save(project_path, data)
+        return True
 
-        list_name = "deny" if is_deny else "allow"
-        print(f"[{self.name()}] Added to {list_name}: {rule}", file=sys.stderr)
-
-    def remove(self, workspace_root: Path, pattern: str) -> None:
+    def remove(self, workspace_root: Path, pattern: str) -> list[str]:
         project_path = self._get_project_file(workspace_root)
         if not project_path or not project_path.is_file():
-            return
-
-        rule = translate_to_rule(pattern)
-        if not rule:
-            return
-
-        try:
-            with open(project_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception as e:
-            print(
-                f"[{self.name()}] Error reading project config: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        grants_wrapper = data.get("permissionGrants", {})
-        grants = grants_wrapper.get("permissionGrants", {})
-        if not grants:
-            return
-
-        removed = False
-        for list_name in ["allow", "deny"]:
+            return []
+        rule = self.translate(pattern)
+        data = self._load(project_path)
+        grants = self._grants(data)
+        removed = []
+        for list_name in ("allow", "deny"):
             lst = grants.get(list_name)
             if lst and rule in lst:
                 lst.remove(rule)
-                removed = True
-                print(
-                    f"[{self.name()}] Removed from {list_name}: {rule}",
-                    file=sys.stderr,
-                )
+                removed.append(list_name)
+        if removed:
+            self._save(project_path, data)
+        return removed
 
-        if not removed:
-            return
-
-        try:
-            with open(project_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-        except Exception as e:
-            print(
-                f"[{self.name()}] Error writing project config: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-    def list(self, workspace_root: Path) -> tuple[list[str], list[str]]:
+    def rules(self, workspace_root: Path) -> dict[str, list[str]]:
         project_path = self._get_project_file(workspace_root)
         if not project_path or not project_path.is_file():
-            return [], []
-
-        try:
-            with open(project_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception as e:
-            print(
-                f"[{self.name()}] Error reading project config: {e}",
-                file=sys.stderr,
-            )
-            return [], []
-
-        grants_wrapper = data.get("permissionGrants", {})
-        grants = grants_wrapper.get("permissionGrants", {})
-        if not grants:
-            return [], []
-
-        return grants.get("allow") or [], grants.get("deny") or []
+            return {}
+        data = self._load(project_path)
+        grants = self._grants(data)
+        return {
+            "allow": [self.untranslate(r) for r in grants.get("allow") or []],
+            "deny": [self.untranslate(r) for r in grants.get("deny") or []],
+        }
 
     def clean(self, workspace_root: Path) -> None:
         project_path = self._get_project_file(workspace_root)
         if not project_path or not project_path.is_file():
             return
+        data = self._load(project_path)
+        grants = self._grants(data)
+        grants["allow"] = []
+        grants["deny"] = []
+        self._save(project_path, data)
+        print(f"[{self.name}] cleared all permission rules", file=sys.stderr)
 
+
+class ClaudeSettingsAdapter(PermissionAdapter):
+    """Claude Code: permissions.allow/deny/ask Bash() rules in the
+    workspace's .claude/settings.local.json (personal, never tracked)."""
+
+    name = "claude"
+    guard_mode = "ask"
+
+    def _settings_path(self, workspace_root: Path) -> Path:
+        return workspace_root / ".claude" / "settings.local.json"
+
+    def is_available(self) -> bool:
+        return CLAUDE_CONFIG_DIR.is_dir()
+
+    def is_initialized(self, workspace_root: Path) -> bool:
+        return self._settings_path(workspace_root).is_file()
+
+    def translate(self, pattern: str) -> str:
+        return f"Bash({pattern.strip()}:*)"
+
+    def untranslate(self, rule: str) -> str:
+        inner = rule
+        if inner.startswith("Bash(") and inner.endswith(")"):
+            inner = inner[len("Bash(") : -1]
+        if inner.endswith(":*"):
+            inner = inner[: -len(":*")]
+        return inner
+
+    def _ensure_ignored(self, workspace_root: Path) -> None:
+        """Keeps settings.local.json out of 'git status' via info/exclude."""
+        rel = ".claude/settings.local.json"
+        res = subprocess.run(
+            ["git", "-C", str(workspace_root), "check-ignore", "-q", rel],
+            capture_output=True,
+        )
+        if res.returncode == 0:  # already ignored
+            return
+        if res.returncode != 1:  # not a git repository
+            return
         try:
-            with open(project_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            res_ex = subprocess.run(
+                ["git", "-C", str(workspace_root), "rev-parse", "--git-path", "info/exclude"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            exclude_file = (workspace_root / res_ex.stdout.strip()).resolve()
+            exclude_file.parent.mkdir(parents=True, exist_ok=True)
+            existing = ""
+            if exclude_file.is_file():
+                existing = exclude_file.read_text(encoding="utf-8", errors="replace")
+            with open(exclude_file, "a", encoding="utf-8") as f:
+                if existing and not existing.endswith("\n"):
+                    f.write("\n")
+                f.write(f"# added by 'permission' to keep local agent settings untracked\n/{rel}\n")
         except Exception as e:
             print(
-                f"[{self.name()}] Error reading project config: {e}",
+                f"[{self.name}] warning: could not update info/exclude: {e}",
                 file=sys.stderr,
             )
-            sys.exit(1)
 
-        grants_wrapper = data.get("permissionGrants", {})
-        grants = grants_wrapper.get("permissionGrants", {})
-        if grants:
-            grants["allow"] = []
-            grants["deny"] = []
+    def _load(self, settings_path: Path) -> dict:
+        if not settings_path.is_file():
+            return {}
+        try:
+            with open(settings_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:
+            die(f"[{self.name}] error reading {settings_path}: {e}")
 
-            try:
-                with open(project_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, indent=2)
-            except Exception as e:
-                print(
-                    f"[{self.name()}] Error writing project config: {e}",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+    def _save(self, workspace_root: Path, data: dict) -> None:
+        settings_path = self._settings_path(workspace_root)
+        created = not settings_path.is_file()
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(settings_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+                f.write("\n")
+        except Exception as e:
+            die(f"[{self.name}] error writing {settings_path}: {e}")
+        if created:
+            print(
+                f"[{self.name}] initialized {settings_path}",
+                file=sys.stderr,
+            )
+        self._ensure_ignored(workspace_root)
 
-        print(f"[{self.name()}] Cleared all permission rules.", file=sys.stderr)
+    def add(self, workspace_root: Path, pattern: str, mode: str) -> bool:
+        rule = self.translate(pattern)
+        data = self._load(self._settings_path(workspace_root))
+        perms = data.setdefault("permissions", {})
+        target_list = perms.setdefault(mode, [])
+        if rule in target_list:
+            return False
+        target_list.append(rule)
+        self._save(workspace_root, data)
+        return True
+
+    def remove(self, workspace_root: Path, pattern: str) -> list[str]:
+        settings_path = self._settings_path(workspace_root)
+        if not settings_path.is_file():
+            return []
+        rule = self.translate(pattern)
+        data = self._load(settings_path)
+        perms = data.get("permissions", {})
+        removed = []
+        for mode in MODES:
+            lst = perms.get(mode)
+            if lst and rule in lst:
+                lst.remove(rule)
+                removed.append(mode)
+        if removed:
+            self._save(workspace_root, data)
+        return removed
+
+    def rules(self, workspace_root: Path) -> dict[str, list[str]]:
+        settings_path = self._settings_path(workspace_root)
+        if not settings_path.is_file():
+            return {}
+        data = self._load(settings_path)
+        perms = data.get("permissions", {})
+        return {
+            mode: [self.untranslate(r) for r in perms.get(mode) or []]
+            for mode in MODES
+        }
+
+    def clean(self, workspace_root: Path) -> None:
+        settings_path = self._settings_path(workspace_root)
+        if not settings_path.is_file():
+            return
+        data = self._load(settings_path)
+        perms = data.get("permissions")
+        if perms:
+            for mode in MODES:
+                perms[mode] = []
+            self._save(workspace_root, data)
+        print(f"[{self.name}] cleared all permission rules", file=sys.stderr)
 
 
-# Registry of all available adapters
 ADAPTERS: list[PermissionAdapter] = [
     AgyProjectAdapter(),
+    ClaudeSettingsAdapter(),
 ]
 
 
-class CustomArgumentParser(argparse.ArgumentParser):
-    def error(self, message):
-        print(f"permission: error: {message}", file=sys.stderr)
-        # Suggest help based on command
-        cmd = None
-        if len(sys.argv) > 1 and sys.argv[1] not in ("-h", "--help", "help"):
-            cmd = sys.argv[1]
-        
-        if cmd in ("add", "remove", "rm", "list", "ls", "clean"):
-            print(f"Try 'permission {cmd} --help' for more information.", file=sys.stderr)
-        else:
-            print("Try 'permission --help' for more information.", file=sys.stderr)
-        sys.exit(2)
+def select_adapters(agent: str | None) -> list[PermissionAdapter]:
+    """Returns the adapters to operate on: the one named by --agent, or every
+    adapter whose agent appears to be in use. May be empty; commands that
+    cannot proceed without one should call require_adapters instead."""
+    if agent:
+        matches = [a for a in ADAPTERS if a.name == agent]
+        if not matches:
+            names = ", ".join(a.name for a in ADAPTERS)
+            die(f"unknown agent '{agent}' (expected one of: {names})")
+        return matches
+    return [a for a in ADAPTERS if a.is_available()]
 
 
-def print_main_help():
-    print(
-        """Usage: permission <command> [arguments]
+def require_adapters(agent: str | None) -> list[PermissionAdapter]:
+    adapters = select_adapters(agent)
+    if not adapters:
+        die(
+            "no supported agent configuration found "
+            f"(looked for {AGY_CONFIG_HOME} and {CLAUDE_CONFIG_DIR}); "
+            "use --agent to force one"
+        )
+    return adapters
 
-Manage workspace-specific agent permissions.
+
+# ==============================================================================
+# Safe-command computation ('apply' / 'doctor')
+# ==============================================================================
+
+
+def parse_unsafe_file(skill_dir: Path) -> list[str]:
+    unsafe_file = skill_dir / "permissions" / "unsafe"
+    if not unsafe_file.is_file():
+        return []
+    lines = []
+    with open(unsafe_file, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                lines.append(line)
+    return lines
+
+
+def compute_skill_rules(name: str, skill_dir: Path) -> tuple[list[str], list[str]]:
+    """Returns (allow, guard) clean patterns for one skill.
+
+    Every executable in the skill's scripts/ directory is pre-approved unless
+    listed in the skill's permissions/unsafe file. Whole-script unsafe lines
+    suppress the allow rule (the command prompts normally); subcommand lines
+    keep the blanket allow but add a guard rule (ask or deny, per agent).
+    """
+    scripts_dir = skill_dir / "scripts"
+    if not scripts_dir.is_dir():
+        return [], []
+    scripts = sorted(
+        p.name
+        for p in scripts_dir.iterdir()
+        if p.is_file() and not p.name.startswith(".") and os.access(p, os.X_OK)
+    )
+    unsafe = parse_unsafe_file(skill_dir)
+
+    unsafe_whole = {line for line in unsafe if " " not in line}
+    for line in unsafe:
+        base = line.split()[0]
+        if base not in scripts:
+            print(
+                f"permission: warning: {name}: unsafe entry '{line}' does not "
+                f"match any script in {scripts_dir}",
+                file=sys.stderr,
+            )
+
+    allow = [s for s in scripts if s not in unsafe_whole]
+    guard = [line for line in unsafe if " " in line]
+    return allow, guard
+
+
+def compute_workspace_rules() -> tuple[list[str], list[str]]:
+    """Aggregates (allow, guard) patterns over all installed skills."""
+    res = subprocess.run(
+        [SKILL_BIN, "list", "--json"], capture_output=True, text=True
+    )
+    if res.returncode != 0:
+        print(res.stderr, file=sys.stderr, end="")
+        die("'skill list' failed")
+    try:
+        entries = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError as e:
+        die(f"could not parse 'skill list --json' output: {e}")
+
+    allow: list[str] = []
+    guard: list[str] = []
+    for entry in entries:
+        name = entry.get("name")
+        path = entry.get("path")
+        if not path:
+            print(
+                f"permission: warning: skipping {name}: not linked "
+                "(run 'skill repair')",
+                file=sys.stderr,
+            )
+            continue
+        a, g = compute_skill_rules(name, Path(path))
+        allow.extend(a)
+        guard.extend(g)
+    return sorted(set(allow)), sorted(set(guard))
+
+
+def cmd_apply(agent: str | None):
+    adapters = select_adapters(agent)
+    if not adapters:
+        print("apply: no supported agents detected; nothing to do", file=sys.stderr)
+        return
+    ws = get_workspace_root()
+    allow, guard = compute_workspace_rules()
+    if not allow and not guard:
+        print(
+            "apply: no installed skills declare any commands "
+            "(run 'skill apply' to install skills first)",
+            file=sys.stderr,
+        )
+        return
+
+    for adapter in adapters:
+        added_allow = sum(adapter.add(ws, p, "allow") for p in allow)
+        added_guard = sum(adapter.add(ws, p, adapter.guard_mode) for p in guard)
+        print(
+            f"[{adapter.name}] allow: {added_allow} added, "
+            f"{len(allow) - added_allow} already present; "
+            f"{adapter.guard_mode}: {added_guard} added",
+            file=sys.stderr,
+        )
+
+
+def cmd_doctor(agent: str | None):
+    adapters = select_adapters(agent)
+    if not adapters:
+        return
+    ws = get_workspace_root()
+    allow, guard = compute_workspace_rules()
+    issues = []
+    for adapter in adapters:
+        current = adapter.rules(ws)
+        current_allow = set(current.get("allow") or [])
+        guarded = set(current.get("deny") or []) | set(current.get("ask") or [])
+        missing_allow = [p for p in allow if p not in current_allow]
+        missing_guard = [p for p in guard if p not in guarded]
+        if not adapter.is_initialized(ws) and (allow or guard):
+            issues.append(f"  [{adapter.name}] not initialized for this workspace")
+        for p in missing_allow:
+            issues.append(f"  [{adapter.name}] missing allow: {p}")
+        for p in missing_guard:
+            issues.append(f"  [{adapter.name}] missing {adapter.guard_mode}: {p}")
+
+    if issues:
+        print("Workspace Permissions:", file=sys.stderr)
+        for line in issues:
+            print(line, file=sys.stderr)
+        print("\n  hint: run 'permission apply'\n", file=sys.stderr)
+        sys.exit(1)
+
+
+# ==============================================================================
+# CLI
+# ==============================================================================
+
+
+def read_patterns(args: list[str]) -> list[str]:
+    if args == ["-"]:
+        return [line.strip() for line in sys.stdin if line.strip()]
+    return args
+
+
+def cmd_add(patterns: list[str], mode: str, agent: str | None):
+    if not patterns:
+        print("permission add: pattern required", file=sys.stderr)
+        print("Try 'permission add --help' for more information.", file=sys.stderr)
+        sys.exit(1)
+    ws = get_workspace_root()
+    for adapter in require_adapters(agent):
+        for pattern in patterns:
+            if adapter.add(ws, pattern, mode):
+                print(f"[{adapter.name}] added to {mode}: {pattern}", file=sys.stderr)
+            else:
+                print(
+                    f"[{adapter.name}] already in {mode} (or unsupported): {pattern}",
+                    file=sys.stderr,
+                )
+
+
+def cmd_remove(patterns: list[str], agent: str | None):
+    if not patterns:
+        print("permission remove: pattern required", file=sys.stderr)
+        print("Try 'permission remove --help' for more information.", file=sys.stderr)
+        sys.exit(1)
+    ws = get_workspace_root()
+    for adapter in require_adapters(agent):
+        if not adapter.is_initialized(ws):
+            continue
+        for pattern in patterns:
+            removed = adapter.remove(ws, pattern)
+            for mode in removed:
+                print(
+                    f"[{adapter.name}] removed from {mode}: {pattern}",
+                    file=sys.stderr,
+                )
+            if not removed:
+                print(f"[{adapter.name}] not found: {pattern}", file=sys.stderr)
+
+
+def cmd_list(agent: str | None):
+    ws = get_workspace_root()
+    has_any = False
+    for adapter in select_adapters(agent):
+        if not adapter.is_initialized(ws):
+            continue
+        rules = adapter.rules(ws)
+        if not any(rules.get(m) for m in MODES):
+            continue
+        print(f"[{adapter.name}]")
+        for mode in MODES:
+            patterns = rules.get(mode)
+            if patterns:
+                print(f"  {mode}:")
+                for p in patterns:
+                    print(f"    {p}")
+        has_any = True
+    if not has_any:
+        print("No permission rules configured.", file=sys.stderr)
+
+
+def cmd_clean(agent: str | None):
+    ws = get_workspace_root()
+    cleaned = False
+    for adapter in select_adapters(agent):
+        if adapter.is_initialized(ws):
+            adapter.clean(ws)
+            cleaned = True
+    if not cleaned:
+        print("clean: nothing to do", file=sys.stderr)
+
+
+HELP_MAIN = """Usage: permission <command> [arguments]
+
+Manage per-workspace agent tool permissions (allow/deny/ask rules) across
+all detected local agents. Rules are written as clean command patterns
+(e.g. "git show"); each agent backend translates to its native syntax.
 
 Commands:
-  add             Add a tool permission rule
-  remove          Remove a tool permission rule (alias: rm)
-  list            List permission rules (alias: ls)
-  clean           Clear all workspace-specific permission rules
+  add PATTERN...     Add rule patterns to the allowlist (--deny / --ask
+                     for the other lists); 'add -' reads patterns from stdin
+  remove PATTERN...  Remove rule patterns from all lists (alias: rm)
+  list               List permission rules per agent (alias: ls)
+  apply              Pre-approve the safe commands declared by this
+                     workspace's installed skills (idempotent)
+  clean              Clear all workspace-specific permission rules
+  doctor             Report missing or drifted rules (read-only)
 
 Options:
-  --help          Display this help message and exit"""
-    )
-    sys.exit(0)
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit
 
+Agents:
+  agy                Antigravity/jetski project config (under ~/.gemini)
+  claude             Claude Code (.claude/settings.local.json, untracked)"""
 
-def print_add_help():
-    print(
-        """Usage: permission add [options] <pattern>
+HELP_ADD = """Usage: permission add [options] PATTERN...
 
-Add a tool permission rule.
-
-Arguments:
-  <pattern>       Clean pattern of the tool/command (e.g. "git commit", "cat")
-
-Options:
-  --deny          Add to the denylist instead of the allowlist
-  --help          Display this help message and exit"""
-    )
-    sys.exit(0)
-
-
-def print_remove_help():
-    print(
-        """Usage: permission remove <pattern>
-
-Remove a tool permission rule.
-
-Arguments:
-  <pattern>       Clean pattern of the tool/command to remove (alias: rm)
+Add tool permission rules. PATTERN is a clean command pattern such as
+"git show" or "packagename uninstall"; each agent backend translates it
+to its native rule syntax. Use 'add -' to read one pattern per line
+from stdin.
 
 Options:
-  --help          Display this help message and exit"""
-    )
-    sys.exit(0)
+  --deny             Add to the denylist (blocked) instead of the allowlist
+  --ask              Add to the ask list (always prompt); Claude Code only
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
 
+HELP_REMOVE = """Usage: permission remove PATTERN...
 
-def print_list_help():
-    print(
-        """Usage: permission list
-
-List permission rules (alias: ls)
+Remove tool permission rules from all lists (alias: rm).
 
 Options:
-  --help          Display this help message and exit"""
-    )
-    sys.exit(0)
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
 
+HELP_LIST = """Usage: permission list
 
-def print_clean_help():
-    print(
-        """Usage: permission clean
-
-Clear all workspace-specific permission rules
+List permission rules per agent (alias: ls).
 
 Options:
-  --help          Display this help message and exit"""
-    )
-    sys.exit(0)
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
+
+HELP_APPLY = """Usage: permission apply
+
+Pre-approve the safe commands declared by this workspace's installed
+skills (idempotent). Every executable in an installed skill's scripts/
+directory is allowed, except entries in the skill's permissions/unsafe
+file: whole-script entries are skipped entirely (they prompt normally),
+and subcommand entries (e.g. "packagename uninstall") are guarded with
+an 'ask' rule on Claude Code and a 'deny' rule on agy.
+
+Options:
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
+
+HELP_CLEAN = """Usage: permission clean
+
+Clear all workspace-specific permission rules.
+
+Options:
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
+
+HELP_DOCTOR = """Usage: permission doctor
+
+Compare each agent's current rules against what 'permission apply' would
+configure and report anything missing (read-only). Exits non-zero if
+problems are found.
+
+Options:
+  --agent NAME       Operate on a single agent backend (agy, claude)
+  --help             Display this help message and exit"""
+
+SUBCOMMAND_HELP = {
+    "add": HELP_ADD,
+    "remove": HELP_REMOVE,
+    "rm": HELP_REMOVE,
+    "list": HELP_LIST,
+    "ls": HELP_LIST,
+    "apply": HELP_APPLY,
+    "clean": HELP_CLEAN,
+    "doctor": HELP_DOCTOR,
+}
+
+
+def usage_error(cmd, msg):
+    prog = "permission" + (f" {cmd}" if cmd else "")
+    print(f"permission: error: {msg}", file=sys.stderr)
+    print(f"Try '{prog} --help' for more information.", file=sys.stderr)
+    sys.exit(2)
 
 
 def main():
-    # Determine if help is requested anywhere
-    is_help = False
-    help_cmd = None
+    argv = sys.argv[1:]
 
-    if len(sys.argv) < 2:
-        is_help = True
-    elif sys.argv[1] in ("--help", "help"):
-        is_help = True
-        if len(sys.argv) > 2:
-            help_cmd = sys.argv[2]
-    else:
-        # Check if subcommand has --help or help
-        for arg in sys.argv[2:]:
-            if arg in ("--help", "help"):
-                is_help = True
-                help_cmd = sys.argv[1]
-                break
+    # Help handling: bare invocation, 'help [cmd]', '--help' anywhere.
+    if not argv or argv[0] in ("--help", "help"):
+        topic = argv[1] if len(argv) > 1 else None
+        print(SUBCOMMAND_HELP.get(topic, HELP_MAIN))
+        sys.exit(0)
 
-    if is_help:
-        if help_cmd == "add":
-            print_add_help()
-        elif help_cmd in ("remove", "rm"):
-            print_remove_help()
-        elif help_cmd in ("list", "ls"):
-            print_list_help()
-        elif help_cmd == "clean":
-            print_clean_help()
+    cmd = argv[0]
+    args = argv[1:]
+    if "--help" in args or "help" in args:
+        print(SUBCOMMAND_HELP.get(cmd, HELP_MAIN))
+        sys.exit(0)
+
+    if cmd not in ("add", "remove", "rm", "list", "ls", "apply", "clean", "doctor"):
+        usage_error(None, f"unknown command '{cmd}'")
+
+    # Parse options shared by all subcommands.
+    mode = "allow"
+    agent = None
+    patterns = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--deny" and cmd == "add":
+            mode = "deny"
+        elif arg == "--ask" and cmd == "add":
+            mode = "ask"
+        elif arg == "--agent":
+            if i + 1 >= len(args):
+                usage_error(cmd, "--agent requires a value")
+            agent = args[i + 1]
+            i += 1
+        elif arg.startswith("--agent="):
+            agent = arg.split("=", 1)[1]
+        elif arg.startswith("-") and arg != "-":
+            usage_error(cmd, f"unrecognized option '{arg}'")
         else:
-            print_main_help()
+            patterns.append(arg)
+        i += 1
 
-    parser = CustomArgumentParser(add_help=False)
-    subparsers = parser.add_subparsers(dest="command")
+    if cmd in ("list", "ls", "apply", "clean", "doctor") and patterns:
+        usage_error(cmd, f"unexpected argument '{patterns[0]}'")
 
-    add_parser = subparsers.add_parser("add", add_help=False)
-    add_parser.add_argument("pattern")
-    add_parser.add_argument("--deny", action="store_true")
-
-    remove_parser = subparsers.add_parser("remove", aliases=["rm"], add_help=False)
-    remove_parser.add_argument("pattern")
-
-    subparsers.add_parser("list", aliases=["ls"], add_help=False)
-    subparsers.add_parser("clean", add_help=False)
-
-    args = parser.parse_args()
-
-    ws = get_workspace_root()
-
-    # Determine initialized and active adapters
-    initialized_adapters = [a for a in ADAPTERS if a.is_initialized(ws)]
-
-    if args.command == "add":
-        # If no configurations are active/initialized, we bootstrap Agy (default)
-        if not initialized_adapters:
-            # Check if any is active globally
-            active_globally = [a for a in ADAPTERS if a.is_active(ws)]
-            if active_globally:
-                target_adapters = active_globally
-            else:
-                target_adapters = [AgyProjectAdapter()]
-        else:
-            target_adapters = initialized_adapters
-
-        for a in target_adapters:
-            a.add(ws, args.pattern, args.deny)
-
-    elif args.command in ("remove", "rm"):
-        if not initialized_adapters:
-            print(
-                "Error: Workspace not initialized. Run 'permission add' to configure first.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        for a in initialized_adapters:
-            a.remove(ws, args.pattern)
-
-    elif args.command in ("list", "ls"):
-        if not initialized_adapters:
-            print("Workspace not initialized. Run 'permission add' to configure first.")
-            return
-
-        has_any = False
-        for a in initialized_adapters:
-            allows, denies = a.list(ws)
-            if allows or denies:
-                print(f"[{a.name()}]")
-                if allows:
-                    print("  Allow:")
-                    for rule in allows:
-                        print(f"    - {rule}")
-                if denies:
-                    print("  Deny:")
-                    for rule in denies:
-                        print(f"    - {rule}")
-                has_any = True
-
-        if not has_any:
-            print("No permission rules configured.")
-
-    elif args.command == "clean":
-        if not initialized_adapters:
-            print(
-                "Error: Workspace not initialized. Run 'permission add' to configure first.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        for a in initialized_adapters:
-            a.clean(ws)
+    if cmd == "add":
+        cmd_add(read_patterns(patterns), mode, agent)
+    elif cmd in ("remove", "rm"):
+        cmd_remove(read_patterns(patterns), agent)
+    elif cmd in ("list", "ls"):
+        cmd_list(agent)
+    elif cmd == "apply":
+        cmd_apply(agent)
+    elif cmd == "clean":
+        cmd_clean(agent)
+    elif cmd == "doctor":
+        cmd_doctor(agent)
 
 
 if __name__ == "__main__":

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -2,7 +2,9 @@
 # /// script
 # requires-python = ">=3.11"
 # ///
+# Tests: tests/skill/
 
+import json
 import os
 import sys
 import tempfile
@@ -20,6 +22,14 @@ def die(msg):
 def cmderr(cmd, msg):
     print(f"skill {cmd}: {msg}", file=sys.stderr)
     sys.exit(1)
+
+
+def clean_p(p):
+    home = str(Path.home())
+    s = str(p)
+    if s.startswith(home):
+        return "~" + s[len(home) :]
+    return s
 
 
 def prune_dirs(dest_dirs):
@@ -59,16 +69,53 @@ class Workspace:
 
     def check_conflict(self, relpath: Path) -> str | None:
         """Returns an error message if there is a conflict, else None."""
-        raise NotImplementedError
+        if relpath.exists() and not relpath.is_symlink():
+            return f"{relpath} exists and is not a symlink; refusing to overwrite"
+        return None
 
     def get_analyze_dir(self) -> Path:
         return self.root
 
+    def doctor_issues(self) -> list[str]:
+        """Returns backend-specific drift findings (read-only)."""
+        return []
 
-class GitWorkspace(Workspace):
-    def __init__(self, root, exclude_file):
+
+class FileStateMixin:
+    """Stores the managed-skill list as one name per line in self.state_file."""
+
+    def get_managed_skills(self):
+        if not self.state_file.is_file():
+            return []
+        with open(self.state_file, "r", encoding="utf-8", errors="replace") as f:
+            return sorted({line.strip() for line in f if line.strip()})
+
+    def save_managed_skills(self, skills):
+        skills = sorted(set(skills))
+        if not skills:
+            if self.state_file.is_file():
+                self.state_file.unlink()
+            return
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.state_file, "w", encoding="utf-8") as f:
+            for item in skills:
+                f.write(item + "\n")
+
+
+class GitWorkspace(FileStateMixin, Workspace):
+    """Git repositories.
+
+    The authoritative managed-skill list lives in .git/info/skills (inside the
+    git dir, so it can never be tracked or collide with other tools). The
+    marker block in .git/info/exclude is a regenerated artifact that only
+    keeps 'git status' clean; if another tool rewrites the exclude file, no
+    state is lost and 'skill repair' restores the block.
+    """
+
+    def __init__(self, root, exclude_file, state_file):
         super().__init__(root)
         self.exclude_file = exclude_file
+        self.state_file = state_file
         self.mark_begin = "# >>> skills (managed by 'skill') >>>"
         self.mark_end = "# <<< skills (managed by 'skill') <<<"
         self.legacy_mark_begin = "# >>> skills (managed by 'git-skill') >>>"
@@ -77,7 +124,6 @@ class GitWorkspace(Workspace):
     @classmethod
     def detect(cls):
         try:
-            # Check if we are inside a git repo and get the top-level
             res = subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
                 capture_output=True,
@@ -85,15 +131,17 @@ class GitWorkspace(Workspace):
                 check=True,
             )
             root = Path(res.stdout.strip())
-            # Get the path to the exclude file
-            res_ex = subprocess.run(
-                ["git", "rev-parse", "--git-path", "info/exclude"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            exclude_path = Path(res_ex.stdout.strip()).resolve()
-            return cls(root, exclude_path)
+
+            def git_path(rel):
+                r = subprocess.run(
+                    ["git", "rev-parse", "--git-path", rel],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                return Path(r.stdout.strip()).resolve()
+
+            return cls(root, git_path("info/exclude"), git_path("info/skills"))
         except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 
@@ -115,18 +163,11 @@ class GitWorkspace(Workspace):
                     managed.append(line_stripped)
         return managed if (in_block or managed) else None
 
-    def get_managed_skills(self):
-        # Try new marker first, then fallback to legacy git-skill marker
-        managed = self._read_block(self.mark_begin, self.mark_end)
-        if managed is None:
-            managed = self._read_block(self.legacy_mark_begin, self.legacy_mark_end)
-        if managed is None:
-            return []
-
-        # Git exclude stores paths like "/.agents/skills/name". Extract the name.
+    def _names_from_exclude_lines(self, lines):
+        # Exclude lines look like "/.agents/skills/name". Extract the name.
         skills = set()
         dest_dirs = self.get_dest_dirs()
-        for line in managed:
+        for line in lines:
             rel = line.lstrip("/")
             for d in dest_dirs:
                 try:
@@ -136,19 +177,32 @@ class GitWorkspace(Workspace):
                 except ValueError:
                     # d is not relative to root (e.g. if SKILL_DEST_DIRS was customized with absolute paths)
                     pass
-        return sorted(list(skills))
+        return sorted(skills)
 
-    def save_managed_skills(self, skills):
-        dest_dirs = self.get_dest_dirs()
-        lines = []
+    def get_managed_skills(self):
+        if self.state_file.is_file():
+            return super().get_managed_skills()
+        # Legacy layout: the managed list used to live only in the exclude
+        # block. Parse it once; the next save migrates it to the state file.
+        lines = self._read_block(self.mark_begin, self.mark_end)
+        if lines is None:
+            lines = self._read_block(self.legacy_mark_begin, self.legacy_mark_end)
+        if lines is None:
+            return []
+        return self._names_from_exclude_lines(lines)
+
+    def _expected_exclude_lines(self, skills):
+        lines = set()
         for name in skills:
-            for d in dest_dirs:
+            for d in self.get_dest_dirs():
                 try:
-                    lines.append(f"/{d.relative_to(self.root)}/{name}")
+                    lines.add(f"/{d.relative_to(self.root)}/{name}")
                 except ValueError:
                     # Fallback if dest_dirs are not relative to root
-                    lines.append(f"/{d.name}/{name}")
+                    lines.add(f"/{d.name}/{name}")
+        return sorted(lines)
 
+    def _write_exclude_block(self, skills):
         self.exclude_file.parent.mkdir(parents=True, exist_ok=True)
         other_lines = []
         if self.exclude_file.is_file():
@@ -175,7 +229,7 @@ class GitWorkspace(Workspace):
                     f.write("\n")
                 if skills:  # Only write block if there are skills
                     f.write(self.mark_begin + "\n")
-                    for line in sorted(list(set(lines))):
+                    for line in self._expected_exclude_lines(skills):
                         f.write(line + "\n")
                     f.write(self.mark_end + "\n")
 
@@ -184,6 +238,11 @@ class GitWorkspace(Workspace):
                     dest.write(src.read())
         finally:
             temp_path.unlink(missing_ok=True)
+
+    def save_managed_skills(self, skills):
+        skills = sorted(set(skills))
+        super().save_managed_skills(skills)
+        self._write_exclude_block(skills)
 
     def check_conflict(self, relpath):
         try:
@@ -200,42 +259,34 @@ class GitWorkspace(Workspace):
             pass
         return None
 
-
-class P4Workspace(Workspace):
-    def __init__(self, root, username):
-        super().__init__(root)
-        self.username = username
-        self._init_paths()
-
-    def _init_paths(self):
-        # Search for a directory at the client root that contains a Bazel-style WORKSPACE file.
-        self.repo_dir = None
-        for path in self.root.iterdir():
-            if path.is_dir() and not path.name.startswith("."):
-                if (path / "WORKSPACE").is_file() or (
-                    path / "WORKSPACE.bazel"
-                ).is_file():
-                    self.repo_dir = path
-                    break
-
-        configs_dir = self.root / "configs"
-        if self.repo_dir and configs_dir.is_dir():
-            # Personal config layout convention (centralized)
-            self.state_file = (
-                self.root
-                / "configs"
-                / "users"
-                / self.username
-                / "_agents"
-                / ".p4-skills-managed"
+    def doctor_issues(self):
+        issues = []
+        skills = self.get_managed_skills()
+        if skills and not self.state_file.is_file():
+            issues.append(
+                f"legacy state  managed list still lives in {clean_p(self.exclude_file)} "
+                f"(migrates to {clean_p(self.state_file)} on the next change)"
             )
-            self.analyze_dir = self.repo_dir
-            self.is_personal = True
-        else:
-            # Standard Perforce convention (local, mirroring git-skill)
-            self.state_file = self.root / ".p4-skills-managed"
-            self.analyze_dir = self.root
-            self.is_personal = False
+        actual = self._read_block(self.mark_begin, self.mark_end) or []
+        if self._read_block(self.legacy_mark_begin, self.legacy_mark_end) is not None:
+            issues.append(f"legacy block  'git-skill' markers in {clean_p(self.exclude_file)}")
+        if self.state_file.is_file() and sorted(set(actual)) != self._expected_exclude_lines(skills):
+            issues.append(
+                f"exclude drift {clean_p(self.exclude_file)} block does not match the managed list"
+            )
+        return issues
+
+
+class P4Workspace(FileStateMixin, Workspace):
+    """Standard Perforce client workspaces.
+
+    Untracked files are invisible to Perforce unless reconciled, so skills
+    are tracked in a .p4-skills-managed file at the client root.
+    """
+
+    def __init__(self, root):
+        super().__init__(root)
+        self.state_file = self.root / ".p4-skills-managed"
 
     @classmethod
     def detect(cls):
@@ -243,173 +294,98 @@ class P4Workspace(Workspace):
             res = subprocess.run(
                 ["p4", "info"], capture_output=True, text=True, check=True
             )
-            client_root = None
-            username = None
-            for line in res.stdout.splitlines():
-                if line.startswith("Client root:"):
-                    client_root = Path(line.split(":", 1)[1].strip())
-                elif line.startswith("User name:"):
-                    username = line.split(":", 1)[1].strip()
-            if client_root and username:
-                return cls(client_root, username)
         except (subprocess.CalledProcessError, FileNotFoundError):
             return None
-        return None
-
-    def get_dest_dirs(self) -> list[Path]:
-        # Always place skills inside the writable repository directory (under dot-directories)
-        # so they are ignored by Perforce but discovered by the agent.
-        base = self.repo_dir if self.repo_dir else self.root
-        return [base / ".agents" / "skills"]
-
-    def get_managed_skills(self):
-        if not self.state_file.is_file():
-            return []
-        with open(self.state_file, "r", encoding="utf-8", errors="replace") as f:
-            return sorted([line.strip() for line in f if line.strip()])
-
-    def save_managed_skills(self, skills):
-        if not skills:
-            if self.state_file.is_file():
-                self.state_file.unlink()
-            return
-        self.state_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.state_file, "w", encoding="utf-8") as f:
-            for item in sorted(list(set(skills))):
-                f.write(item + "\n")
-
-    def check_conflict(self, relpath):
-        if relpath.exists() and not relpath.is_symlink():
-            return f"{relpath} exists and is not a symlink; refusing to overwrite"
-        return None
-
-    def get_analyze_dir(self):
-        return (
-            self.repo_dir if (self.is_personal and self.repo_dir) else self.analyze_dir
-        )
-
-
-class VfsWorkspace(Workspace):
-    """Support for virtual/mapped workspaces."""
-
-    def __init__(self, root, vfs_root):
-        super().__init__(root)
-        self.vfs_root = vfs_root
-        self.state_file = self.root / ".skills-managed"
-
-    @classmethod
-    def detect(cls):
-        curr = Path.cwd()
-        vfs_root = None
-        # Walk up to find the metadata directory
-        for p in [curr] + list(curr.parents):
-            if (p / ".citc").is_dir():
-                vfs_root = p
-                break
-
-        if not vfs_root:
+        client_root = None
+        for line in res.stdout.splitlines():
+            if line.startswith("Client root:"):
+                client_root = Path(line.split(":", 1)[1].strip())
+        if not client_root:
             return None
-
-        # Verify workspace type by checking manifest metadata
-        manifest_path = vfs_root / ".citc" / "manifest.ascii"
-        if not manifest_path.is_file():
-            return None
-
-        is_matched = False
+        # 'p4 info' succeeds with a default client from anywhere; only claim
+        # the workspace when the current directory is actually inside it.
         try:
-            with open(manifest_path, "r", encoding="utf-8", errors="replace") as f:
-                # Read first few KB to find markers
-                content = f.read(4096)
-                if "cog.use_jj" in content or "devtools_srcfs" in content:
-                    is_matched = True
-        except Exception:
-            pass
-
-        if not is_matched:
+            Path.cwd().resolve().relative_to(client_root.resolve())
+        except (ValueError, OSError):
             return None
-
-        # Find the repository root.
-        # Typically there is one main directory that is not hidden (e.g., 'android').
-        repo_dir = None
-        try:
-            for path in vfs_root.iterdir():
-                if path.is_dir() and not path.name.startswith("."):
-                    repo_dir = path
-                    break
-        except Exception:
-            pass
-
-        if not repo_dir:
-            repo_dir = vfs_root
-
-        return cls(repo_dir, vfs_root)
-
-    def get_managed_skills(self):
-        if not self.state_file.is_file():
-            return []
-        with open(self.state_file, "r", encoding="utf-8", errors="replace") as f:
-            return sorted([line.strip() for line in f if line.strip()])
-
-    def save_managed_skills(self, skills):
-        if not skills:
-            if self.state_file.is_file():
-                self.state_file.unlink()
-            return
-        self.state_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.state_file, "w", encoding="utf-8") as f:
-            for item in sorted(list(set(skills))):
-                f.write(item + "\n")
-
-    def check_conflict(self, relpath):
-        if relpath.exists() and not relpath.is_symlink():
-            return f"{relpath} exists and is not a symlink; refusing to overwrite"
-        return None
+        return cls(client_root)
 
 
-class DefaultWorkspace(Workspace):
+class DefaultWorkspace(FileStateMixin, Workspace):
     """Fallback for non-VCS directories."""
 
     def __init__(self, root):
         super().__init__(root)
         self.state_file = self.root / ".skills-managed"
 
-    def get_managed_skills(self):
-        if not self.state_file.is_file():
-            return []
-        with open(self.state_file, "r", encoding="utf-8", errors="replace") as f:
-            return sorted([line.strip() for line in f if line.strip()])
-
-    def save_managed_skills(self, skills):
-        if not skills:
-            if self.state_file.is_file():
-                self.state_file.unlink()
-            return
-        self.state_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.state_file, "w", encoding="utf-8") as f:
-            for item in sorted(list(set(skills))):
-                f.write(item + "\n")
-
-    def check_conflict(self, relpath):
-        if relpath.exists() and not relpath.is_symlink():
-            return f"{relpath} exists and is not a symlink; refusing to overwrite"
-        return None
-
 
 # ==============================================================================
-# Auto-Detection
+# Plugins & Auto-Detection
 # ==============================================================================
+
+
+class SkillAPI:
+    """API surface passed to a plugin's register() function.
+
+    Plugins live in $XDG_CONFIG_HOME/skill/plugins/*.py and may register
+    additional Workspace subclasses (subclass api.Workspace and implement a
+    'detect()' classmethod returning an instance or None). Plugin detectors
+    are consulted before the built-in Git/Perforce/Default detection, in
+    sorted filename order.
+    """
+
+    Workspace = Workspace
+    FileStateMixin = FileStateMixin
+
+    def __init__(self):
+        self.workspace_classes = []
+
+    def register_workspace(self, cls):
+        self.workspace_classes.append(cls)
+
+
+def load_plugins() -> SkillAPI:
+    import importlib.util
+
+    api = SkillAPI()
+    plugins_dir = (
+        Path(os.environ.get("XDG_CONFIG_HOME") or "~/.config").expanduser()
+        / "skill"
+        / "plugins"
+    )
+    if not plugins_dir.is_dir():
+        return api
+    for filepath in sorted(plugins_dir.glob("*.py")):
+        module_name = f"skill_plugin_{filepath.stem}"
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, filepath)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+                if hasattr(module, "register"):
+                    module.register(api)
+        except Exception as e:
+            print(
+                f"skill: warning: failed to load plugin {filepath}: {e}",
+                file=sys.stderr,
+            )
+    return api
 
 
 def get_workspace() -> Workspace:
-    ws = GitWorkspace.detect()
-    if ws:
-        return ws
-    ws = P4Workspace.detect()
-    if ws:
-        return ws
-    ws = VfsWorkspace.detect()
-    if ws:
-        return ws
+    api = load_plugins()
+    for cls in api.workspace_classes + [GitWorkspace, P4Workspace]:
+        try:
+            ws = cls.detect()
+        except Exception as e:
+            print(
+                f"skill: warning: workspace detector {cls.__name__} failed: {e}",
+                file=sys.stderr,
+            )
+            continue
+        if ws:
+            return ws
     return DefaultWorkspace(Path.cwd())
 
 
@@ -514,37 +490,47 @@ def cmd_remove(names):
     prune_dirs(dest_dirs)
 
 
-def cmd_list():
-    ws = get_workspace()
-    managed = ws.get_managed_skills()
+def resolve_installed(ws):
+    """Returns [(name, resolved_target_path_or_None)] for managed skills."""
     dest_dirs = ws.get_dest_dirs()
-
-    home = str(Path.home())
-
-    def clean_p(p):
-        s = str(p)
-        if s.startswith(home):
-            return "~" + s[len(home) :]
-        return s
-
-    resolved_skills = []
-    for name in sorted(managed):
+    resolved = []
+    for name in sorted(ws.get_managed_skills()):
         target = None
         for d in dest_dirs:
             p = d / name
             if p.is_symlink():
                 try:
-                    target = clean_p((p.parent / p.readlink()).resolve())
-                    break
+                    candidate = (p.parent / p.readlink()).resolve()
+                    if candidate.exists():
+                        target = candidate
+                        break
                 except Exception:
                     pass
-        resolved_skills.append((name, target))
+        resolved.append((name, target))
+    return resolved
+
+
+def cmd_list(args):
+    as_json = "--json" in args
+    ws = get_workspace()
+    resolved_skills = resolve_installed(ws)
+
+    if as_json:
+        print(
+            json.dumps(
+                [
+                    {"name": name, "path": str(target) if target else None}
+                    for name, target in resolved_skills
+                ]
+            )
+        )
+        return
 
     if resolved_skills:
         max_len = max(len(name) for name, _ in resolved_skills)
         for name, target in resolved_skills:
             if target:
-                print(f"{name.ljust(max_len)} -> {target}")
+                print(f"{name.ljust(max_len)} -> {clean_p(target)}")
             else:
                 print(name)
 
@@ -612,8 +598,6 @@ def cmd_apply(args):
         print(res.stderr, file=sys.stderr, end="")
         die("skill-select failed")
 
-    import json
-
     specs = []
     names = []
     for line in res.stdout.strip().splitlines():
@@ -648,11 +632,26 @@ def cmd_suggest(args):
         sys.exit(res.returncode)
 
 
+def cmd_repair():
+    ws = get_workspace()
+    managed = ws.get_managed_skills()
+    if not managed:
+        ws.save_managed_skills([])
+        print("repair: nothing managed", file=sys.stderr)
+        return
+    # Re-resolving and re-adding every managed skill re-links any missing
+    # symlinks and rewrites both the state file and the exclude block.
+    cmd_add(managed)
+    print(f"repair: verified {len(managed)} skill(s)", file=sys.stderr)
+
+
 def cmd_doctor():
     ws = get_workspace()
+    managed = ws.get_managed_skills()
     dest_dirs = ws.get_dest_dirs()
 
     dangling = []
+    missing = []
     for d in dest_dirs:
         if not d.is_dir():
             continue
@@ -663,24 +662,39 @@ def cmd_doctor():
                 except Exception:
                     target = "unknown"
                 dangling.append((item, target))
+    for name in managed:
+        for d in dest_dirs:
+            p = d / name
+            if not p.is_symlink():
+                missing.append(p)
 
+    backend_issues = ws.doctor_issues()
+
+    if not (dangling or missing or backend_issues):
+        return True
+
+    def rel(p):
+        try:
+            return p.relative_to(ws.root)
+        except ValueError:
+            return p
+
+    print("Workspace Skills:", file=sys.stderr)
+    for item, target in dangling:
+        print(f"  dangling      {rel(item)} -> {target}", file=sys.stderr)
+    for p in missing:
+        print(f"  missing       {rel(p)} (managed but not linked)", file=sys.stderr)
+    for issue in backend_issues:
+        print(f"  {issue}", file=sys.stderr)
+
+    hints = []
     if dangling:
-        print("Workspace Skills:", file=sys.stderr)
-        for item, target in dangling:
-            try:
-                rel = item.relative_to(ws.root)
-            except ValueError:
-                rel = item
-            print(f"  dangling     {rel} -> {target}", file=sys.stderr)
-
-        names_to_remove = sorted(list(set(item.name for item, _ in dangling)))
-        remove_cmd = f"skill remove {' '.join(names_to_remove)}"
-        print(
-            f"\n  hint: run '{remove_cmd}' to clean them up, or 'skill clean && skill apply' to reset to recommended skills\n",
-            file=sys.stderr,
-        )
-        return False
-    return True
+        names_to_remove = sorted(set(item.name for item, _ in dangling))
+        hints.append(f"'skill remove {' '.join(names_to_remove)}' to drop dangling links")
+    if missing or backend_issues:
+        hints.append("'skill repair' to re-link and regenerate tracking records")
+    print(f"\n  hint: run {', or '.join(hints)}\n", file=sys.stderr)
+    return False
 
 
 def usage():
@@ -689,7 +703,8 @@ def usage():
 
 Manage per-workspace agent skills as untracked symlinks. Automatically detects
 whether the current directory is a Git repository, Perforce workspace, or an
-unmanaged directory, and applies the appropriate tracking mechanism.
+unmanaged directory, and applies the appropriate tracking mechanism. Extra
+workspace types can be added via plugins in ~/.config/skill/plugins/.
 
 Commands:
   apply           Provision skills for this workspace via skill-select (idempotent)
@@ -697,11 +712,12 @@ Commands:
   add SPEC...     Add a skill: a local path or a registered catalog entry
   add -           Read skill names from stdin
   remove NAME...  Remove a skill this tool added (alias: rm)
-  list            List skills this tool is managing in the current workspace
+  list [--json]   List skills this tool is managing in the current workspace
   update SPEC...  Re-fetch a registered catalog entry; --all for every managed
                   skill, --catalog to refresh the whole metadata index
   clean           Remove all skills this tool added and clear the tracking record
   doctor          Diagnose drift between desired and on-disk skills (read-only)
+  repair          Re-link managed skills and regenerate tracking records
   catalog         List registered skills and sources
   resolve NAME    Print the source path 'add NAME' would symlink to
 
@@ -742,13 +758,15 @@ def main():
     elif cmd in ("remove", "rm"):
         cmd_remove(args)
     elif cmd == "list":
-        cmd_list()
+        cmd_list(args)
     elif cmd == "clean":
         cmd_clean()
     elif cmd == "apply":
         cmd_apply(args)
     elif cmd == "suggest":
         cmd_suggest(args)
+    elif cmd == "repair":
+        cmd_repair()
     else:
         print(f"skill: unknown command '{cmd}'", file=sys.stderr)
         print("Try 'skill --help' for more information.", file=sys.stderr)

--- a/tests/git-setup/test-basic
+++ b/tests/git-setup/test-basic
@@ -10,7 +10,14 @@ export PATH="$DIR/../../bin:$PATH"
 export SKILL_SOURCE_DIRS="$DIR/../../skills"
 export XDG_CONFIG_HOME="$DIR/../../etc"
 
-echo "1..6"
+# Isolate agent detection so 'permission' steps are deterministic: no agents
+# unless a test creates one of these directories.
+AGENTS_TMP=$(mktemp -d "/tmp/git-setup-test-agents.XXXXXX")
+trap 'rm -rf -- "$AGENTS_TMP"' EXIT
+export AGY_CONFIG_HOME="$AGENTS_TMP/gemini"
+export CLAUDE_CONFIG_DIR="$AGENTS_TMP/claude"
+
+echo "1..7"
 
 # Test 1: --help succeeds and documents --force
 if out=$("$BIN" --help 2>&1) &&
@@ -100,5 +107,20 @@ if (cd "$DOC" && "$BIN" doctor) >/dev/null 2>&1; then
   echo "ok 6 - doctor passes after hooks and a skill are installed"
 else
   echo "not ok 6 - doctor failed on a configured repo"
+fi
+
+# Test 7: once an agent appears, doctor flags missing permissions and
+# 'permission apply' resolves it (no API call).
+mkdir -p "$CLAUDE_CONFIG_DIR"
+if (cd "$DOC" && "$BIN" doctor) >/dev/null 2>&1; then
+  echo "not ok 7 - doctor should flag missing permission rules"
+else
+  (cd "$DOC" && permission apply) >/dev/null 2>&1
+  if (cd "$DOC" && "$BIN" doctor) >/dev/null 2>&1 &&
+    grep -q 'Bash(token-count:\*)' "$DOC/.claude/settings.local.json"; then
+    echo "ok 7 - doctor flags missing permissions; permission apply fixes them"
+  else
+    echo "not ok 7 - permission apply did not satisfy doctor"
+  fi
 fi
 rm -rf "$DOC"

--- a/tests/permission/test-basic
+++ b/tests/permission/test-basic
@@ -5,107 +5,211 @@ set -euo pipefail
 # Find script path relative to test
 TEST_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${TEST_DIR}/../../skills/workspace-config/scripts/permission"
+SKILL_SCRIPT="${TEST_DIR}/../../skills/workspace-config/scripts/skill"
 
-echo "1..11"
+echo "1..18"
 
 # Temporary directory for configuration simulations
 TMPDIR=$(mktemp -d)
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
-export AGENT_CONFIG_HOME="${TMPDIR}/config"
+# Isolate agent detection: neither agent exists until a test creates its dir.
+export AGY_CONFIG_HOME="${TMPDIR}/gemini"
+export CLAUDE_CONFIG_DIR="${TMPDIR}/claude"
+export XDG_CONFIG_HOME="${TMPDIR}/.config"
+export XDG_CACHE_HOME="${TMPDIR}/.cache"
 
-# Test 1: list fails/reports uninitialized on clean workspace
-if out=$(uv run "${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'Workspace not initialized'; then
-  echo "ok 1 - [list] uninitialized workspace detected"
-else
-  echo "not ok 1 - [list] did not report uninitialized: $out"
-fi
+# Workspace: a git repository so the claude adapter's exclude handling runs.
+WS="${TMPDIR}/ws"
+mkdir -p "$WS"
+git -C "$WS" init -q
+cd "$WS"
 
-# Test 2: add command auto-initializes workspace
-if out=$(uv run "${SCRIPT}" add "git show" 2>&1) && printf '%s' "$out" | grep -q 'Initialized configuration file'; then
-  CACHE_FILE="${AGENT_CONFIG_HOME}/jetski/cli/cache/projects.json"
-  if [ -f "${CACHE_FILE}" ]; then
-    echo "ok 2 - [add] bootstrapped configuration successfully"
-  else
-    echo "not ok 2 - [add] failed to create cache file"
-  fi
-else
-  echo "not ok 2 - [add] did not output initialization message: $out"
-fi
-
-# Test 3: list contains allow rule after auto-init
-if out=$(uv run "${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'command((?:.*/)?git show)'; then
-  echo "ok 3 - [list] allow rule listed correctly"
-else
-  echo "not ok 3 - [list] allow rule not listed in: $out"
-fi
-
-# Test 4: add deny rule
-if out=$(uv run "${SCRIPT}" add --deny "rm -rf" 2>&1) && printf '%s' "$out" | grep -q 'Added to deny'; then
-  echo "ok 4 - [add --deny] rule accepted"
-else
-  echo "not ok 4 - [add --deny] failed: $out"
-fi
-
-# Test 5: list contains deny rule
-if out=$(uv run "${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'command((?:.*/)?rm -rf)'; then
-  echo "ok 5 - [list] deny rule listed correctly"
-else
-  echo "not ok 5 - [list] deny rule not found in: $out"
-fi
-
-# Test 6: remove allow rule
-if out=$(uv run "${SCRIPT}" remove "git show" 2>&1) && printf '%s' "$out" | grep -q 'Removed from allow'; then
-  list_out=$(uv run "${SCRIPT}" list 2>/dev/null)
-  if ! printf '%s' "$list_out" | grep -q 'git show'; then
-    echo "ok 6 - [remove] rule removed cleanly"
-  else
-    echo "not ok 6 - [remove] rule still present in: $list_out"
-  fi
-else
-  echo "not ok 6 - [remove] command failed: $out"
-fi
-
-# Test 7: clean clears remaining rules
-if uv run "${SCRIPT}" clean >/dev/null 2>&1; then
-  list_out=$(uv run "${SCRIPT}" list 2>/dev/null)
-  if printf '%s' "$list_out" | grep -q 'No permission rules configured'; then
-    echo "ok 7 - [clean] all rules cleared successfully"
-  else
-    echo "not ok 7 - [clean] rules still present in: $list_out"
-  fi
-else
-  echo "not ok 7 - [clean] command failed"
-fi
-
-# Test 8: running permission with no arguments prints help and exits 0
+# Test 1: running permission with no arguments prints help and exits 0
 if out=$(uv run "${SCRIPT}" 2>/dev/null) && printf '%s' "$out" | grep -q 'Usage: permission <command>'; then
-  echo "ok 8 - [no-args] prints help and exits 0"
+  echo "ok 1 - [no-args] prints help and exits 0"
 else
-  echo "not ok 8 - [no-args] failed to print help: $out"
+  echo "not ok 1 - [no-args] failed to print help: $out"
 fi
 
-# Test 9: running permission --help prints help and exits 0
+# Test 2: --help prints help and exits 0
 if out=$(uv run "${SCRIPT}" --help 2>/dev/null) && printf '%s' "$out" | grep -q 'Usage: permission <command>'; then
-  echo "ok 9 - [--help] prints help and exits 0"
+  echo "ok 2 - [--help] prints help and exits 0"
 else
-  echo "not ok 9 - [--help] failed: $out"
+  echo "not ok 2 - [--help] failed: $out"
 fi
 
-# Test 10: running permission add --help prints subcommand-specific help
+# Test 3: subcommand help
 if out=$(uv run "${SCRIPT}" add --help 2>/dev/null) && printf '%s' "$out" | grep -q 'Usage: permission add'; then
-  echo "ok 10 - [subcommand help] prints subcommand help"
+  echo "ok 3 - [subcommand help] prints subcommand help"
 else
-  echo "not ok 10 - [subcommand help] failed: $out"
+  echo "not ok 3 - [subcommand help] failed: $out"
 fi
 
-# Test 11: running permission -h prints an error and exits non-zero
+# Test 4: -h is an error (GNU convention: -h is not help)
 if out=$(uv run "${SCRIPT}" -h 2>&1); then
-  echo "not ok 11 - [-h] should fail (expected non-zero exit)"
+  echo "not ok 4 - [-h] should fail (expected non-zero exit)"
 else
   if printf '%s' "$out" | grep -q 'permission: error:'; then
-    echo "ok 11 - [-h] fails and prints error"
+    echo "ok 4 - [-h] fails and prints error"
   else
-    echo "not ok 11 - [-h] failed with wrong output: $out"
+    echo "not ok 4 - [-h] failed with wrong output: $out"
   fi
+fi
+
+# Test 5: add fails cleanly when no agents are detected
+if out=$(uv run "${SCRIPT}" add "git show" 2>&1); then
+  echo "not ok 5 - [add] should fail with no agents detected"
+else
+  if printf '%s' "$out" | grep -q 'no supported agent configuration'; then
+    echo "ok 5 - [add] reports no agents detected"
+  else
+    echo "not ok 5 - [add] wrong error: $out"
+  fi
+fi
+
+# Test 6: apply is a no-op (exit 0) when no agents are detected
+if out=$(uv run "${SCRIPT}" apply 2>&1) && printf '%s' "$out" | grep -q 'no supported agents'; then
+  echo "ok 6 - [apply] no-op without agents"
+else
+  echo "not ok 6 - [apply] failed without agents: $out"
+fi
+
+# --- agy adapter ---
+mkdir -p "$AGY_CONFIG_HOME"
+
+# Test 7: add auto-initializes the agy project config
+if out=$(uv run "${SCRIPT}" add "git show" 2>&1) && printf '%s' "$out" | grep -q '\[agy\] added to allow: git show'; then
+  CACHE_FILE="${AGY_CONFIG_HOME}/jetski/cli/cache/projects.json"
+  if [ -f "${CACHE_FILE}" ]; then
+    echo "ok 7 - [agy add] bootstrapped configuration"
+  else
+    echo "not ok 7 - [agy add] cache file missing"
+  fi
+else
+  echo "not ok 7 - [agy add] failed: $out"
+fi
+
+# Test 8: rules are stored in translated (jetski) syntax
+if grep -rq 'command((?:.\*/)?git show)' "${AGY_CONFIG_HOME}/config/projects/" 2>/dev/null ||
+  grep -rqF 'command((?:.*/)?git show)' "${AGY_CONFIG_HOME}/config/projects/"; then
+  echo "ok 8 - [agy] stores translated rule"
+else
+  echo "not ok 8 - [agy] translated rule not found"
+fi
+
+# Test 9: list shows the clean pattern, not the translated rule
+if out=$(uv run "${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q '^    git show$'; then
+  echo "ok 9 - [list] shows clean patterns"
+else
+  echo "not ok 9 - [list] clean pattern not shown: $out"
+fi
+
+# Test 10: add --deny
+if uv run "${SCRIPT}" add --deny "rm -rf" >/dev/null 2>&1 &&
+  uv run "${SCRIPT}" list 2>/dev/null | grep -A2 'deny:' | grep -q 'rm -rf'; then
+  echo "ok 10 - [add --deny] rule listed under deny"
+else
+  echo "not ok 10 - [add --deny] failed"
+fi
+
+# Test 11: remove
+if out=$(uv run "${SCRIPT}" remove "git show" 2>&1) && printf '%s' "$out" | grep -q 'removed from allow'; then
+  if ! uv run "${SCRIPT}" list 2>/dev/null | grep -q 'git show'; then
+    echo "ok 11 - [remove] rule removed cleanly"
+  else
+    echo "not ok 11 - [remove] rule still listed"
+  fi
+else
+  echo "not ok 11 - [remove] failed: $out"
+fi
+
+# --- claude adapter ---
+mkdir -p "$CLAUDE_CONFIG_DIR"
+
+# Test 12: add writes Bash() rules to .claude/settings.local.json (and agy too)
+SETTINGS="${WS}/.claude/settings.local.json"
+if out=$(uv run "${SCRIPT}" add "git log" 2>&1) &&
+  grep -qF 'Bash(git log:*)' "$SETTINGS" 2>/dev/null &&
+  printf '%s' "$out" | grep -q '\[agy\] added to allow: git log'; then
+  echo "ok 12 - [claude add] writes settings.local.json and agy config"
+else
+  echo "not ok 12 - [claude add] failed: $out"
+fi
+
+# Test 13: settings.local.json is git-ignored after initialization
+if git -C "$WS" check-ignore -q .claude/settings.local.json; then
+  echo "ok 13 - [claude] settings.local.json is git-ignored"
+else
+  echo "not ok 13 - [claude] settings.local.json not ignored"
+fi
+
+# Test 14: --ask lands in claude's ask list and is skipped by agy
+if out=$(uv run "${SCRIPT}" add --ask "foo bar" 2>&1) &&
+  grep -qF 'Bash(foo bar:*)' "$SETTINGS" &&
+  printf '%s' "$out" | grep -q "\[agy\] no 'ask' support"; then
+  echo "ok 14 - [add --ask] claude ask list updated, agy skips"
+else
+  echo "not ok 14 - [add --ask] failed: $out"
+fi
+
+# --- apply / doctor ---
+# Fake skill: two scripts, one fully unsafe, one with an unsafe subcommand.
+SRC="${TMPDIR}/sources/tools"
+mkdir -p "$SRC/scripts" "$SRC/permissions"
+printf -- '---\nname: tools\n---\nbody\n' >"$SRC/SKILL.md"
+printf '#!/bin/sh\n' >"$SRC/scripts/safe-tool"
+printf '#!/bin/sh\n' >"$SRC/scripts/danger-tool"
+chmod +x "$SRC/scripts/safe-tool" "$SRC/scripts/danger-tool"
+printf 'danger-tool\nsafe-tool nuke\n' >"$SRC/permissions/unsafe"
+export SKILL_SOURCE_DIRS="${TMPDIR}/sources"
+uv run "${SKILL_SCRIPT}" add tools >/dev/null 2>&1
+
+# Test 15: apply allows safe scripts, skips unsafe scripts, guards subcommands
+if out=$(uv run "${SCRIPT}" apply 2>&1) &&
+  grep -qF 'Bash(safe-tool:*)' "$SETTINGS" &&
+  ! grep -qF 'Bash(danger-tool:*)' "$SETTINGS" &&
+  grep -qF 'Bash(safe-tool nuke:*)' "$SETTINGS"; then
+  # the guard must be in the ask list, not allow
+  if uv run "${SCRIPT}" list --agent claude 2>/dev/null | grep -A3 'ask:' | grep -q 'safe-tool nuke'; then
+    echo "ok 15 - [apply] allow/skip/guard semantics correct (claude)"
+  else
+    echo "not ok 15 - [apply] guard not in ask list"
+  fi
+else
+  echo "not ok 15 - [apply] failed: $out"
+fi
+
+# Test 16: apply guards land in agy's deny list
+if uv run "${SCRIPT}" list --agent agy 2>/dev/null | grep -A3 'deny:' | grep -q 'safe-tool nuke'; then
+  echo "ok 16 - [apply] guard in agy deny list"
+else
+  echo "not ok 16 - [apply] agy deny guard missing"
+fi
+
+# Test 17: doctor passes after apply, fails after a rule is removed
+if uv run "${SCRIPT}" doctor >/dev/null 2>&1; then
+  uv run "${SCRIPT}" remove "safe-tool" >/dev/null 2>&1
+  if out=$(uv run "${SCRIPT}" doctor 2>&1); then
+    echo "not ok 17 - [doctor] should fail after rule removal"
+  else
+    if printf '%s' "$out" | grep -q 'missing allow: safe-tool'; then
+      echo "ok 17 - [doctor] passes when synced, flags missing rules"
+    else
+      echo "not ok 17 - [doctor] wrong output: $out"
+    fi
+  fi
+else
+  echo "not ok 17 - [doctor] failed right after apply"
+fi
+
+# Test 18: clean clears all rules
+if uv run "${SCRIPT}" clean >/dev/null 2>&1; then
+  if out=$(uv run "${SCRIPT}" list 2>&1) && printf '%s' "$out" | grep -q 'No permission rules configured'; then
+    echo "ok 18 - [clean] all rules cleared"
+  else
+    echo "not ok 18 - [clean] rules still present: $out"
+  fi
+else
+  echo "not ok 18 - [clean] command failed"
 fi

--- a/tests/skill/test-basic
+++ b/tests/skill/test-basic
@@ -6,7 +6,7 @@ set -euo pipefail
 TEST_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${TEST_DIR}/../../bin/skill"
 
-echo "1..25"
+echo "1..27"
 
 # Need a temporary directory for workspace simulations
 TMPDIR=$(mktemp -d)
@@ -103,251 +103,310 @@ else
   echo "not ok 6 - [Git] add failed"
 fi
 
-# Test 7: list returns members
-if out=$("${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'coding-standards'; then
-  echo "ok 7 - [Git] list returns members"
+# Test 7: authoritative state lives in .git/info/skills
+if [ -f .git/info/skills ] && grep -q 'coding-standards' .git/info/skills &&
+  grep -q 'emumanager' .git/info/skills; then
+  echo "ok 7 - [Git] state recorded in .git/info/skills"
 else
-  echo "not ok 7 - [Git] list failed"
+  echo "not ok 7 - [Git] .git/info/skills missing entries"
 fi
 
-# Test 8: info/exclude contains managed block
-if [ -f .git/info/exclude ] && grep -q "managed by 'skill'" .git/info/exclude; then
+# Test 8: info/exclude contains regenerated managed block
+if [ -f .git/info/exclude ] && grep -q "managed by 'skill'" .git/info/exclude &&
+  grep -q '/.claude/skills/coding-standards' .git/info/exclude; then
   echo "ok 8 - [Git] info/exclude contains managed block"
 else
   echo "not ok 8 - [Git] info/exclude missing managed entries"
 fi
 
-# Test 9: remove deletes symlink and exclude entry
+# Test 9: list --json emits names and resolved paths
+if out=$("${SCRIPT}" list --json 2>/dev/null) &&
+  printf '%s' "$out" | grep -q '"name": *"coding-standards"' &&
+  printf '%s' "$out" | grep -q '"path": *"'; then
+  echo "ok 9 - [Git] list --json emits names and paths"
+else
+  echo "not ok 9 - [Git] list --json failed: $out"
+fi
+
+# Test 10: exclude block is regenerable: corrupt it, doctor flags, repair fixes
+sed -i '/skills/d' .git/info/exclude
+if "${SCRIPT}" doctor >/dev/null 2>&1; then
+  echo "not ok 10 - [Git] doctor should flag exclude drift"
+else
+  if "${SCRIPT}" repair >/dev/null 2>&1 &&
+    grep -q '/.claude/skills/coding-standards' .git/info/exclude &&
+    "${SCRIPT}" doctor >/dev/null 2>&1; then
+    echo "ok 10 - [Git] doctor flags exclude drift; repair regenerates it"
+  else
+    echo "not ok 10 - [Git] repair did not restore exclude block"
+  fi
+fi
+
+# Test 11: remove deletes symlink, state entry, and exclude entry
 if "${SCRIPT}" remove emumanager >/dev/null 2>&1; then
-  if [ ! -L .agents/skills/emumanager ] && ! grep -q "emumanager" .git/info/exclude; then
-    echo "ok 9 - [Git] remove deletes symlink and exclude entry"
+  if [ ! -L .agents/skills/emumanager ] && ! grep -q "emumanager" .git/info/exclude &&
+    ! grep -q "emumanager" .git/info/skills; then
+    echo "ok 11 - [Git] remove deletes symlink, state, and exclude entry"
   else
-    echo "not ok 9 - [Git] remove left symlink or exclude entry"
+    echo "not ok 11 - [Git] remove left symlink, state, or exclude entry"
   fi
 else
-  echo "not ok 9 - [Git] remove failed"
+  echo "not ok 11 - [Git] remove failed"
 fi
 
-# Test 10: clean removes links and managed block
+# Test 12: clean removes links, state file, and managed block
 if "${SCRIPT}" clean >/dev/null 2>&1; then
-  if [ ! -L .claude/skills/coding-standards ] && ! grep -q "coding-standards" .git/info/exclude; then
-    echo "ok 10 - [Git] clean removes links and exclude block"
+  if [ ! -L .claude/skills/coding-standards ] && [ ! -f .git/info/skills ] &&
+    ! grep -q "coding-standards" .git/info/exclude; then
+    echo "ok 12 - [Git] clean removes links, state, and exclude block"
   else
-    echo "not ok 10 - [Git] clean left links or exclude block"
+    echo "not ok 12 - [Git] clean left links, state, or exclude block"
   fi
 else
-  echo "not ok 10 - [Git] clean failed"
+  echo "not ok 12 - [Git] clean failed"
 fi
 
-# Test 11: add from subdirectory updates top-level exclude
+# Test 13: add from subdirectory updates top-level exclude and state
 mkdir -p sub
 cd sub
 if "${SCRIPT}" add coding-standards >/dev/null 2>&1; then
-  if grep -q "/.claude/skills/coding-standards" ../.git/info/exclude; then
-    echo "ok 11 - [Git] add from subdirectory updates top-level exclude"
+  if grep -q "/.claude/skills/coding-standards" ../.git/info/exclude &&
+    grep -q "coding-standards" ../.git/info/skills; then
+    echo "ok 13 - [Git] add from subdirectory updates top-level records"
   else
-    echo "not ok 11 - [Git] top-level exclude not updated"
+    echo "not ok 13 - [Git] top-level records not updated"
   fi
 else
-  echo "not ok 11 - [Git] add from subdirectory failed"
+  echo "not ok 13 - [Git] add from subdirectory failed"
 fi
 cd ..
 
+# Test 14: legacy migration: managed list parsed from old exclude block
+LEGACY_DIR="${TMPDIR}/git_legacy"
+mkdir -p "$LEGACY_DIR"
+cd "$LEGACY_DIR"
+git init -q
+mkdir -p .claude/skills .agents/skills
+ln -s "${TMPDIR}/sources/coding-standards" .claude/skills/coding-standards
+ln -s "${TMPDIR}/sources/coding-standards" .agents/skills/coding-standards
+cat <<'EOF' >.git/info/exclude
+# >>> skills (managed by 'skill') >>>
+/.claude/skills/coding-standards
+/.agents/skills/coding-standards
+# <<< skills (managed by 'skill') <<<
+EOF
+if out=$("${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'coding-standards'; then
+  # Any state change migrates the list to .git/info/skills
+  "${SCRIPT}" add emumanager >/dev/null 2>&1
+  if grep -q 'coding-standards' .git/info/skills && grep -q 'emumanager' .git/info/skills; then
+    echo "ok 14 - [Git] legacy exclude-block state is read and migrated"
+  else
+    echo "not ok 14 - [Git] migration did not preserve legacy entries"
+  fi
+else
+  echo "not ok 14 - [Git] legacy exclude-block state not read: $out"
+fi
+
 # ==============================================================================
-# PART 3: Perforce Workspace Mode
+# PART 3: Perforce Workspace Mode (standard layout)
 # ==============================================================================
 # Re-mock p4 command to succeed and return simulated workspace info
 cat <<'EOF' >"$MOCK_BIN_DIR/p4"
 #!/usr/bin/env bash
-cmd=$1
-shift
-if [ "$cmd" = "info" ]; then
+if [ "$1" = "info" ]; then
   echo "User name: testuser"
   echo "Client root: $MOCK_CLIENT_ROOT"
   exit 0
-elif [ "$cmd" = "fstat" ]; then
-  if [ -n "${MOCK_TRACKED_FILES:-}" ] && echo "$MOCK_TRACKED_FILES" | grep -q "$1"; then
-    echo "depotFile //depot/something"
-    exit 0
-  fi
-  echo "no such file" >&2
-  exit 1
 fi
+exit 1
 EOF
 chmod +x "$MOCK_BIN_DIR/p4"
 
-# --- Centralized Mode ---
-export MOCK_CLIENT_ROOT="${TMPDIR}/centralized_ws"
-mkdir -p "${MOCK_CLIENT_ROOT}/main-repo"
-touch "${MOCK_CLIENT_ROOT}/main-repo/WORKSPACE"
-mkdir -p "${MOCK_CLIENT_ROOT}/configs/users/testuser/_agents"
-
-cd "${MOCK_CLIENT_ROOT}/main-repo"
-
-# Test 12: add multiple skills (centralized)
-if "${SCRIPT}" add coding-standards emumanager >/dev/null 2>&1; then
-  DEST_DIR="${MOCK_CLIENT_ROOT}/configs/users/testuser/_agents/skills"
-  if [ -L "${DEST_DIR}/coding-standards" ] && [ -L "${DEST_DIR}/emumanager" ]; then
-    echo "ok 12 - [P4-Centralized] add multiple skills"
-  else
-    echo "not ok 12 - [P4-Centralized] add did not create symlinks"
-  fi
-else
-  echo "not ok 12 - [P4-Centralized] add failed"
-fi
-
-# Test 13: list
-if out=$("${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'coding-standards'; then
-  echo "ok 13 - [P4-Centralized] list returns members"
-else
-  echo "not ok 13 - [P4-Centralized] list failed"
-fi
-
-# Test 14: state file
-STATE_FILE="${MOCK_CLIENT_ROOT}/configs/users/testuser/_agents/.p4-skills-managed"
-if [ -f "$STATE_FILE" ] && grep -q "coding-standards" "$STATE_FILE"; then
-  echo "ok 14 - [P4-Centralized] state file updated"
-else
-  echo "not ok 14 - [P4-Centralized] state file missing entries"
-fi
-
-# Test 15: clean
-if "${SCRIPT}" clean >/dev/null 2>&1; then
-  DEST_DIR="${MOCK_CLIENT_ROOT}/configs/users/testuser/_agents/skills"
-  if [ ! -d "${DEST_DIR}" ] && [ ! -f "$STATE_FILE" ]; then
-    echo "ok 15 - [P4-Centralized] clean removes links and state"
-  else
-    echo "not ok 15 - [P4-Centralized] clean left files"
-  fi
-else
-  echo "not ok 15 - [P4-Centralized] clean failed"
-fi
-
-# --- Standard P4 Mode (Local) ---
 export MOCK_CLIENT_ROOT="${TMPDIR}/public_ws"
 mkdir -p "${MOCK_CLIENT_ROOT}"
 cd "${MOCK_CLIENT_ROOT}"
 
-# Test 16: add multiple skills (public mode uses .agents/skills and .claude/skills)
+# Test 15: add multiple skills (standard locations)
 if "${SCRIPT}" add coding-standards emumanager >/dev/null 2>&1; then
   if [ -L ".agents/skills/coding-standards" ] && [ -L ".claude/skills/emumanager" ]; then
-    echo "ok 16 - [P4-Standard] add multiple skills"
+    echo "ok 15 - [P4] add multiple skills"
   else
-    echo "not ok 16 - [P4-Standard] add did not create symlinks in standard locations"
+    echo "not ok 15 - [P4] add did not create symlinks in standard locations"
   fi
 else
-  echo "not ok 16 - [P4-Standard] add failed"
+  echo "not ok 15 - [P4] add failed"
+fi
+
+# Test 16: state file at client root
+if [ -f .p4-skills-managed ] && grep -q "coding-standards" .p4-skills-managed; then
+  echo "ok 16 - [P4] state file updated"
+else
+  echo "not ok 16 - [P4] state file missing entries"
 fi
 
 # Test 17: clean
 if "${SCRIPT}" clean >/dev/null 2>&1; then
   if [ ! -d ".agents" ] && [ ! -d ".claude" ] && [ ! -f ".p4-skills-managed" ]; then
-    echo "ok 17 - [P4-Standard] clean removes links and state"
+    echo "ok 17 - [P4] clean removes links and state"
   else
-    echo "not ok 17 - [P4-Standard] clean left files"
+    echo "not ok 17 - [P4] clean left files"
   fi
 else
-  echo "not ok 17 - [P4-Standard] clean failed"
+  echo "not ok 17 - [P4] clean failed"
+fi
+
+# Test 18: p4 client is ignored when cwd is outside the client root
+OUTSIDE="${TMPDIR}/outside_p4"
+mkdir -p "$OUTSIDE"
+cd "$OUTSIDE"
+if "${SCRIPT}" add coding-standards >/dev/null 2>&1; then
+  if [ -f "$OUTSIDE/.skills-managed" ] && [ ! -f "${MOCK_CLIENT_ROOT}/.p4-skills-managed" ]; then
+    echo "ok 18 - [P4] cwd outside client root falls back to unmanaged"
+  else
+    echo "not ok 18 - [P4] adopted a client root we are not inside"
+  fi
+  "${SCRIPT}" clean >/dev/null 2>&1
+else
+  echo "not ok 18 - [P4] add failed outside client root"
 fi
 
 # ==============================================================================
 # PART 4: Generic / Error Handling / Help Tests
 # ==============================================================================
-# Test 18: add bogus-skill-name reports unknown skill
+# Test 19: add bogus-skill-name reports unknown skill
 if ! "${SCRIPT}" add bogus-skill-name >/dev/null 2>&1; then
-  echo "ok 18 - add bogus-skill-name reports unknown skill"
+  echo "ok 19 - add bogus-skill-name reports unknown skill"
 else
-  echo "not ok 18 - add bogus-skill-name succeeded unexpectedly"
+  echo "not ok 19 - add bogus-skill-name succeeded unexpectedly"
 fi
 
-# Test 19: resolves names against SKILL_SOURCE_DIRS
+# Test 20: resolves names against SKILL_SOURCE_DIRS
 mkdir -p "${TMPDIR}/custom-skills/test-skill"
 echo -e "---\nname: test-skill\n---\nbody" >"${TMPDIR}/custom-skills/test-skill/SKILL.md"
 if SKILL_SOURCE_DIRS="${TMPDIR}/custom-skills" "${SCRIPT}" resolve test-skill | grep -q 'custom-skills/test-skill'; then
-  echo "ok 19 - resolves names against SKILL_SOURCE_DIRS"
+  echo "ok 20 - resolves names against SKILL_SOURCE_DIRS"
 else
-  echo "not ok 19 - failed to resolve custom skill"
+  echo "not ok 20 - failed to resolve custom skill"
 fi
 
-# Test 20: update --catalog with empty registry preserves catalog
+# Test 21: update --catalog with empty registry preserves catalog
 mkdir -p "${XDG_CACHE_HOME}/skill-select/catalog/dummy"
 touch "${XDG_CACHE_HOME}/skill-select/catalog/dummy/SKILL.md"
 if "${SCRIPT}" update --catalog >/dev/null 2>&1; then
   if [ -d "${XDG_CACHE_HOME}/skill-select/catalog/dummy" ]; then
-    echo "ok 20 - update --catalog with empty registry preserves catalog (GC guard)"
+    echo "ok 21 - update --catalog with empty registry preserves catalog (GC guard)"
   else
-    echo "not ok 20 - update --catalog destroyed unrelated catalog"
+    echo "not ok 21 - update --catalog destroyed unrelated catalog"
   fi
 else
-  echo "not ok 20 - update --catalog failed"
+  echo "not ok 21 - update --catalog failed"
 fi
 
-# Test 21: help documents update --catalog
+# Test 22: help documents update --catalog
 if "${SCRIPT}" --help 2>&1 | grep -q '\-\-catalog'; then
-  echo "ok 21 - help documents update --catalog"
+  echo "ok 22 - help documents update --catalog"
 else
-  echo "not ok 21 - help does not document update --catalog"
+  echo "not ok 22 - help does not document update --catalog"
+fi
+
+# Test 23: help documents repair and list --json
+if out=$("${SCRIPT}" --help 2>&1) && printf '%s' "$out" | grep -q 'repair' &&
+  printf '%s' "$out" | grep -q 'list \[--json\]'; then
+  echo "ok 23 - help documents repair and list --json"
+else
+  echo "not ok 23 - help missing repair or list --json"
 fi
 
 # ==============================================================================
-# PART 5: Virtual Workspace Mode (VfsWorkspace)
+# PART 5: Workspace Detector Plugins
 # ==============================================================================
-# Reset p4 mock to fail, so we don't detect P4 workspace
+# Reset p4 mock to fail
 cat <<'EOF' >"$MOCK_BIN_DIR/p4"
 #!/usr/bin/env bash
 exit 1
 EOF
 chmod +x "$MOCK_BIN_DIR/p4"
 
-VFS_ROOT="${TMPDIR}/vfs_workspace"
-mkdir -p "${VFS_ROOT}/.citc"
-# Write simulated manifest with markers
-echo -e "cog.use_jj\ndevtools_srcfs" >"${VFS_ROOT}/.citc/manifest.ascii"
-# Create the repository directory inside the workspace
-mkdir -p "${VFS_ROOT}/android"
+mkdir -p "${XDG_CONFIG_HOME}/skill/plugins"
+cat <<'EOF' >"${XDG_CONFIG_HOME}/skill/plugins/testws.py"
+from pathlib import Path
 
-cd "${VFS_ROOT}/android"
 
-# Test 22: add skill from root
+def register(api):
+    class MarkerWorkspace(api.FileStateMixin, api.Workspace):
+        def __init__(self, root):
+            super().__init__(root)
+            self.state_file = self.root / ".marker-skills"
+
+        @classmethod
+        def detect(cls):
+            curr = Path.cwd().resolve()
+            for parent in [curr] + list(curr.parents):
+                if (parent / ".marker-ws").is_dir():
+                    return cls(parent)
+            return None
+
+    api.register_workspace(MarkerWorkspace)
+EOF
+
+PLUGIN_DIR="${TMPDIR}/plugin_ws"
+mkdir -p "${PLUGIN_DIR}/.marker-ws" "${PLUGIN_DIR}/sub"
+
+# Test 24: plugin workspace detected from a subdirectory
+cd "${PLUGIN_DIR}/sub"
 if "${SCRIPT}" add coding-standards >/dev/null 2>&1; then
-  if [ -L .claude/skills/coding-standards ]; then
-    echo "ok 22 - [Vfs] add skill from root"
+  if [ -L "${PLUGIN_DIR}/.claude/skills/coding-standards" ] &&
+    [ -f "${PLUGIN_DIR}/.marker-skills" ] && [ ! -d .claude ]; then
+    echo "ok 24 - [Plugin] custom workspace detected, links at plugin root"
   else
-    echo "not ok 22 - [Vfs] add did not create symlink"
+    echo "not ok 24 - [Plugin] links or state in wrong location"
   fi
 else
-  echo "not ok 22 - [Vfs] add failed"
+  echo "not ok 24 - [Plugin] add failed"
 fi
 
-# Test 23: list returns members
-if out=$("${SCRIPT}" list 2>/dev/null) && printf '%s' "$out" | grep -q 'coding-standards'; then
-  echo "ok 23 - [Vfs] list returns members"
-else
-  echo "not ok 23 - [Vfs] list failed"
-fi
-
-# Test 24: add from subdirectory resolves to repo root
-mkdir -p wear
-cd wear
-if "${SCRIPT}" add emumanager >/dev/null 2>&1; then
-  # Should be at the repo root (parent), not here
-  if [ -L ../.agents/skills/emumanager ] && [ ! -d .agents ] && [ ! -f .skills-managed ]; then
-    echo "ok 24 - [Vfs] add from subdirectory resolves to repo root"
+# Test 25: plugin detector takes precedence over git
+GIT_IN_PLUGIN="${TMPDIR}/plugin_git"
+mkdir -p "${GIT_IN_PLUGIN}/.marker-ws"
+git -C "${GIT_IN_PLUGIN}" init -q
+cd "${GIT_IN_PLUGIN}"
+if "${SCRIPT}" add coding-standards >/dev/null 2>&1; then
+  if [ -f .marker-skills ] && [ ! -f .git/info/skills ]; then
+    echo "ok 25 - [Plugin] plugin detector takes precedence over git"
   else
-    echo "not ok 24 - [Vfs] installed in subdirectory instead of root"
+    echo "not ok 25 - [Plugin] git detector ran despite plugin match"
   fi
 else
-  echo "not ok 24 - [Vfs] add from subdirectory failed"
+  echo "not ok 25 - [Plugin] add failed in git+plugin workspace"
 fi
-cd ..
 
-# Test 25: clean removes links and state at root
-if "${SCRIPT}" clean >/dev/null 2>&1; then
-  if [ ! -d .claude ] && [ ! -d .agents ] && [ ! -f .skills-managed ]; then
-    echo "ok 25 - [Vfs] clean removes links and state"
+# Test 26: broken plugin is skipped with a warning, built-ins still work
+cat <<'EOF' >"${XDG_CONFIG_HOME}/skill/plugins/broken.py"
+raise RuntimeError("boom")
+EOF
+NOPLUGIN_DIR="${TMPDIR}/noplugin"
+mkdir -p "$NOPLUGIN_DIR"
+cd "$NOPLUGIN_DIR"
+if out=$("${SCRIPT}" add coding-standards 2>&1); then
+  if printf '%s' "$out" | grep -q 'failed to load plugin' && [ -f .skills-managed ]; then
+    echo "ok 26 - [Plugin] broken plugin warns and is skipped"
   else
-    echo "not ok 25 - [Vfs] clean left files at root"
+    echo "not ok 26 - [Plugin] missing warning or fallback: $out"
   fi
 else
-  echo "not ok 25 - [Vfs] clean failed"
+  echo "not ok 26 - [Plugin] add failed with broken plugin present"
+fi
+rm -f "${XDG_CONFIG_HOME}/skill/plugins/broken.py"
+
+# Test 27: doctor flags a managed-but-missing symlink
+cd "${PLUGIN_DIR}"
+rm .claude/skills/coding-standards
+if out=$("${SCRIPT}" doctor 2>&1); then
+  echo "not ok 27 - doctor should flag missing symlink"
+else
+  if printf '%s' "$out" | grep -q 'missing'; then
+    echo "ok 27 - doctor flags managed-but-missing symlink"
+  else
+    echo "not ok 27 - doctor failed without expected output: $out"
+  fi
 fi

--- a/update
+++ b/update
@@ -600,6 +600,13 @@ heading "skill registry"
 xmkdir "$HOME/.config/skill-select/registry.d"
 link_overlay_files "config/skill/registry.d" "$HOME/.config/skill-select/registry.d"
 
+# Workspace-detector and root-marker plugins for 'skill' and 'permission'
+# (overlay repos provide these under config/<tool>/plugins).
+xmkdir "$HOME/.config/skill/plugins"
+link_overlay_files "config/skill/plugins" "$HOME/.config/skill/plugins"
+xmkdir "$HOME/.config/permission/plugins"
+link_overlay_files "config/permission/plugins" "$HOME/.config/permission/plugins"
+
 heading "agents"
 
 # Symlink user-supplied context for all agents


### PR DESCRIPTION
- permission: adapter architecture with Claude Code support (.claude/settings.local.json Bash rules, kept git-ignored) alongside agy; list/remove keyed on clean patterns; multi-pattern add with --deny/--ask and stdin; --agent scoping; new apply and doctor commands
- skills declare exceptions in permissions/unsafe; 'permission apply' pre-approves every other script of every installed skill (whole-name lines are never allowed, "script subcommand" lines are guarded with ask on Claude Code and deny on agy)
- skill: authoritative managed list moves from the .git/info/exclude marker block to .git/info/skills; the exclude block is regenerated from it, doctor detects drift and missing links, and the new repair command fixes them; list gains --json
- skill/permission: workspace detection extensible via plugins in ~/.config/{skill,permission}/plugins; built-in detection reduced to Git, standard Perforce, and unmanaged directories; Perforce detection now requires the current directory to be inside the client root
- git-setup: runs 'permission apply' after 'skill apply', doctor aggregates 'permission doctor', and the help now spells out exactly what each step writes
- update: link skill/permission plugin dirs from overlay repos; add fish completions for permission
