### PR TITLE
Redesign envrc skills management with add/remove/list operations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,13 +69,15 @@ ad-hoc or manual fashion across the `envrc` command, `skill` command, and
 - `[ ]` **Move general functionality into `envrc` command:** Transition generic
   block modification, section parsing, and updating of environment variables
   into [envrc](bin/envrc).
-- `[ ]` **Support list-based environment variables:** Allow `envrc` to push,
+- `[x]` **Support list-based environment variables:** Allow `envrc` to push,
   pop, or modify values within space-separated environment variables (e.g., list
-  manipulation) in `.envrc`.
-- `[ ]` **Automate `AGENT_REQUIRED_SKILLS` updates:** Provide a way to
+  manipulation) in `.envrc`. *(Done for the skills block: `envrc add|remove|list
+  skills` operate on items; `envrc create|delete` manage whole blocks.)*
+- `[x]` **Automate `AGENT_REQUIRED_SKILLS` updates:** Provide a way to
   automatically add/remove/negate items in the `AGENT_REQUIRED_SKILLS` variable
   when using `skill add` / `skill remove` rather than printing manual
-  directions.
+  directions. *(Resolved: `skill` now prints ready-to-run `envrc add skills ...`
+  commands; deliberately does not invoke `envrc` automatically.)*
 - `[ ]` **Standardize write paths:** Audit where other commands (such as
   `permission` or setup scripts) prompt or modify environment configuration, and
   ensure they route their operations through the unified `envrc` utility to

--- a/bin/envrc
+++ b/bin/envrc
@@ -141,6 +141,7 @@ append_block() {
 allow_direnv() {
   if [[ "$ENVRC_FILE" == ".envrc" ]] && command -v direnv >/dev/null 2>&1; then
     direnv allow
+    echo "$SCRIPT_NAME: changes take effect at the next prompt (run 'direnv reload' to apply them now)" >&2
   fi
 }
 

--- a/bin/envrc
+++ b/bin/envrc
@@ -1,39 +1,54 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Tests: tests/envrc/
+
 SCRIPT_NAME=$(basename "$0")
 ENVRC_FILE=".envrc"
 
 usage() {
   cat <<EOF
 Usage: $SCRIPT_NAME [options] <command> [args...]
-Manage specific configuration blocks within a .envrc file.
-Allows multiple configurations to co-exist safely.
+
+Manage configuration blocks within a .envrc file. Blocks are delimited by
+managed marker comments so multiple configurations can co-exist safely. The
+'skills' block holds a list that can be edited item-by-item.
 
 Options:
   --output FILE  Path to the output file (default: .envrc)
   --help         Display this help message and exit
 
 Commands:
-  add <type> [args...]   Add or update a configuration block
-  remove <type>          Remove a configuration block
-  list                   List active configuration types in .envrc
-  types                  List available configuration types
+  create <type> [args...]  Create a configuration block
+  delete <type>            Delete an entire configuration block
+  add skills NAME...       Add skills to the skills block (creates it if needed)
+  remove skills NAME...    Remove skills from the skills block (alias: rm);
+                           names provided by the environment default are
+                           excluded with a '-NAME' negation instead
+  list [skills]            List active blocks, or the skills in the skills block
+  catalog                  List available configuration types
 
 Types:
-  git-identity-beebo     Adds Git author identity variables
-  node [VERSION]         Adds Node.js direnv layout (default version: 24)
-  ruby [VERSION]         Adds Ruby direnv layout (default version: 3.4)
-  firebase <PROJECT_ID>  Adds Firebase project variables
+  git-identity-beebo       Adds Git author identity variables
+  node [VERSION]           Adds Node.js direnv layout (default version: 24)
+  ruby [VERSION]           Adds Ruby direnv layout (default version: 3.4)
+  firebase <PROJECT_ID>    Adds Firebase project variables
   appengine <APP_ID> [URL] Adds Google App Engine variables
-  skills                 Adds agent skills environment variables
+  skills [NAME...]         Adds the agent skills list (AGENT_REQUIRED_SKILLS)
 
 Examples:
-  $SCRIPT_NAME add git-identity-beebo
-  $SCRIPT_NAME add node 22
-  $SCRIPT_NAME add firebase my-project-id
-  $SCRIPT_NAME add skills
-  $SCRIPT_NAME remove node
+  $SCRIPT_NAME create git-identity-beebo
+  $SCRIPT_NAME create node 22
+  $SCRIPT_NAME add skills adb jetpack
+  $SCRIPT_NAME remove skills stillers
+  $SCRIPT_NAME list skills
+  $SCRIPT_NAME delete node
+
+The skills block contains a 'skills NAME...' line (a direnv function defined
+in ~/.direnvrc) that appends to the AGENT_REQUIRED_SKILLS environment
+variable. Prefix a name with '-' or '!' to exclude a globally required skill;
+'remove' writes the negation automatically when the name comes from the
+environment default rather than from the block itself.
 EOF
   exit 0
 }
@@ -71,6 +86,26 @@ require() {
   }
 }
 
+lc() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_list_type() {
+  [[ "$1" == "skills" ]]
+}
+
+block_exists() {
+  [[ -f "$ENVRC_FILE" ]] && grep -qF "# >>> envrc managed block: $1 >>>" "$ENVRC_FILE"
+}
+
+# Print the lines between (excluding) a block's markers
+get_block_content() {
+  local mark_begin="# >>> envrc managed block: $1 >>>"
+  local mark_end="# <<< envrc managed block: $1 <<<"
+  awk -v s="$mark_begin" -v e="$mark_end" \
+    '$0==s{b=1; next} $0==e{b=0; next} b{print}' "$ENVRC_FILE"
+}
+
 # Safely remove an existing managed block
 remove_block() {
   local type="$1"
@@ -103,7 +138,150 @@ append_block() {
   } >>"$ENVRC_FILE"
 }
 
