### PR TITLE
Rename update to install.sh and add network bootstrap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,14 +24,14 @@ jobs:
 
       - name: shellcheck
         run: |
-          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install \
+          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install.sh \
             | grep -v '__pycache__' \
             | sort \
             | xargs shellcheck
 
       - name: shfmt
         run: |
-          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install \
+          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install.sh \
             | grep -v '__pycache__' \
             | sort \
             | xargs shfmt -d -i 2 -ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,14 +24,14 @@ jobs:
 
       - name: shellcheck
         run: |
-          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults update \
+          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install \
             | grep -v '__pycache__' \
             | sort \
             | xargs shellcheck
 
       - name: shfmt
         run: |
-          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults update \
+          grep -rlE '^#!.*\bba?sh\b' bin/ skills/*/scripts/ etc/macos/apply-defaults install \
             | grep -v '__pycache__' \
             | sort \
             | xargs shfmt -d -i 2 -ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ apply.
 ## Script Quality and Development
 
 This section provides guidelines for script entrypoints in `bin/`, canonical
-script sources in `skills/*/scripts/`, as well as the `./install` script.
+script sources in `skills/*/scripts/`, as well as the `./install.sh` script.
 
 ### General Script Requirements
 
@@ -232,7 +232,7 @@ blocks:
 bin/command-index-sync --all
 ```
 
-`./install` runs `command-index-sync --check --all` and warns when blocks have
+`./install.sh` runs `command-index-sync --check --all` and warns when blocks have
 drifted. The command named in a marker is executed with its working directory
 set to the directory containing the Markdown file (hence the `../scripts/`
 prefix).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ apply.
 ## Script Quality and Development
 
 This section provides guidelines for script entrypoints in `bin/`, canonical
-script sources in `skills/*/scripts/`, as well as the `./update` script.
+script sources in `skills/*/scripts/`, as well as the `./install` script.
 
 ### General Script Requirements
 
@@ -232,7 +232,7 @@ blocks:
 bin/command-index-sync --all
 ```
 
-`./update` runs `command-index-sync --check --all` and warns when blocks have
+`./install` runs `command-index-sync --check --all` and warns when blocks have
 drifted. The command named in a marker is executed with its working directory
 set to the directory containing the Markdown file (hence the `../scripts/`
 prefix).

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ and various other tools.
 │   ├── conf.d/          # Fish startup snippets
 │   ├── completions/     # Fish completions
 │   └── functions/       # Fish functions (autoloaded)
-├── home/                # Dotfiles symlinked into $HOME by update
+├── home/                # Dotfiles symlinked into $HOME by install.sh
 ├── etc/                 # Tool-specific config (git templates, VS Code, etc.)
 ├── skills/              # Agent skill definitions
 ├── tests/               # TAP tests for bin/ scripts
-└── install              # Idempotent install/update script
+└── install.sh           # Idempotent install/update script
 ```
 
-`install` symlinks `home/.*` into `$HOME`, installs packages, and wires up
+`install.sh` symlinks `home/.*` into `$HOME`, installs packages, and wires up
 tool-specific config. It is safe to run multiple times, and doubles as the
 updater: an existing checkout is fast-forwarded before applying. It can be run
-locally (`./install`) or piped straight from the network (see
+locally (`./install.sh`) or piped straight from the network (see
 [Installation](#installation)).
 
 ## Overlays
@@ -48,7 +48,7 @@ of the public repository. This repository works fine without them.
 
 ### Precedence
 
-`install` processes overlays in this order: `.dotfiles` → `.private` → `.corp`.
+`install.sh` processes overlays in this order: `.dotfiles` → `.private` → `.corp`.
 Later layers win on conflict. A file in `~/.corp` always beats the same path in
 `~/.private` or `~/.dotfiles`.
 
@@ -84,7 +84,7 @@ the last overlay to provide a given filename wins.
 
 ### Per-overlay `update` hooks
 
-After the main install, `install` runs `~/.private/update` and `~/.corp/update`
+After the main install, `install.sh` runs `~/.private/update` and `~/.corp/update`
 if they exist and are executable. These hooks handle overlay-specific setup that
 cannot be expressed as file overlays (package installs, auth setup, etc.).
 
@@ -100,7 +100,7 @@ cannot be expressed as file overlays (package installs, auth setup, etc.).
 ├── home/               # Dotfiles symlinked into $HOME (e.g. .gitconfig.local)
 ├── etc/                # Tool-specific config (see overlay-aware paths above)
 ├── skills/             # Agent skills that shadow ~/.dotfiles/skills/ by name
-└── update              # Optional hook run at end of ./install
+└── update              # Optional hook run at end of ./install.sh
 ```
 
 `fish/config.fish` prepends `~/.private/fish/functions` (and `.corp`
@@ -108,7 +108,7 @@ equivalents) and `~/.private/fish/completions` to the fish search paths, and
 sources any `~/.private/fish/conf.d/*.fish` snippets at shell startup.
 
 To install: clone your private repos to `~/.private` and/or `~/.corp`, then run
-`./install` again.
+`./install.sh` again.
 
 ## Secret management
 
@@ -164,32 +164,42 @@ layout uv              # creates .venv if absent, activates it
 
 ## Installation
 
-Install (or update) with a single command:
+The same `install.sh` script both installs and updates, and runs in two ways.
+`git` must already be installed either way (see [Prerequisites](#git)).
+
+### Option 1: Straight from the network
+
+Clones the repo to `~/.dotfiles` (if absent), points the push remote at SSH,
+then installs — and on later runs, updates (it fast-forwards `~/.dotfiles`
+before applying):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash
+curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install.sh | bash
 ```
 
-This clones the repository to `~/.dotfiles` (if not already present), points the
-push remote at SSH, then runs the installer. Re-running it updates an existing
-checkout (it fast-forwards `~/.dotfiles` before applying). `git` must already be
-installed (see [Prerequisites](#git)). Pass flags after `-s --`, e.g.
-`… | bash -s -- --force`.
+It must be piped to `bash`, not `sh` — the script is bash and refuses to run
+under other shells. Pass flags after `-s --`, e.g.
+`… | bash -s -- --force`. To download the whole script before running anything
+(rather than streaming it into the interpreter), use the equivalent:
 
-To install from a local checkout instead:
+```sh
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install.sh)"
+```
+
+### Option 2: From a local checkout
 
 ```sh
 cd $HOME
 git clone https://github.com/ithinkihaveacat/dotfiles.git .dotfiles
 cd .dotfiles
 git remote set-url origin --push git@github.com:ithinkihaveacat/dotfiles.git
-./install
+./install.sh
 ```
 
-After cloning `~/.private` and/or `~/.corp` (if available), run `./install`
+After cloning `~/.private` and/or `~/.corp` (if available), run `./install.sh`
 again so the overlay is applied.
 
-> **Note:** `install` may overwrite unmanaged files in locations such as
+> **Note:** `install.sh` may overwrite unmanaged files in locations such as
 > `~/Library/KeyBindings`. It is otherwise safe to run multiple times.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ and various other tools.
 ├── etc/                 # Tool-specific config (git templates, VS Code, etc.)
 ├── skills/              # Agent skill definitions
 ├── tests/               # TAP tests for bin/ scripts
-└── update               # Idempotent install script
+└── install              # Idempotent install/update script
 ```
 
-`update` symlinks `home/.*` into `$HOME`, installs packages, and wires up
-tool-specific config. It is safe to run multiple times.
+`install` symlinks `home/.*` into `$HOME`, installs packages, and wires up
+tool-specific config. It is safe to run multiple times, and doubles as the
+updater: an existing checkout is fast-forwarded before applying. It can be run
+locally (`./install`) or piped straight from the network (see
+[Installation](#installation)).
 
 ## Overlays
 
@@ -45,7 +48,7 @@ of the public repository. This repository works fine without them.
 
 ### Precedence
 
-`update` processes overlays in this order: `.dotfiles` → `.private` → `.corp`.
+`install` processes overlays in this order: `.dotfiles` → `.private` → `.corp`.
 Later layers win on conflict. A file in `~/.corp` always beats the same path in
 `~/.private` or `~/.dotfiles`.
 
@@ -81,7 +84,7 @@ the last overlay to provide a given filename wins.
 
 ### Per-overlay `update` hooks
 
-After the main install, `update` runs `~/.private/update` and `~/.corp/update`
+After the main install, `install` runs `~/.private/update` and `~/.corp/update`
 if they exist and are executable. These hooks handle overlay-specific setup that
 cannot be expressed as file overlays (package installs, auth setup, etc.).
 
@@ -97,7 +100,7 @@ cannot be expressed as file overlays (package installs, auth setup, etc.).
 ├── home/               # Dotfiles symlinked into $HOME (e.g. .gitconfig.local)
 ├── etc/                # Tool-specific config (see overlay-aware paths above)
 ├── skills/             # Agent skills that shadow ~/.dotfiles/skills/ by name
-└── update              # Optional hook run at end of ./update
+└── update              # Optional hook run at end of ./install
 ```
 
 `fish/config.fish` prepends `~/.private/fish/functions` (and `.corp`
@@ -105,7 +108,7 @@ equivalents) and `~/.private/fish/completions` to the fish search paths, and
 sources any `~/.private/fish/conf.d/*.fish` snippets at shell startup.
 
 To install: clone your private repos to `~/.private` and/or `~/.corp`, then run
-`./update` again.
+`./install` again.
 
 ## Secret management
 
@@ -161,18 +164,32 @@ layout uv              # creates .venv if absent, activates it
 
 ## Installation
 
+Install (or update) with a single command:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash
+```
+
+This clones the repository to `~/.dotfiles` (if not already present), points the
+push remote at SSH, then runs the installer. Re-running it updates an existing
+checkout (it fast-forwards `~/.dotfiles` before applying). `git` must already be
+installed (see [Prerequisites](#git)). Pass flags after `-s --`, e.g.
+`… | bash -s -- --force`.
+
+To install from a local checkout instead:
+
 ```sh
 cd $HOME
 git clone https://github.com/ithinkihaveacat/dotfiles.git .dotfiles
 cd .dotfiles
 git remote set-url origin --push git@github.com:ithinkihaveacat/dotfiles.git
-./update
+./install
 ```
 
-After cloning `~/.private` and/or `~/.corp` (if available), run `./update` again
-so the overlay is applied.
+After cloning `~/.private` and/or `~/.corp` (if available), run `./install`
+again so the overlay is applied.
 
-> **Note:** `update` may overwrite unmanaged files in locations such as
+> **Note:** `install` may overwrite unmanaged files in locations such as
 > `~/Library/KeyBindings`. It is otherwise safe to run multiple times.
 
 ## Prerequisites

--- a/install
+++ b/install
@@ -8,12 +8,41 @@ set -euo pipefail
 # correct locations: $HOME, $HOME/.config/fish, $HOME/.config/templates,
 # etc.
 
+# Bootstrap: when piped from curl (e.g. `curl -fsSL .../install | bash`) the
+# script has no path on disk, so BASH_SOURCE[0] is empty and the self-location
+# logic below cannot find the repo. In that case, clone the repo to ~/.dotfiles
+# if it is not already present, point the push remote at SSH, then re-exec the
+# on-disk copy with the same arguments. A local run (./install) has a real
+# BASH_SOURCE and skips this block entirely; an existing checkout is left for
+# the `git pull` step further down to fast-forward.
+if [ ! -f "${BASH_SOURCE[0]:-}" ]; then
+  DOTFILES="${DOTFILES:-$HOME/.dotfiles}"
+  if [ ! -d "$DOTFILES/.git" ]; then
+    command -v git >/dev/null 2>&1 || {
+      echo "install: git not found; install git and re-run" >&2
+      exit 127
+    }
+    echo "Cloning dotfiles into $DOTFILES..."
+    git clone https://github.com/ithinkihaveacat/dotfiles.git "$DOTFILES"
+    git -C "$DOTFILES" remote set-url origin --push \
+      git@github.com:ithinkihaveacat/dotfiles.git
+  fi
+  exec "$DOTFILES/install" "$@"
+fi
+
 # Show usage information
 function usage {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Symlinks and copies dotfiles from ~/.dotfiles to their correct locations.
+Installs and updates dotfiles. Symlinks and copies dotfiles from ~/.dotfiles to
+their correct locations, installs packages, and wires up tool-specific config.
+Safe to run repeatedly; an existing checkout is fast-forwarded first.
+
+Can also be run directly from the network, which clones the repo to ~/.dotfiles
+(if absent) before installing:
+
+  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash
 
 OPTIONS:
   --help        Show this help message and exit
@@ -24,8 +53,11 @@ OPTIONS:
                 Run without prompting or interactive terminal-session validation
 
 EXAMPLES:
-  $(basename "$0")            # Install dotfiles
+  $(basename "$0")            # Install or update dotfiles
   $(basename "$0") --trace    # Same, but log each wrapped command
+
+  # Install/update over the network, passing flags after '-s --':
+  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash -s -- --force
 
 EOF
   exit "${1:-0}"

--- a/install.sh
+++ b/install.sh
@@ -2,24 +2,46 @@
 # bash 3.2+ compatible (macOS default). Do not use bash 4+ features
 # (declare -A, readarray, ${var,,}, |&).
 
+# When piped from the network the caller picks the interpreter
+# (`curl ... | bash`), so the shebang above is bypassed. The body of this script
+# is bash (arrays, [[ ]], process substitution, printf %q), so fail fast with a
+# clear message if it is fed to a non-bash shell, an ancient bash, or a bash in
+# POSIX mode (which disables process substitution). These three checks use only
+# POSIX sh syntax so they degrade gracefully under dash/sh/zsh/ksh instead of
+# emitting cryptic syntax errors. They run before `set -euo pipefail` because
+# `pipefail` itself is not POSIX.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "install.sh: must be run with bash, e.g.:" >&2
+  echo "  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install.sh | bash" >&2
+  exit 1
+fi
+if [ "${BASH_VERSINFO[0]}" -lt 3 ] || { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "install.sh: bash 3.2 or newer required (found ${BASH_VERSION})" >&2
+  exit 1
+fi
+if [ -n "${POSIXLY_CORRECT+1}" ]; then
+  echo "install.sh: bash must not run in POSIX mode; unset POSIXLY_CORRECT and retry" >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # Symlinks and copies files from the ~/.dotfiles directory into their
 # correct locations: $HOME, $HOME/.config/fish, $HOME/.config/templates,
 # etc.
 
-# Bootstrap: when piped from curl (e.g. `curl -fsSL .../install | bash`) the
+# Bootstrap: when piped from curl (e.g. `curl -fsSL .../install.sh | bash`) the
 # script has no path on disk, so BASH_SOURCE[0] is empty and the self-location
 # logic below cannot find the repo. In that case, clone the repo to ~/.dotfiles
 # if it is not already present, point the push remote at SSH, then re-exec the
-# on-disk copy with the same arguments. A local run (./install) has a real
+# on-disk copy with the same arguments. A local run (./install.sh) has a real
 # BASH_SOURCE and skips this block entirely; an existing checkout is left for
 # the `git pull` step further down to fast-forward.
 if [ ! -f "${BASH_SOURCE[0]:-}" ]; then
   DOTFILES="${DOTFILES:-$HOME/.dotfiles}"
   if [ ! -d "$DOTFILES/.git" ]; then
     command -v git >/dev/null 2>&1 || {
-      echo "install: git not found; install git and re-run" >&2
+      echo "install.sh: git not found; install git and re-run" >&2
       exit 127
     }
     echo "Cloning dotfiles into $DOTFILES..."
@@ -27,7 +49,7 @@ if [ ! -f "${BASH_SOURCE[0]:-}" ]; then
     git -C "$DOTFILES" remote set-url origin --push \
       git@github.com:ithinkihaveacat/dotfiles.git
   fi
-  exec "$DOTFILES/install" "$@"
+  exec "$DOTFILES/install.sh" "$@"
 fi
 
 # Show usage information
@@ -42,7 +64,7 @@ Safe to run repeatedly; an existing checkout is fast-forwarded first.
 Can also be run directly from the network, which clones the repo to ~/.dotfiles
 (if absent) before installing:
 
-  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash
+  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install.sh | bash
 
 OPTIONS:
   --help        Show this help message and exit
@@ -57,7 +79,7 @@ EXAMPLES:
   $(basename "$0") --trace    # Same, but log each wrapped command
 
   # Install/update over the network, passing flags after '-s --':
-  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install | bash -s -- --force
+  curl -fsSL https://raw.githubusercontent.com/ithinkihaveacat/dotfiles/master/install.sh | bash -s -- --force
 
 EOF
   exit "${1:-0}"

--- a/skills/agent-tools/references/software-installation.md
+++ b/skills/agent-tools/references/software-installation.md
@@ -1,8 +1,8 @@
 # Software Installation
 
 This document covers installation of CLI tools that are managed as optional
-entries in the dotfiles `install` script. These tools are installed manually and
-self-update via their own update commands; the `install` script calls those
+entries in the dotfiles `install.sh` script. These tools are installed manually and
+self-update via their own update commands; the `install.sh` script calls those
 commands automatically when the tool is present in PATH.
 
 ## Antigravity (agy)
@@ -24,7 +24,7 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 agy update
 ```
 
-Called automatically by the `install` script when `agy` is in PATH.
+Called automatically by the `install.sh` script when `agy` is in PATH.
 
 ## Claude Code
 
@@ -54,7 +54,7 @@ Two casks are available: `claude-code` (stable, ~1 week behind) and
 claude update
 ```
 
-Called automatically by the `install` script when `claude` is in PATH. Native
+Called automatically by the `install.sh` script when `claude` is in PATH. Native
 installs also auto-update in the background. For Homebrew installs, use
 `brew upgrade claude-code` instead.
 
@@ -107,6 +107,6 @@ brew install --cask codex
 codex update
 ```
 
-Called automatically by the `install` script when `codex` is in PATH.
+Called automatically by the `install.sh` script when `codex` is in PATH.
 
 [cc-versioning]: https://code.claude.com/docs/en/setup.md#install-a-specific-version

--- a/skills/agent-tools/references/software-installation.md
+++ b/skills/agent-tools/references/software-installation.md
@@ -1,8 +1,8 @@
 # Software Installation
 
 This document covers installation of CLI tools that are managed as optional
-entries in the dotfiles `update` script. These tools are installed manually and
-self-update via their own update commands; the `update` script calls those
+entries in the dotfiles `install` script. These tools are installed manually and
+self-update via their own update commands; the `install` script calls those
 commands automatically when the tool is present in PATH.
 
 ## Antigravity (agy)
@@ -24,7 +24,7 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 agy update
 ```
 
-Called automatically by the `update` script when `agy` is in PATH.
+Called automatically by the `install` script when `agy` is in PATH.
 
 ## Claude Code
 
@@ -54,7 +54,7 @@ Two casks are available: `claude-code` (stable, ~1 week behind) and
 claude update
 ```
 
-Called automatically by the `update` script when `claude` is in PATH. Native
+Called automatically by the `install` script when `claude` is in PATH. Native
 installs also auto-update in the background. For Homebrew installs, use
 `brew upgrade claude-code` instead.
 
@@ -107,6 +107,6 @@ brew install --cask codex
 codex update
 ```
 
-Called automatically by the `update` script when `codex` is in PATH.
+Called automatically by the `install` script when `codex` is in PATH.
 
 [cc-versioning]: https://code.claude.com/docs/en/setup.md#install-a-specific-version

--- a/skills/coding-standards/scripts/command-index-sync
+++ b/skills/coding-standards/scripts/command-index-sync
@@ -67,7 +67,7 @@ Exit Codes:
 Examples:
   {SCRIPT_NAME} skills/agent-tools/references/command-index.md
   {SCRIPT_NAME} --all
-  {SCRIPT_NAME} --check --all   # detect drift, e.g. from ./install
+  {SCRIPT_NAME} --check --all   # detect drift, e.g. from ./install.sh
 """,
         file=sys.stdout if code == 0 else sys.stderr,
     )

--- a/skills/coding-standards/scripts/command-index-sync
+++ b/skills/coding-standards/scripts/command-index-sync
@@ -67,7 +67,7 @@ Exit Codes:
 Examples:
   {SCRIPT_NAME} skills/agent-tools/references/command-index.md
   {SCRIPT_NAME} --all
-  {SCRIPT_NAME} --check --all   # detect drift, e.g. from ./update
+  {SCRIPT_NAME} --check --all   # detect drift, e.g. from ./install
 """,
         file=sys.stdout if code == 0 else sys.stderr,
     )


### PR DESCRIPTION
Renames the `update` script to `install.sh` and adds support for running directly from the network via `curl | bash`, with automatic repository cloning and re-execution.

## Summary

The `update` script is renamed to `install.sh` to better reflect its dual purpose as both an installer and updater. The script now supports two execution modes:

1. **Local execution** (`./install.sh`): Traditional on-disk execution
2. **Network execution** (`curl ... | bash`): Automatically clones the repository to `~/.dotfiles` if absent, configures the push remote for SSH, and re-executes the on-disk copy

## Key Changes

- **Script rename**: `update` → `install.sh` across all references (documentation, CI workflows, comments)
- **Bash compatibility checks**: Added early validation to ensure the script runs under bash (not sh/dash/zsh), requires bash 3.2+, and is not in POSIX mode. These checks use only POSIX syntax to degrade gracefully on non-bash shells
- **Network bootstrap logic**: When `BASH_SOURCE[0]` is empty (piped from network), the script clones the repository if needed, configures the SSH push remote, and re-executes the on-disk copy with original arguments
- **Updated documentation**: 
  - Installation section now documents both execution modes with examples
  - Usage help text updated with network installation examples
  - README clarifies the dual install/update purpose and network capability
  - All references to `update` in documentation, skills, and CI workflows updated to `install.sh`

## Implementation Details

- Bootstrap logic checks for `BASH_SOURCE[0]` to detect network execution (empty when piped)
- Uses `DOTFILES` environment variable (defaulting to `~/.dotfiles`) for repository location
- Validates git availability before attempting clone
- Configures push remote to use SSH (`git@github.com:...`) while keeping HTTPS for fetch
- Re-execution preserves all original command-line arguments via `"$@"`
- Compatibility checks run before `set -euo pipefail` since `pipefail` is not POSIX

https://claude.ai/code/session_01R9ohEX4TiLpmADRCXJPcyG