+allow_direnv() {
+  if [[ "$ENVRC_FILE" == ".envrc" ]] && command -v direnv >/dev/null 2>&1; then
+    direnv allow
+  fi
+}
+
+# Case-insensitive membership test: list_contains NEEDLE ITEM...
+list_contains() {
+  local needle item
+  needle=$(lc "$1")
+  shift
+  for item in "$@"; do
+    if [[ "$(lc "$item")" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print ITEM... with TOKEN dropped (case-insensitive): drop_token TOKEN ITEM...
+drop_token() {
+  local target item out=""
+  target=$(lc "$1")
+  shift
+  for item in "$@"; do
+    if [[ "$(lc "$item")" != "$target" ]]; then
+      out="${out:+$out }$item"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# Print the skills block's items, one per line. Understands the canonical
+# 'skills NAME...' line as well as the legacy raw-export form (which gets
+# rewritten canonically on the next mutation). Returns 1 on any line it does
+# not understand, so hand-crafted blocks are never silently clobbered.
+read_skills_items() {
+  local content line trimmed rest item
+  # shellcheck disable=SC2016 # single quotes intended: match a literal '$AGENT_REQUIRED_SKILLS'
+  local legacy_re='^export[[:space:]]+AGENT_REQUIRED_SKILLS="\$AGENT_REQUIRED_SKILLS([^"]*)"$'
+  content=$(get_block_content skills)
+  while IFS= read -r line; do
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    if [[ -z "$trimmed" || "$trimmed" == "#"* ]]; then
+      continue
+    fi
+    rest=""
+    if [[ "$trimmed" == "skills" ]]; then
+      :
+    elif [[ "$trimmed" == skills\ * ]]; then
+      rest="${trimmed#skills }"
+    elif [[ "$trimmed" =~ $legacy_re ]]; then
+      rest="${BASH_REMATCH[1]}"
+    else
+      return 1
+    fi
+    # shellcheck disable=SC2086 # word splitting of the item list is intended
+    for item in $rest; do
+      printf '%s\n' "$item"
+    done
+  done <<<"$content"
+  return 0
+}
+
+# Load the skills block items into $ITEMS (space-separated), or exit with an
+# error if the block content is not machine-editable.
+load_skills_items() {
+  local caller="$1" raw
+  ITEMS=""
+  if ! raw=$(read_skills_items); then
+    echo "$SCRIPT_NAME $caller: skills block in $ENVRC_FILE has unrecognized content;" \
+      "edit it manually or run '$SCRIPT_NAME delete skills' and recreate it" >&2
+    exit 1
+  fi
+  local item
+  # shellcheck disable=SC2086 # word splitting of the item list is intended
+  for item in $raw; do
+    ITEMS="${ITEMS:+$ITEMS }$item"
+  done
+}
+
+write_skills_block() {
+  local items="$1" content="skills"
+  if [[ -n "$items" ]]; then
+    content="skills $items"
+  fi
+  remove_block skills
+  append_block skills "$content"
+}
+
+# Print the effective required-skills list from the inherited environment,
+# applying the '-name'/'!name' negation mini-language (mirrors 'skill').
+env_required_skills() {
+  local tok name item out="" newout
+  # shellcheck disable=SC2086 # word splitting of the env list is intended
+  for tok in ${AGENT_REQUIRED_SKILLS:-}; do
+    case "$tok" in
+      -* | !*)
+        name="${tok#?}"
+        newout=""
+        # shellcheck disable=SC2086
+        for item in $out; do
+          if [[ "$(lc "$item")" != "$(lc "$name")" ]]; then
+            newout="${newout:+$newout }$item"
+          fi
+        done
+        out="$newout"
+        ;;
+      *)
+        # shellcheck disable=SC2086
+        if ! list_contains "$tok" $out; then
+          out="${out:+$out }$tok"
+        fi
+        ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 cmd_list() {
+  if [[ "${1:-}" == "--help" ]]; then
+    usage
+  fi
+
+  if [[ $# -ge 1 ]]; then
+    local type="$1"
+    if ! is_list_type "$type"; then
+      echo "$SCRIPT_NAME list: '$type' is not a list-valued block" >&2
+      exit 1
+    fi
+    if ! block_exists skills; then
+      echo "No skills block in $ENVRC_FILE" >&2
+      return
+    fi
+    load_skills_items list
+    local item
+    # shellcheck disable=SC2086 # word splitting of the item list is intended
+    for item in $ITEMS; do
+      printf '%s\n' "$item"
+    done
+    return
+  fi
+
   if [[ ! -f "$ENVRC_FILE" ]]; then
     echo "No active configurations (no $ENVRC_FILE found)"
     return
@@ -120,14 +298,105 @@ cmd_list() {
   fi
 }
 
-cmd_types() {
+cmd_catalog() {
   echo "Available types:"
-  echo "  git-identity-beebo"
-  echo "  node"
-  echo "  ruby"
-  echo "  firebase"
-  echo "  appengine"
-  echo "  skills"
+  echo "  git-identity-beebo       Git author identity variables"
+  echo "  node [VERSION]           Node.js direnv layout"
+  echo "  ruby [VERSION]           Ruby direnv layout"
+  echo "  firebase PROJECT_ID      Firebase project variables"
+  echo "  appengine APP_ID [URL]   Google App Engine variables"
+  echo "  skills [NAME...]         Agent skills list (supports add/remove/list)"
+}
+
+cmd_delete() {
+  if [[ "${1:-}" == "--help" ]]; then
+    usage
+  fi
+
+  if [[ $# -lt 1 ]]; then
+    echo "$SCRIPT_NAME delete: missing configuration type" >&2
+    exit 1
+  fi
+
+  local type="$1"
+  if ! block_exists "$type"; then
+    echo "$SCRIPT_NAME delete: no '$type' block in $ENVRC_FILE" >&2
+    return
+  fi
+  remove_block "$type"
+
+  echo "$SCRIPT_NAME: deleted '$type' configuration block from $ENVRC_FILE" >&2
+  allow_direnv
+}
+
+cmd_add() {
+  if [[ "${1:-}" == "--help" ]]; then
+    usage
+  fi
+
+  if [[ $# -lt 1 ]]; then
+    echo "$SCRIPT_NAME add: missing configuration type" >&2
+    exit 1
+  fi
+
+  local type="$1"
+  shift
+  if ! is_list_type "$type"; then
+    echo "$SCRIPT_NAME add: '$type' is not a list-valued block; use '$SCRIPT_NAME create $type'" >&2
+    exit 1
+  fi
+  if [[ $# -lt 1 ]]; then
+    echo "$SCRIPT_NAME add: skill name required (to create an empty block, use '$SCRIPT_NAME create skills')" >&2
+    exit 1
+  fi
+
+  ITEMS=""
+  if block_exists skills; then
+    load_skills_items add
+  fi
+
+  local changed=0 name bare
+  for name in "$@"; do
+    case "$name" in
+      -* | !*)
+        # Explicit negation request: exclude the named skill
+        bare="${name#?}"
+        # shellcheck disable=SC2086 # word splitting of the item list is intended
+        if list_contains "-$bare" $ITEMS || list_contains "!$bare" $ITEMS; then
+          echo "$SCRIPT_NAME add: '$bare' is already excluded" >&2
+        else
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "$bare" $ITEMS)
+          ITEMS="${ITEMS:+$ITEMS }-$bare"
+          changed=1
+          echo "$SCRIPT_NAME: excluded '$bare'" >&2
+        fi
+        ;;
+      *)
+        # shellcheck disable=SC2086 # word splitting of the item list is intended
+        if list_contains "-$name" $ITEMS || list_contains "!$name" $ITEMS; then
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "-$name" $ITEMS)
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "!$name" $ITEMS)
+          changed=1
+          echo "$SCRIPT_NAME: re-enabled '$name' (removed negation)" >&2
+        elif list_contains "$name" $ITEMS; then
+          echo "$SCRIPT_NAME add: '$name' already present" >&2
+        else
+          ITEMS="${ITEMS:+$ITEMS }$name"
+          changed=1
+          echo "$SCRIPT_NAME: added '$name'" >&2
+        fi
+        ;;
+    esac
+  done
+
+  if [[ $changed -eq 1 ]]; then
+    write_skills_block "$ITEMS"
+    echo "$SCRIPT_NAME: updated skills block in $ENVRC_FILE" >&2
+    allow_direnv
+  fi
 }
 
 cmd_remove() {
@@ -141,22 +410,74 @@ cmd_remove() {
   fi
 
   local type="$1"
-  remove_block "$type"
+  shift
+  if ! is_list_type "$type"; then
+    echo "$SCRIPT_NAME remove: '$type' is not a list-valued block; to delete the block, use '$SCRIPT_NAME delete $type'" >&2
+    exit 1
+  fi
+  if [[ $# -lt 1 ]]; then
+    echo "$SCRIPT_NAME remove: skill name required (to delete the whole block, use '$SCRIPT_NAME delete skills')" >&2
+    exit 1
+  fi
 
-  echo "$SCRIPT_NAME: removed '$type' configuration from $ENVRC_FILE" >&2
+  ITEMS=""
+  if block_exists skills; then
+    load_skills_items remove
+  fi
 
-  if [[ "$ENVRC_FILE" == ".envrc" ]] && command -v direnv >/dev/null 2>&1; then
-    direnv allow
+  local env_base changed=0 name bare
+  env_base=$(env_required_skills)
+  for name in "$@"; do
+    case "$name" in
+      -* | !*)
+        # Remove an existing negation token (re-enable the default)
+        bare="${name#?}"
+        # shellcheck disable=SC2086 # word splitting of the item list is intended
+        if list_contains "-$bare" $ITEMS || list_contains "!$bare" $ITEMS; then
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "-$bare" $ITEMS)
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "!$bare" $ITEMS)
+          changed=1
+          echo "$SCRIPT_NAME: removed negation of '$bare'" >&2
+        else
+          echo "$SCRIPT_NAME remove: '$name' not present; nothing to do" >&2
+        fi
+        ;;
+      *)
+        # shellcheck disable=SC2086 # word splitting of the item list is intended
+        if list_contains "$name" $ITEMS; then
+          # shellcheck disable=SC2086
+          ITEMS=$(drop_token "$name" $ITEMS)
+          changed=1
+          echo "$SCRIPT_NAME: removed '$name'" >&2
+        elif list_contains "-$name" $ITEMS || list_contains "!$name" $ITEMS; then
+          echo "$SCRIPT_NAME remove: '$name' is already excluded" >&2
+        elif list_contains "$name" $env_base; then
+          ITEMS="${ITEMS:+$ITEMS }-$name"
+          changed=1
+          echo "$SCRIPT_NAME: excluded default skill '$name' (added '-$name')" >&2
+        else
+          echo "$SCRIPT_NAME remove: '$name' not present; nothing to do" >&2
+        fi
+        ;;
+    esac
+  done
+
+  if [[ $changed -eq 1 ]]; then
+    write_skills_block "$ITEMS"
+    echo "$SCRIPT_NAME: updated skills block in $ENVRC_FILE" >&2
+    allow_direnv
   fi
 }
 
-cmd_add() {
+cmd_create() {
   if [[ "${1:-}" == "--help" ]]; then
     usage
   fi
 
   if [[ $# -lt 1 ]]; then
-    echo "$SCRIPT_NAME add: missing configuration type" >&2
+    echo "$SCRIPT_NAME create: missing configuration type" >&2
     exit 1
   fi
 
@@ -204,7 +525,7 @@ EOF
 
     firebase)
       if [[ $# -lt 1 ]]; then
-        echo "$SCRIPT_NAME add firebase: missing PROJECT_ID" >&2
+        echo "$SCRIPT_NAME create firebase: missing PROJECT_ID" >&2
         exit 1
       fi
       require firebase
@@ -226,7 +547,7 @@ EOF
 
     appengine)
       if [[ $# -lt 1 ]]; then
-        echo "$SCRIPT_NAME add appengine: missing APP_ID" >&2
+        echo "$SCRIPT_NAME create appengine: missing APP_ID" >&2
         exit 1
       fi
       local app_id="$1"
@@ -240,19 +561,17 @@ EOF
       ;;
 
     skills)
-      if grep -q "AGENT_REQUIRED_SKILLS=" "$ENVRC_FILE" 2>/dev/null; then
-        echo "$SCRIPT_NAME: error: skills block already exists in $ENVRC_FILE. Edit it manually to manage AGENT_REQUIRED_SKILLS." >&2
+      if block_exists skills; then
+        echo "$SCRIPT_NAME create: skills block already exists in $ENVRC_FILE (use '$SCRIPT_NAME add skills NAME...' to modify it)" >&2
         exit 1
       fi
-      content=$(
-        cat <<'EOF'
-# Set the required agent skills for this workspace.
-# The AGENT_REQUIRED_SKILLS variable supports a mini-language:
-#   - Space-separated names to require skills (e.g. "coding-standards adb")
-#   - Prefix with '-' or '!' to negate/exclude skills (e.g. "-travel" or "!emumanager")
-export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS"
-EOF
-      )
+      if [[ -f "$ENVRC_FILE" ]] && grep -q "AGENT_REQUIRED_SKILLS" "$ENVRC_FILE"; then
+        echo "$SCRIPT_NAME: warning: $ENVRC_FILE already references AGENT_REQUIRED_SKILLS outside a managed block" >&2
+      fi
+      content="skills"
+      if [[ $# -gt 0 ]]; then
+        content="skills $*"
+      fi
       ;;
 
     *)
@@ -264,16 +583,19 @@ EOF
   remove_block "$type"
   append_block "$type" "$content"
 
-  echo "$SCRIPT_NAME: added '$type' configuration to $ENVRC_FILE" >&2
-
-  if [[ "$ENVRC_FILE" == ".envrc" ]] && command -v direnv >/dev/null 2>&1; then
-    direnv allow
-  fi
+  echo "$SCRIPT_NAME: created '$type' configuration block in $ENVRC_FILE" >&2
+  allow_direnv
 }
 
 case "$COMMAND" in
   help)
     usage
+    ;;
+  create)
+    cmd_create "$@"
+    ;;
+  delete)
+    cmd_delete "$@"
     ;;
   add)
     cmd_add "$@"
@@ -282,13 +604,14 @@ case "$COMMAND" in
     cmd_remove "$@"
     ;;
   list)
-    cmd_list
+    cmd_list "$@"
     ;;
-  types)
-    cmd_types
+  catalog | types)
+    cmd_catalog
     ;;
   *)
     echo "$SCRIPT_NAME: unknown command: $COMMAND" >&2
+    echo "Try '$SCRIPT_NAME --help' for more information." >&2
     exit 1
     ;;
 esac

--- a/fish/completions/envrc.fish
+++ b/fish/completions/envrc.fish
@@ -38,22 +38,28 @@ function __fish_envrc_needs_command
     test (count $parsed) -eq 0
 end
 
-# Helper function: check if we are completing the configuration type
+# Helper function: check if we are completing the block type for create/delete
 function __fish_envrc_needs_type
     set -l parsed (__fish_envrc_parse)
-    test (count $parsed) -eq 1; and contains "$parsed[1]" add remove rm
+    test (count $parsed) -eq 1; and contains "$parsed[1]" create delete
+end
+
+# Helper function: check if we are completing the list type for add/remove/list
+function __fish_envrc_needs_list_type
+    set -l parsed (__fish_envrc_parse)
+    test (count $parsed) -eq 1; and contains "$parsed[1]" add remove rm list
 end
 
 # Helper function: check if we are completing the node version
 function __fish_envrc_needs_node_version
     set -l parsed (__fish_envrc_parse)
-    test (count $parsed) -eq 2; and test "$parsed[1]" = add; and test "$parsed[2]" = node
+    test (count $parsed) -eq 2; and test "$parsed[1]" = create; and test "$parsed[2]" = node
 end
 
 # Helper function: check if we are completing the ruby version
 function __fish_envrc_needs_ruby_version
     set -l parsed (__fish_envrc_parse)
-    test (count $parsed) -eq 2; and test "$parsed[1]" = add; and test "$parsed[2]" = ruby
+    test (count $parsed) -eq 2; and test "$parsed[1]" = create; and test "$parsed[2]" = ruby
 end
 
 # Helper function: list available types
@@ -89,15 +95,20 @@ end
 complete -c envrc -f
 
 # Complete subcommands
-complete -c envrc -n __fish_envrc_needs_command -a add -d 'Add or update a configuration block'
-complete -c envrc -n __fish_envrc_needs_command -a remove -d 'Remove a configuration block'
-complete -c envrc -n __fish_envrc_needs_command -a rm -d 'Remove a configuration block'
-complete -c envrc -n __fish_envrc_needs_command -a list -d 'List active configuration types in .envrc'
-complete -c envrc -n __fish_envrc_needs_command -a types -d 'List available configuration types'
+complete -c envrc -n __fish_envrc_needs_command -a create -d 'Create a configuration block'
+complete -c envrc -n __fish_envrc_needs_command -a delete -d 'Delete an entire configuration block'
+complete -c envrc -n __fish_envrc_needs_command -a add -d 'Add skills to the skills block'
+complete -c envrc -n __fish_envrc_needs_command -a remove -d 'Remove skills from the skills block'
+complete -c envrc -n __fish_envrc_needs_command -a rm -d 'Remove skills from the skills block'
+complete -c envrc -n __fish_envrc_needs_command -a list -d 'List active blocks or skills'
+complete -c envrc -n __fish_envrc_needs_command -a catalog -d 'List available configuration types'
 complete -c envrc -n __fish_envrc_needs_command -a help -d 'Display help message and exit'
 
-# Complete types for add, remove, rm
+# Complete types for create, delete
 complete -c envrc -n __fish_envrc_needs_type -a '(__fish_envrc_types)'
+
+# Complete list-valued types for add, remove, rm, list
+complete -c envrc -n __fish_envrc_needs_list_type -a skills -d 'Agent skills list'
 
 # Complete node versions
 complete -c envrc -n __fish_envrc_needs_node_version -a '(__fish_envrc_node_versions)'

--- a/home/.direnvrc
+++ b/home/.direnvrc
@@ -84,20 +84,30 @@ layout_uv() {
 # Agent-assisted Development - Skills & Preflight Gates
 #
 # Customize the required skills for local agent development on a per-directory
-# basis by setting AGENT_REQUIRED_SKILLS in your .envrc file.
+# basis with the skills function below, which appends its arguments to the
+# AGENT_REQUIRED_SKILLS environment variable.
 #
 # Default globally mandated skills (e.g. agent-tools, coding-standards,
 # workspace-config, stillers, corp-airlock) can be added to or subtracted from.
 #
 # Options (in .envrc):
 #
-#   1. Add a required skill:
-#      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS my-custom-skill"
+#   1. Add required skills:
+#      skills my-custom-skill another-skill
 #
 #   2. Opt-out/Blacklist a globally required skill (case-insensitive, using - or !):
-#      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS -stillers"
-#      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS !corp-airlock"
+#      skills -stillers
+#      skills !corp-airlock
+#
+# The 'envrc' command maintains this line inside a managed block
+# ('envrc add skills NAME', 'envrc remove skills NAME'), but the function can
+# equally be called by hand anywhere in .envrc. Raw
+# 'export AGENT_REQUIRED_SKILLS=...' assignments continue to work as before.
 #
 # Negated skills are automatically subtracted from the preflight check, and
 # 'git-setup' (skill apply) will actively ignore and suppress them during
 # bootstrapping, respecting your local repository opt-out.
+
+skills() {
+  export AGENT_REQUIRED_SKILLS="${AGENT_REQUIRED_SKILLS-} $*"
+}

--- a/skills/workspace-config/SKILL.md
+++ b/skills/workspace-config/SKILL.md
@@ -69,6 +69,16 @@ skill <command> [arguments]
 
 ### Environment
 
+Variable names follow a two-tier rule: `AGENT_*` variables are **policy** a
+human sets (what agents should do in this workspace); `SKILL_*` variables are
+**plumbing** for this tool (how it finds and links things, rarely touched).
+
+- `AGENT_REQUIRED_SKILLS`: Space-separated skill names this workspace requires;
+  prefix a name with `-` or `!` to exclude a globally required skill. Managed
+  per-workspace via `envrc add skills` / `envrc remove skills` (`.envrc`).
+- `AGENT_PREFLIGHT_SKIP`: When set, `skill preflight` passes without checking —
+  bypass the agent launch gate once with `AGENT_PREFLIGHT_SKIP=1 claude`. (The
+  legacy spelling `_agent_preflight_skip` is still honored.)
 - `SKILL_SOURCE_DIRS`: Colon-separated directories searched for skills by name
   (default: `~/.dotfiles/skills:~/.private/skills:~/.corp/skills` plus the
   catalog cache).

--- a/skills/workspace-config/SKILL.md
+++ b/skills/workspace-config/SKILL.md
@@ -62,7 +62,8 @@ skill <command> [arguments]
   all, `--catalog` for the catalog index).
 - **`clean`**: Remove all managed skills and clear tracking records.
 - **`doctor`**: Diagnose mismatch between desired and on-disk skills
-  (read-only).
+  (read-only). Also warns when `AGENT_REQUIRED_SKILLS` looks stale relative to
+  the workspace's `.envrc` skills declaration (fix: `direnv reload`).
 - **`catalog`**: List all plugin-provided skills and their sources.
 - **`resolve NAME`**: Print the source path a skill name would resolve to.
 

--- a/skills/workspace-config/SKILL.md
+++ b/skills/workspace-config/SKILL.md
@@ -172,6 +172,14 @@ skill add coding-standards
 skill add /path/to/custom-skill
 ```
 
+An ad-hoc `skill add` is pruned by the next `skill apply` unless the skill is
+also declared in `AGENT_REQUIRED_SKILLS`. To persist it, record it in the
+workspace's `.envrc` (the `envrc` command manages the declaration):
+
+```bash
+envrc add skills coding-standards
+```
+
 ### Managing Permissions by Hand
 
 ```bash

--- a/skills/workspace-config/references/model.md
+++ b/skills/workspace-config/references/model.md
@@ -66,6 +66,38 @@ Health is the conjunction of these (plus the agent, plugin-path, and catalog
 checks). `apply` is the idempotent fixpoint: running it makes a workspace
 healthy, and running it again changes nothing.
 
+## The freshness check (advisory)
+
+`AGENT_REQUIRED_SKILLS` is the source of truth `skill` acts on — but in a
+direnv workspace it is a *cache*: the `.envrc` managed skills block (written by
+`envrc`, evaluated via the `skills` function in `~/.direnvrc`) records changes
+that only reach the environment at the next prompt. Between an `.envrc` edit
+and the next direnv reload, the cache is stale.
+
+`check_env_freshness()` detects this by statically parsing the managed block
+(never executing shell) and asserting that every name the block adds appears in
+the parsed environment, and every name it negates does not. Detection is
+deliberately **one-directional**: a name present in the environment but absent
+from the block is unjudgeable, because the base layer (global defaults from the
+shell config) cannot be observed separately. That asymmetry is safe — the
+detectable direction (block declares, env lacks) is the one where acting on the
+stale cache would *destroy* state, while the undetectable direction merely
+delays convergence by one reload.
+
+The result is strictly advisory: it may cause `skill` to **say more or do
+less, never to do something different**:
+
+- **`doctor`** renders it as the *Environment Freshness* check (WARNING) with a
+  `direnv reload` resolution step.
+- **`apply`** declines to run its pruning phase while stale (additions still
+  proceed; they are harmless), telling the user to reload and re-run.
+- Nothing ever merges block contents into the expected-skills set. If that
+  ever seems desirable, the correct design is to recompute the environment via
+  `direnv export` — not a partial merge here.
+
+A block whose content the parser does not recognize yields *no* freshness data
+(the check disappears entirely): an advisory signal must not guess.
+
 ## The one exception: doctor vs. preflight severity
 
 `doctor` and `preflight` run the *same* checks but answer different questions,
@@ -78,7 +110,7 @@ so they weigh findings differently:
   launch; WARNING findings are suppressed from its output and do not stop the
   agent.
 
-This is the single, deliberate asymmetry in the model. It exists because two
+This is the single, deliberate asymmetry in the model. It exists because three
 checks are advisory rather than blocking:
 
 - **Orphaned Directories** (WARNING): a `.claude/skills` or `.agents/skills`
@@ -93,6 +125,11 @@ checks are advisory rather than blocking:
 - **Catalog Cache** staleness (WARNING): a cached remote catalog stub is older
   than its source. Advisory only, and never consulted at launch — `preflight`
   runs with `check_catalog=False`.
+- **Environment Freshness** (WARNING): the `.envrc` managed skills block
+  declares changes that `AGENT_REQUIRED_SKILLS` does not reflect yet (see "The
+  freshness check" above). The skills an agent actually loads come from the
+  on-disk symlinks, which may well match the declared intent — only the
+  environment copy is behind — so blocking launch on it would be wrong.
 
 Everything else a `doctor` reports is an ERROR and blocks launch: a missing
 skill, a dangling symlink, unmanaged junk, exclude drift, a missing plugin local

--- a/skills/workspace-config/references/model.md
+++ b/skills/workspace-config/references/model.md
@@ -108,7 +108,9 @@ so they weigh findings differently:
 - **`skill preflight LABEL`** is the gate run just before an agent launches (it
   calls `cmd_doctor(errors_only=True)`). Only **ERROR**-severity findings block
   launch; WARNING findings are suppressed from its output and do not stop the
-  agent.
+  agent. Setting `AGENT_PREFLIGHT_SKIP` (legacy spelling:
+  `_agent_preflight_skip`) bypasses the gate entirely; the failure message
+  advertises this escape hatch so it never has to be remembered.
 
 This is the single, deliberate asymmetry in the model. It exists because three
 checks are advisory rather than blocking:

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -1455,9 +1455,13 @@ def cmd_apply(args):
 
 
 def cmd_preflight(caller_label):
-    if os.environ.get("_agent_preflight_skip"):
+    # AGENT_PREFLIGHT_SKIP is the documented name; _agent_preflight_skip is
+    # the legacy spelling, honored indefinitely for old configs.
+    if os.environ.get("AGENT_PREFLIGHT_SKIP") or os.environ.get(
+        "_agent_preflight_skip"
+    ):
         print(
-            f"{caller_label}: skill check skipped (_agent_preflight_skip set)",
+            f"{caller_label}: skill check skipped (AGENT_PREFLIGHT_SKIP set)",
             file=sys.stderr,
         )
         sys.exit(0)
@@ -1477,6 +1481,10 @@ def cmd_preflight(caller_label):
     if not is_healthy:
         print(
             f"{caller_label}: error: preflight check failed in workspace: {ws.root}",
+            file=sys.stderr,
+        )
+        print(
+            f"{caller_label}: to launch anyway: AGENT_PREFLIGHT_SKIP=1 {caller_label}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -9,6 +9,7 @@
 
 import json
 import os
+import re
 import sys
 import time
 import tarfile
@@ -1237,15 +1238,15 @@ def cmd_update(names):
             print(f"skill update: unknown skill '{name}'", file=sys.stderr)
 
 
-def get_parsed_skills():
+def parse_skill_tokens(tokens):
     """
-    Parses AGENT_REQUIRED_SKILLS from environment.
-    Returns a tuple: (required_set, negated_set)
+    Folds a list of skill tokens ('name', '-name', '!name') into
+    (required_set, negated_set) — the same mini-language AGENT_REQUIRED_SKILLS
+    uses, applied to any token source.
     """
-    env_val = os.environ.get("AGENT_REQUIRED_SKILLS", "")
     required_set = []
     negated_set = []
-    for spec in env_val.split():
+    for spec in tokens:
         if spec.startswith("-") or spec.startswith("!"):
             clean_name = spec[1:]
             negated_set.append(clean_name.lower())
@@ -1256,6 +1257,94 @@ def get_parsed_skills():
             if spec not in required_set:
                 required_set.append(spec)
     return required_set, negated_set
+
+
+def get_parsed_skills():
+    """
+    Parses AGENT_REQUIRED_SKILLS from environment.
+    Returns a tuple: (required_set, negated_set)
+    """
+    return parse_skill_tokens(os.environ.get("AGENT_REQUIRED_SKILLS", "").split())
+
+
+ENVRC_SKILLS_MARK_BEGIN = "# >>> envrc managed block: skills >>>"
+ENVRC_SKILLS_MARK_END = "# <<< envrc managed block: skills <<<"
+ENVRC_LEGACY_EXPORT_RE = re.compile(
+    r'^export\s+AGENT_REQUIRED_SKILLS="\$AGENT_REQUIRED_SKILLS([^"]*)"$'
+)
+
+
+def read_envrc_declared_skills(ws):
+    """Statically read the skill tokens declared in the workspace's .envrc
+    managed skills block (written by 'envrc'), without executing any shell.
+
+    Returns the token list, or None when there is nothing trustworthy to read:
+    no .envrc, no managed block, or block content the parser does not
+    recognize. The freshness check built on this is advisory, so it must never
+    guess.
+    """
+    envrc = ws.root / ".envrc"
+    if not envrc.is_file():
+        return None
+    try:
+        lines = envrc.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    in_block = False
+    found = False
+    tokens = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == ENVRC_SKILLS_MARK_BEGIN:
+            in_block = True
+            found = True
+            continue
+        if stripped == ENVRC_SKILLS_MARK_END:
+            in_block = False
+            continue
+        if not in_block or not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "skills" or stripped.startswith("skills "):
+            tokens.extend(stripped.split()[1:])
+            continue
+        m = ENVRC_LEGACY_EXPORT_RE.match(stripped)
+        if m:
+            tokens.extend(m.group(1).split())
+            continue
+        return None
+    if not found:
+        return None
+    return tokens
+
+
+def check_env_freshness(ws):
+    """Compare the skills declared in .envrc's managed block against the
+    inherited AGENT_REQUIRED_SKILLS (the source of truth skill acts on).
+
+    Returns None when there is nothing to compare, else a tuple
+    (declared_but_missing, negated_but_still_present): names the block adds
+    that the environment does not reflect, and names the block negates that
+    the environment still contains. Either being non-empty means the
+    environment is a stale cache of the .envrc (direnv has not reloaded yet).
+
+    The detection is deliberately one-directional: the reverse (a name in the
+    environment that the block no longer mentions) is unjudgeable, because the
+    base layer (global defaults) cannot be observed separately. The result is
+    advisory only — callers may warn or decline destructive work, but must
+    never merge it into the desired set.
+    """
+    tokens = read_envrc_declared_skills(ws)
+    if tokens is None:
+        return None
+    decl_required, decl_negated = parse_skill_tokens(tokens)
+    env_required, _ = get_parsed_skills()
+    env_lower = {r.lower() for r in env_required}
+    missing = [d for d in decl_required if d.lower() not in env_lower]
+    stale_negated = []
+    for n in decl_negated:
+        if n in env_lower and n not in stale_negated:
+            stale_negated.append(n)
+    return missing, stale_negated
 
 
 def cmd_apply(args):
@@ -1316,20 +1405,50 @@ def cmd_apply(args):
                     pass
 
     if extra_skills:
-        for s in extra_skills:
-            if is_using_envrc(ws):
-                print(
-                    f"skill: pruning extra symlink not in AGENT_REQUIRED_SKILLS: '{s}'. "
-                    f"(To keep it, run: envrc add skills {s})",
-                    file=sys.stderr,
+        # Freshness interlock: when .envrc declares changes the environment
+        # does not reflect yet, the desired set we are about to enforce is a
+        # stale cache. Do less, not different: skip the destructive prune and
+        # tell the human how to refresh. (Adding symlinks above is harmless
+        # and proceeds regardless.)
+        freshness = check_env_freshness(ws)
+        if freshness is not None and (freshness[0] or freshness[1]):
+            fresh_missing, fresh_negated = freshness
+            reasons = []
+            if fresh_missing:
+                reasons.append(
+                    f".envrc declares {', '.join(repr(s) for s in fresh_missing)} "
+                    "not reflected in AGENT_REQUIRED_SKILLS"
                 )
-            else:
-                print(
-                    f"skill: pruning extra symlink not in AGENT_REQUIRED_SKILLS: '{s}'. "
-                    f"(To keep it, add it to the AGENT_REQUIRED_SKILLS environment variable)",
-                    file=sys.stderr,
+            if fresh_negated:
+                reasons.append(
+                    f".envrc negates {', '.join(repr(s) for s in fresh_negated)} "
+                    "still present in AGENT_REQUIRED_SKILLS"
                 )
-        cmd_remove(extra_skills, announce=False)
+            print(
+                f"skill: environment looks stale for this workspace: {'; '.join(reasons)}",
+                file=sys.stderr,
+            )
+            print(
+                f"skill: not pruning {len(extra_skills)} extra symlink(s) while the "
+                "environment is stale; run 'direnv reload' (or start a new prompt), "
+                "then re-run 'skill apply'",
+                file=sys.stderr,
+            )
+        else:
+            for s in extra_skills:
+                if is_using_envrc(ws):
+                    print(
+                        f"skill: pruning extra symlink not in AGENT_REQUIRED_SKILLS: '{s}'. "
+                        f"(To keep it, run: envrc add skills {s})",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"skill: pruning extra symlink not in AGENT_REQUIRED_SKILLS: '{s}'. "
+                        f"(To keep it, add it to the AGENT_REQUIRED_SKILLS environment variable)",
+                        file=sys.stderr,
+                    )
+            cmd_remove(extra_skills, announce=False)
 
     if not add_ok:
         sys.exit(1)
@@ -1958,6 +2077,46 @@ def cmd_doctor(
             }
         )
 
+    # Check 3b: Environment Freshness (advisory).
+    # Compares the .envrc managed skills block (the recording) against
+    # AGENT_REQUIRED_SKILLS (the truth skill acts on). Only rendered when the
+    # workspace has a readable block; WARNING severity so it fails 'doctor'
+    # (a full audit) but never blocks 'preflight' (the launch gate).
+    freshness = check_env_freshness(ws)
+    fresh_missing = []
+    fresh_negated = []
+    if freshness is not None:
+        fresh_missing, fresh_negated = freshness
+        fresh_details = []
+        if fresh_missing:
+            fresh_details.append(
+                "Declared in .envrc but not reflected in the environment:"
+            )
+            fresh_details += [f"  - {s}" for s in fresh_missing]
+        if fresh_negated:
+            fresh_details.append(
+                "Negated in .envrc but still present in the environment:"
+            )
+            fresh_details += [f"  - {s}" for s in fresh_negated]
+        if fresh_details:
+            checks.append(
+                {
+                    "name": "Environment Freshness",
+                    "status": "WARNING",
+                    "summary": "AGENT_REQUIRED_SKILLS does not reflect this workspace's .envrc (stale environment?)",
+                    "details": fresh_details,
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "Environment Freshness",
+                    "status": "OK",
+                    "summary": "The environment reflects .envrc's skills declaration",
+                    "details": [],
+                }
+            )
+
     # Check 4: Symlink Health
     if dangling:
         checks.append(
@@ -2199,6 +2358,11 @@ def cmd_doctor(
 
     # Collect resolution steps
     resolutions = []
+    if fresh_missing or fresh_negated:
+        resolutions.append(
+            "Reload this workspace's environment so AGENT_REQUIRED_SKILLS picks up .envrc:\n"
+            "      direnv reload   # or start a new prompt, then re-run 'skill apply'"
+        )
     if missing or dangling or backend_issues or extra or negated_extra:
         resolutions.append(
             "To synchronize and repair your configuration, run 'git-setup' or 'skill apply'."

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -1039,7 +1039,7 @@ def cmd_add(specs, is_apply=False):
         if not is_apply:
             if is_using_envrc(ws):
                 print(
-                    f"skill: note: to make this permanent, add '{name}' to AGENT_REQUIRED_SKILLS in your .envrc",
+                    f"skill: note: to make this permanent, run: envrc add skills {name}",
                     file=sys.stderr,
                 )
             else:
@@ -1320,7 +1320,7 @@ def cmd_apply(args):
             if is_using_envrc(ws):
                 print(
                     f"skill: pruning extra symlink not in AGENT_REQUIRED_SKILLS: '{s}'. "
-                    f"(To keep it, add it to AGENT_REQUIRED_SKILLS in your .envrc)",
+                    f"(To keep it, run: envrc add skills {s})",
                     file=sys.stderr,
                 )
             else:
@@ -2206,8 +2206,8 @@ def cmd_doctor(
     if extra:
         if is_using_envrc(ws):
             resolutions.append(
-                "Add the extra skill(s) to your AGENT_REQUIRED_SKILLS in .envrc:\n"
-                f'      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS {" ".join(extra)}"\n'
+                "Add the extra skill(s) to your required skills (updates .envrc):\n"
+                f"      envrc add skills {' '.join(extra)}\n"
                 "  - Or remove the local symlink(s):\n"
                 f"      skill remove {' '.join(extra)}"
             )

--- a/skills/workspace-config/tests/test-skill
+++ b/skills/workspace-config/tests/test-skill
@@ -6,7 +6,7 @@ set -euo pipefail
 TEST_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${TEST_DIR}/../scripts/skill"
 
-echo "1..52"
+echo "1..55"
 
 # Need a temporary directory for workspace simulations
 TMPDIR=$(mktemp -d)
@@ -375,6 +375,14 @@ if ! command -v fish >/dev/null 2>&1; then
   echo "ok 26 - [Preflight] managed dir with missing required skill fails # skip fish not available"
   echo "ok 27 - [Preflight] subtraction operator works # skip fish not available"
 else
+  # _agent_preflight calls the bare 'skill' command; make sure that resolves
+  # to the script under test. (procps ships /usr/bin/skill, which would
+  # otherwise shadow it on systems where the dotfiles bin/ is not on PATH.)
+  cat >"$MOCK_BIN_DIR/skill" <<EOF
+#!/usr/bin/env bash
+exec "${SCRIPT}" "\$@"
+EOF
+  chmod +x "$MOCK_BIN_DIR/skill"
   fish -c "
 # Source dependencies
 source '${TEST_DIR}/../../../fish/functions/_agent_preflight.fish'
@@ -997,4 +1005,137 @@ if [ "$doctor_list_rc" -eq 0 ] &&
 else
   echo "not ok 52 - [Diagnostics] doctor failed to list VCS-managed skills (rc=$doctor_list_rc): $doctor_list_out"
 fi
+cd "$TMPDIR"
+
+# ==============================================================================
+# PART 12: Environment Freshness (.envrc managed block vs AGENT_REQUIRED_SKILLS)
+# ==============================================================================
+
+# Test 53: 'apply' declines to prune while the environment is stale (.envrc
+# declares a skill the environment does not reflect), then prunes normally
+# once the environment is fresh.
+FRESH_DIR="${TMPDIR}/freshness-apply"
+mkdir -p "$FRESH_DIR"
+cd "$FRESH_DIR"
+git init -q
+mkdir -p .claude/skills .agents/skills
+cat >.envrc <<'EOF'
+# >>> envrc managed block: skills >>>
+skills emumanager
+# <<< envrc managed block: skills <<<
+EOF
+ln -s "${TMPDIR}/sources/emumanager" .claude/skills/emumanager
+ln -s "${TMPDIR}/sources/emumanager" .agents/skills/emumanager
+
+# Phase 1: stale (env lacks emumanager) -- the extra symlink must survive
+export AGENT_REQUIRED_SKILLS="coding-standards"
+stale_rc=0
+stale_out=$("${SCRIPT}" apply 2>&1) || stale_rc=$?
+phase1_ok=0
+if [ "$stale_rc" -eq 0 ] && [ -L .claude/skills/emumanager ] &&
+  printf '%s\n' "$stale_out" | grep -q "not pruning" &&
+  printf '%s\n' "$stale_out" | grep -q "direnv reload"; then
+  phase1_ok=1
+fi
+
+# Phase 2: fresh (simulated reload) -- emumanager is now desired and stays
+export AGENT_REQUIRED_SKILLS="coding-standards emumanager"
+"${SCRIPT}" apply >/dev/null 2>&1
+phase2_ok=0
+if [ -L .claude/skills/emumanager ] && "${SCRIPT}" doctor >/dev/null 2>&1; then
+  phase2_ok=1
+fi
+
+# Phase 3: a genuinely-extra symlink is still pruned when the env is fresh
+ln -s "${TMPDIR}/sources/test-skill" .claude/skills/test-skill
+ln -s "${TMPDIR}/sources/test-skill" .agents/skills/test-skill
+"${SCRIPT}" apply >/dev/null 2>&1
+phase3_ok=0
+if [ ! -L .claude/skills/test-skill ] && [ ! -L .agents/skills/test-skill ]; then
+  phase3_ok=1
+fi
+
+if [ "$phase1_ok" -eq 1 ] && [ "$phase2_ok" -eq 1 ] && [ "$phase3_ok" -eq 1 ]; then
+  echo "ok 53 - [Freshness] apply skips pruning while stale, prunes when fresh"
+else
+  echo "not ok 53 - [Freshness] apply guard failed (p1=$phase1_ok p2=$phase2_ok p3=$phase3_ok): $stale_out"
+fi
+export AGENT_REQUIRED_SKILLS=""
+cd "$TMPDIR"
+
+# Test 54: doctor reports Environment Freshness as a WARNING (fails doctor,
+# passes preflight), covering both directions: a declared-but-missing skill
+# and a negated-but-still-present skill.
+FRESH_DOC_DIR="${TMPDIR}/freshness-doctor"
+mkdir -p "$FRESH_DOC_DIR"
+cd "$FRESH_DOC_DIR"
+git init -q
+mkdir -p .claude/skills .agents/skills
+cat >.envrc <<'EOF'
+# >>> envrc managed block: skills >>>
+skills test-skill -emumanager
+# <<< envrc managed block: skills <<<
+EOF
+
+# Stale environment, but disk fully matches it (warning-only workspace)
+export AGENT_REQUIRED_SKILLS="coding-standards emumanager"
+"${SCRIPT}" apply >/dev/null 2>&1
+doctor_fresh_rc=0
+doctor_fresh_out=$("${SCRIPT}" doctor 2>&1) || doctor_fresh_rc=$?
+preflight_fresh_rc=0
+preflight_fresh_out=$("${SCRIPT}" preflight 2>&1) || preflight_fresh_rc=$?
+stale_phase_ok=0
+if [ "$doctor_fresh_rc" -ne 0 ] &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "\[!\] Environment Freshness:" &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "Declared in .envrc but not reflected in the environment:" &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "  - test-skill" &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "Negated in .envrc but still present in the environment:" &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "  - emumanager" &&
+  printf '%s\n' "$doctor_fresh_out" | grep -q "direnv reload" &&
+  [ "$preflight_fresh_rc" -eq 0 ] && [ -z "$preflight_fresh_out" ]; then
+  stale_phase_ok=1
+fi
+
+# Fresh environment: the check goes green and doctor passes
+export AGENT_REQUIRED_SKILLS="coding-standards test-skill"
+"${SCRIPT}" apply >/dev/null 2>&1
+doctor_ok_rc=0
+doctor_ok_out=$("${SCRIPT}" doctor 2>&1) || doctor_ok_rc=$?
+ok_phase_ok=0
+if [ "$doctor_ok_rc" -eq 0 ] &&
+  printf '%s\n' "$doctor_ok_out" | grep -q "\[✓\] Environment Freshness:"; then
+  ok_phase_ok=1
+fi
+
+if [ "$stale_phase_ok" -eq 1 ] && [ "$ok_phase_ok" -eq 1 ]; then
+  echo "ok 54 - [Freshness] doctor warns on stale env; preflight passes; fresh env is green"
+else
+  echo "not ok 54 - [Freshness] doctor/preflight severity wrong (stale=$stale_phase_ok ok=$ok_phase_ok): $doctor_fresh_out"
+fi
+export AGENT_REQUIRED_SKILLS=""
+cd "$TMPDIR"
+
+# Test 55: an unrecognized skills block yields no freshness data -- the check
+# is advisory and must not guess, so doctor simply omits it.
+FRESH_BAD_DIR="${TMPDIR}/freshness-bad"
+mkdir -p "$FRESH_BAD_DIR"
+cd "$FRESH_BAD_DIR"
+git init -q
+mkdir -p .claude/skills .agents/skills
+cat >.envrc <<'EOF'
+# >>> envrc managed block: skills >>>
+if [ -n "$SOMETHING" ]; then skills extra; fi
+# <<< envrc managed block: skills <<<
+EOF
+export AGENT_REQUIRED_SKILLS="coding-standards"
+"${SCRIPT}" apply >/dev/null 2>&1
+doctor_bad_rc=0
+doctor_bad_out=$("${SCRIPT}" doctor 2>&1) || doctor_bad_rc=$?
+if [ "$doctor_bad_rc" -eq 0 ] &&
+  ! printf '%s\n' "$doctor_bad_out" | grep -q "Environment Freshness"; then
+  echo "ok 55 - [Freshness] unrecognized block content disables the check"
+else
+  echo "not ok 55 - [Freshness] unrecognized block mishandled (rc=$doctor_bad_rc): $doctor_bad_out"
+fi
+export AGENT_REQUIRED_SKILLS=""
 cd "$TMPDIR"

--- a/skills/workspace-config/tests/test-skill
+++ b/skills/workspace-config/tests/test-skill
@@ -6,7 +6,7 @@ set -euo pipefail
 TEST_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${TEST_DIR}/../scripts/skill"
 
-echo "1..55"
+echo "1..56"
 
 # Need a temporary directory for workspace simulations
 TMPDIR=$(mktemp -d)
@@ -1136,6 +1136,31 @@ if [ "$doctor_bad_rc" -eq 0 ] &&
   echo "ok 55 - [Freshness] unrecognized block content disables the check"
 else
   echo "not ok 55 - [Freshness] unrecognized block mishandled (rc=$doctor_bad_rc): $doctor_bad_out"
+fi
+export AGENT_REQUIRED_SKILLS=""
+cd "$TMPDIR"
+
+# Test 56: AGENT_PREFLIGHT_SKIP bypasses the launch gate (legacy spelling
+# '_agent_preflight_skip' still honored), and the failure message advertises
+# the escape hatch so it never has to be remembered.
+SKIP_DIR="${TMPDIR}/preflight-skip"
+mkdir -p "$SKIP_DIR"
+cd "$SKIP_DIR"
+git init -q
+mkdir -p .claude/skills .agents/skills
+export AGENT_REQUIRED_SKILLS="missing-skill"
+fail_rc=0
+fail_out=$("${SCRIPT}" preflight claude 2>&1) || fail_rc=$?
+skip_rc=0
+AGENT_PREFLIGHT_SKIP=1 "${SCRIPT}" preflight claude >/dev/null 2>&1 || skip_rc=$?
+legacy_rc=0
+_agent_preflight_skip=1 "${SCRIPT}" preflight claude >/dev/null 2>&1 || legacy_rc=$?
+if [ "$fail_rc" -ne 0 ] &&
+  printf '%s\n' "$fail_out" | grep -q "to launch anyway: AGENT_PREFLIGHT_SKIP=1 claude" &&
+  [ "$skip_rc" -eq 0 ] && [ "$legacy_rc" -eq 0 ]; then
+  echo "ok 56 - [Preflight] skip variable bypasses the gate; failure advertises it"
+else
+  echo "not ok 56 - [Preflight] skip handling wrong (fail=$fail_rc skip=$skip_rc legacy=$legacy_rc): $fail_out"
 fi
 export AGENT_REQUIRED_SKILLS=""
 cd "$TMPDIR"

--- a/tests/envrc/test-basic
+++ b/tests/envrc/test-basic
@@ -18,7 +18,7 @@ fail() {
   echo "not ok $n - $1"
 }
 
-echo "1..18"
+echo "1..19"
 export AGENT_REQUIRED_SKILLS=""
 
 f="$TMP/a.envrc"
@@ -188,4 +188,19 @@ if grep -q 'GIT_AUTHOR_NAME' "$f5" && ! grep -q 'skills' "$f5"; then
   ok "delete leaves other blocks intact"
 else
   fail "delete leaves other blocks intact: $(cat "$f5")"
+fi
+
+# 19: mutating a live .envrc (direnv present) prints the reload hint
+live="$TMP/live"
+mkdir -p "$live/bin"
+cat >"$live/bin/direnv" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$live/bin/direnv"
+out=$(cd "$live" && PATH="$live/bin:$PATH" "$BIN" add skills foo 2>&1)
+if printf '%s\n' "$out" | grep -q "direnv reload" && grep -qx 'skills foo' "$live/.envrc"; then
+  ok "mutating a live .envrc prints the reload hint"
+else
+  fail "mutating a live .envrc prints the reload hint: $out"
 fi

--- a/tests/envrc/test-basic
+++ b/tests/envrc/test-basic
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -u
+
+BIN="$(cd "$(dirname "$0")/../.." && pwd)/bin/envrc"
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+# All invocations use --output with an absolute path, so 'direnv allow' is
+# never triggered and the tests are hermetic and parallel-safe.
+
+n=0
+ok() {
+  n=$((n + 1))
+  echo "ok $n - $1"
+}
+fail() {
+  n=$((n + 1))
+  echo "not ok $n - $1"
+}
+
+echo "1..18"
+export AGENT_REQUIRED_SKILLS=""
+
+f="$TMP/a.envrc"
+
+# 1: create skills with initial items writes the canonical line
+"$BIN" --output "$f" create skills foo bar >/dev/null 2>&1
+if grep -qx 'skills foo bar' "$f"; then
+  ok "create skills writes canonical 'skills' line"
+else
+  fail "create skills writes canonical 'skills' line: $(cat "$f")"
+fi
+
+# 2: create refuses to overwrite an existing skills block
+if "$BIN" --output "$f" create skills >/dev/null 2>&1; then
+  fail "create refuses existing skills block"
+else
+  ok "create refuses existing skills block"
+fi
+
+# 3: add merges new items into the existing block
+"$BIN" --output "$f" add skills baz >/dev/null 2>&1
+if grep -qx 'skills foo bar baz' "$f"; then
+  ok "add merges a new item"
+else
+  fail "add merges a new item: $(cat "$f")"
+fi
+
+# 4: adding an existing item is a no-op
+"$BIN" --output "$f" add skills foo >/dev/null 2>&1
+if grep -qx 'skills foo bar baz' "$f" && [ "$(grep -c '^skills ' "$f")" -eq 1 ]; then
+  ok "add of an existing item is a no-op"
+else
+  fail "add of an existing item is a no-op: $(cat "$f")"
+fi
+
+# 5: add auto-creates a missing skills block
+f2="$TMP/b.envrc"
+"$BIN" --output "$f2" add skills alpha >/dev/null 2>&1
+if grep -qx 'skills alpha' "$f2" && grep -qF '# >>> envrc managed block: skills >>>' "$f2"; then
+  ok "add auto-creates the skills block"
+else
+  fail "add auto-creates the skills block: $(cat "$f2")"
+fi
+
+# 6: remove drops an item present in the block
+"$BIN" --output "$f" remove skills bar >/dev/null 2>&1
+if grep -qx 'skills foo baz' "$f"; then
+  ok "remove drops a block item"
+else
+  fail "remove drops a block item: $(cat "$f")"
+fi
+
+# 7: remove of a default-provided skill writes a negation instead
+AGENT_REQUIRED_SKILLS="globaldefault" "$BIN" --output "$f" remove skills globaldefault >/dev/null 2>&1
+if grep -qx 'skills foo baz -globaldefault' "$f"; then
+  ok "remove negates a default-provided skill"
+else
+  fail "remove negates a default-provided skill: $(cat "$f")"
+fi
+
+# 8: add re-enables a negated skill by dropping the negation
+"$BIN" --output "$f" add skills globaldefault >/dev/null 2>&1
+if grep -qx 'skills foo baz' "$f"; then
+  ok "add removes an existing negation"
+else
+  fail "add removes an existing negation: $(cat "$f")"
+fi
+
+# 9: add of an explicit negation excludes the skill
+"$BIN" --output "$f" add skills -foo >/dev/null 2>&1
+if grep -qx 'skills baz -foo' "$f"; then
+  ok "add of '-name' drops the positive and adds the negation"
+else
+  fail "add of '-name' drops the positive and adds the negation: $(cat "$f")"
+fi
+
+# 10: remove of an explicit negation re-enables the default
+"$BIN" --output "$f" remove skills -foo >/dev/null 2>&1
+if grep -qx 'skills baz' "$f"; then
+  ok "remove of '-name' drops the negation token"
+else
+  fail "remove of '-name' drops the negation token: $(cat "$f")"
+fi
+
+# 11: removing an unknown name leaves the file untouched
+before=$(cat "$f")
+"$BIN" --output "$f" remove skills no-such-skill >/dev/null 2>&1
+if [ "$(cat "$f")" = "$before" ]; then
+  ok "remove of an unknown name is a no-op"
+else
+  fail "remove of an unknown name is a no-op: $(cat "$f")"
+fi
+
+# 12: list skills prints one item per line on stdout
+"$BIN" --output "$f" add skills qux >/dev/null 2>&1
+out=$("$BIN" --output "$f" list skills 2>/dev/null)
+if [ "$out" = "baz
+qux" ]; then
+  ok "list skills prints items one per line"
+else
+  fail "list skills prints items one per line: $out"
+fi
+
+# 13: delete removes the whole block including markers
+"$BIN" --output "$f" delete skills >/dev/null 2>&1
+if ! grep -q 'skills' "$f"; then
+  ok "delete removes the whole skills block"
+else
+  fail "delete removes the whole skills block: $(cat "$f")"
+fi
+
+# 14: legacy raw-export blocks are parsed and rewritten canonically
+f3="$TMP/c.envrc"
+cat >"$f3" <<'EOF'
+# >>> envrc managed block: skills >>>
+# a comment that should be dropped on rewrite
+export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS old1 old2"
+# <<< envrc managed block: skills <<<
+EOF
+"$BIN" --output "$f3" add skills new1 >/dev/null 2>&1
+if grep -qx 'skills old1 old2 new1' "$f3" && ! grep -q 'export AGENT_REQUIRED_SKILLS' "$f3"; then
+  ok "legacy export block is migrated to the canonical line"
+else
+  fail "legacy export block is migrated to the canonical line: $(cat "$f3")"
+fi
+
+# 15: unrecognized block content is refused, not clobbered
+f4="$TMP/d.envrc"
+cat >"$f4" <<'EOF'
+# >>> envrc managed block: skills >>>
+if [ -n "$SOMETHING" ]; then skills extra; fi
+# <<< envrc managed block: skills <<<
+EOF
+before=$(cat "$f4")
+if "$BIN" --output "$f4" add skills new1 >/dev/null 2>&1; then
+  fail "unrecognized block content is refused"
+elif [ "$(cat "$f4")" = "$before" ]; then
+  ok "unrecognized block content is refused"
+else
+  fail "unrecognized block content is refused (file was modified): $(cat "$f4")"
+fi
+
+# 16: add on a scalar (non-list) type errors and points at create
+if out=$("$BIN" --output "$f" add node 22 2>&1); then
+  fail "add on a scalar type errors"
+elif printf '%s\n' "$out" | grep -q 'envrc create node'; then
+  ok "add on a scalar type errors and suggests create"
+else
+  fail "add on a scalar type errors and suggests create: $out"
+fi
+
+# 17: remove skills with no names errors and mentions delete
+if out=$("$BIN" --output "$f" remove skills 2>&1); then
+  fail "remove skills with no names errors"
+elif printf '%s\n' "$out" | grep -q 'delete skills'; then
+  ok "remove skills with no names errors and mentions delete"
+else
+  fail "remove skills with no names errors and mentions delete: $out"
+fi
+
+# 18: blocks of different types coexist; delete only touches its own block
+f5="$TMP/e.envrc"
+"$BIN" --output "$f5" create git-identity-beebo >/dev/null 2>&1
+"$BIN" --output "$f5" add skills one two >/dev/null 2>&1
+"$BIN" --output "$f5" delete skills >/dev/null 2>&1
+if grep -q 'GIT_AUTHOR_NAME' "$f5" && ! grep -q 'skills' "$f5"; then
+  ok "delete leaves other blocks intact"
+else
+  fail "delete leaves other blocks intact: $(cat "$f5")"
+fi


### PR DESCRIPTION
## Summary

Redesign the `envrc` command to support fine-grained management of the `skills` block as a list-valued configuration type, separate from scalar types like `node`, `ruby`, and `firebase`. The `skills` block now uses a canonical `skills NAME...` line format (compatible with the `skills` function in `~/.direnvrc`) and supports item-by-item add/remove/list operations with negation support.

## Key Changes

**Command Structure:**
- Rename `add` → `create` for scalar configuration types (git-identity-beebo, node, ruby, firebase, appengine)
- Rename `remove` → `delete` for removing entire blocks
- Introduce `add skills NAME...` to add individual skills to the skills block (auto-creates if missing)
- Introduce `remove skills NAME...` to remove individual skills, with automatic negation for default-provided skills
- Introduce `list [skills]` to list active blocks or items within the skills block
- Rename `types` → `catalog` with improved descriptions

**Skills Block Format:**
- Migrate from raw `export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS..."` to canonical `skills NAME...` line
- Support negation mini-language: `-name` or `!name` to exclude skills from defaults
- Automatically rewrite legacy export-style blocks to canonical format on mutation
- Refuse to modify unrecognized block content (hand-crafted blocks are never silently clobbered)

**Implementation Details:**
- Add helper functions: `lc()` (lowercase), `is_list_type()`, `block_exists()`, `get_block_content()`, `list_contains()`, `drop_token()`, `read_skills_items()`, `load_skills_items()`, `write_skills_block()`, `env_required_skills()`, `allow_direnv()`
- Implement case-insensitive skill name matching throughout
- Improve error messages with actionable suggestions (e.g., "use `envrc create` for scalar types")
- Add comprehensive test suite (`tests/envrc/test-basic`) covering 19 scenarios

**Integration with `skill` Command:**
- Update `skill` to suggest `envrc add skills NAME` instead of manual `.envrc` editing
- Add `read_envrc_declared_skills()` to statically parse the managed skills block without executing shell
- Add `check_env_freshness()` to detect stale environment (`.envrc` declares changes not yet reflected in `AGENT_REQUIRED_SKILLS`)
- Implement freshness interlock in `cmd_apply()`: skip pruning while environment is stale, with user guidance to reload
- Add freshness check to `cmd_doctor()` as a WARNING-level diagnostic
- Update `cmd_preflight()` to honor both `AGENT_PREFLIGHT_SKIP` (documented) and `_agent_preflight_skip` (legacy)

**Documentation:**
- Expand help text with detailed examples and mini-language explanation
- Update `~/.direnvrc` comments to reference the `skills` function instead of manual export
- Add freshness check documentation to `model.md`
- Update `SKILL.md` to document the new `envrc` integration and freshness behavior
- Update Fish shell completions for new command structure

**Test Coverage:**
- Add 19 comprehensive tests for envrc skills operations (create, add, remove, list, delete, negation, legacy migration, error cases)
- Add 4 new tests for skill freshness detection and environment staleness handling
- Verify direnv reload hints are printed when mutating live `.envrc`

https://claude.ai/code/session_01U7sSfUtyeuu5KmNrh2Y31i