### PR TITLE
Replace --force flag with git-hooks-multiplexer

### DIFF
--- a/bin/git-hooks-agent
+++ b/bin/git-hooks-agent
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [doctor] [--force]
+Usage: $(basename "$0") [doctor]
 
 Install git hooks for AI agent workflows into the current repository.
 
@@ -12,18 +12,20 @@ Hooks installed:
 The commit-msg hook edits the message in place before the commit is
 written. Use git-commit-clean to clean up any existing commits.
 
+Hooks are installed via git-hooks-multiplexer, so they coexist with hooks
+from other tools. A pre-existing hook not managed by the multiplexer is
+preserved as .git/hooks/<name>.d/00-legacy and continues to run first.
+
 Commands:
   doctor    Report whether the managed hooks are installed (read-only); does
             not modify the repository. Exits non-zero if anything is missing
             or unmanaged.
 
 Options:
-  --force   Overwrite an existing hook not managed by this tool
   --help    Display this help message and exit
 
 Examples:
   cd ~/project && $(basename "$0")
-  $(basename "$0") --force
   $(basename "$0") doctor
 EOF
   exit 0
@@ -36,18 +38,15 @@ require() {
   }
 }
 
-# MARKER removed, managed by git-hooks-multiplexer
 # Hook source lives alongside the dotfiles tree, two levels up from this script:
 # bin/git-hooks-agent -> etc/git/templates/agent/hooks/.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)
 TEMPLATE_DIR="$SCRIPT_DIR/../etc/git/templates/agent/hooks"
 
-force=0
 mode=install
 for arg in "$@"; do
   case "$arg" in
     --help) usage ;;
-    --force) force=1 ;;
     doctor) mode=doctor ;;
     -*)
       echo "$(basename "$0"): unknown option: $arg" >&2
@@ -62,17 +61,13 @@ for arg in "$@"; do
   esac
 done
 
-# Keep force variable for backward compatibility with callers (e.g. git-setup)
-: "$force"
-
 require git
+require git-hooks-multiplexer
 
-git_dir=$(git rev-parse --git-dir 2>/dev/null) || {
+git rev-parse --git-dir >/dev/null 2>&1 || {
   echo "$(basename "$0"): not a git repository" >&2
   exit 1
 }
-
-hooks_dir="$git_dir/hooks"
 
 MANAGED_HOOKS=(
   "commit-msg"
@@ -83,17 +78,22 @@ if [ "$mode" = "doctor" ]; then
   rc=0
   echo "Hooks:"
   for name in "${MANAGED_HOOKS[@]}"; do
-    if ! status=$(git-hooks-multiplexer doctor "$name" "10-agent" 2>&1); then
-      printf '  %-12s %s (%s)\n' "missing" "$name" "$status"
-      rc=1
-    else
+    if status=$(git-hooks-multiplexer doctor "$name" "10-agent" 2>/dev/null); then
       printf '  %-12s %s\n' "ok" "$name"
+    else
+      case "$status" in
+        unmanaged_multiplexer)
+          printf '  %-12s %s present but unmanaged (run '\''%s'\'')\n' "drift" "$name" "$(basename "$0")"
+          ;;
+        *)
+          printf '  %-12s %s (run '\''%s'\'')\n' "missing" "$name" "$(basename "$0")"
+          ;;
+      esac
+      rc=1
     fi
   done
   exit "$rc"
 fi
-
-mkdir -p "$hooks_dir"
 
 install_hook() {
   local name="$1"

--- a/bin/git-hooks-gerrit
+++ b/bin/git-hooks-gerrit
@@ -27,6 +27,7 @@ require() {
 
 require git
 require curl
+require git-hooks-multiplexer
 
 git rev-parse --git-dir >/dev/null 2>&1 || {
   echo "$(basename "$0"): error: not a git repository" >&2

--- a/bin/git-hooks-multiplexer
+++ b/bin/git-hooks-multiplexer
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# git-hooks-multiplexer: Manage multiplexed git hooks.
 # Targets Bash version 3.2.57(1)-release
+# Tests: tests/test-git-hooks-multiplexer
 
 set -euo pipefail
 
@@ -10,13 +10,19 @@ usage() {
 Usage: $(basename "$0") COMMAND [ARGUMENTS]
 
 Manage multiplexed git hooks by installing a multiplexer at .git/hooks/<hook-name>
-and placing individual hooks in .git/hooks/<hook-name>.d/<key>.
+and placing individual hooks in .git/hooks/<hook-name>.d/<key>. Sub-hooks run in
+lexical key order; the first failure aborts the hook with that exit code.
+
+A pre-existing hook not managed by this tool is preserved as
+.git/hooks/<hook-name>.d/00-legacy and continues to run first.
 
 Commands:
   install <hook-name> <key> <source-file>
               Install a sub-hook into the multiplexer.
   doctor <hook-name> <key>
-              Verify the installation of a multiplexed hook.
+              Verify the installation of a multiplexed hook (read-only).
+              Prints one of: ok, missing_multiplexer, unmanaged_multiplexer,
+              missing_subhook. Exits non-zero unless ok.
 
 Arguments:
   <hook-name> The git hook to target (e.g., commit-msg, pre-push)
@@ -59,12 +65,12 @@ key="$2"
 
 require git
 
-git_dir=$(git rev-parse --git-dir 2>/dev/null) || {
+# --git-path resolves core.hooksPath and linked worktrees (where hooks live
+# in the common git dir, not the per-worktree one).
+hooks_dir=$(git rev-parse --git-path hooks 2>/dev/null) || {
   echo "$(basename "$0") $cmd: error: not a git repository" >&2
   exit 1
 }
-
-hooks_dir="$git_dir/hooks"
 multiplexer_dst="$hooks_dir/$hook_name"
 subhooks_dir="$multiplexer_dst.d"
 subhook_dst="$subhooks_dir/$key"
@@ -79,10 +85,13 @@ multiplexer_content() {
 
 HOOKS_DIR="\$(dirname "\$0")/$hook_name.d"
 
-# Buffer stdin so multiple hooks can read the same stream
+# Buffer stdin so multiple hooks can read the same stream. Skip a terminal
+# so running the hook by hand does not block waiting for EOF.
 STDIN_TMP=\$(mktemp)
 trap 'rm -f "\$STDIN_TMP"' EXIT
-cat > "\$STDIN_TMP"
+if [ ! -t 0 ]; then
+  cat > "\$STDIN_TMP"
+fi
 
 if [ -d "\$HOOKS_DIR" ]; then
   for hook in "\$HOOKS_DIR"/*; do

--- a/bin/git-setup
+++ b/bin/git-setup
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [doctor] [--force]
+Usage: $(basename "$0") [doctor]
 
 Set up the current git repository for agent-assisted development.
 Idempotent: re-running refreshes the same files and never duplicates work.
@@ -37,12 +37,10 @@ Commands:
             problem.
 
 Options:
-  --force   Pass --force to git-hooks-agent (overwrite a foreign commit-msg hook)
   --help    Display this help message and exit
 
 Examples:
   $(basename "$0")
-  $(basename "$0") --force
   $(basename "$0") doctor
 EOF
   exit 0
@@ -55,12 +53,10 @@ require() {
   }
 }
 
-force=0
 mode=install
 for arg in "$@"; do
   case "$arg" in
     --help) usage ;;
-    --force) force=1 ;;
     doctor) mode=doctor ;;
     -*)
       echo "$(basename "$0"): unknown option: $arg" >&2
@@ -105,14 +101,7 @@ fi
 
 echo "$(basename "$0"): installing hooks, provisioning skills, and applying permissions"
 
-hook_args=()
-[ "$force" -eq 1 ] && hook_args+=(--force)
-
-if [ "${#hook_args[@]}" -gt 0 ]; then
-  git-hooks-agent "${hook_args[@]}"
-else
-  git-hooks-agent
-fi
+git-hooks-agent
 
 skill apply
 permission apply

--- a/fish/completions/git-hooks-agent.fish
+++ b/fish/completions/git-hooks-agent.fish
@@ -1,4 +1,3 @@
 complete -c git-hooks-agent -f
 complete -c git-hooks-agent -n __fish_use_subcommand -a doctor -d 'Report whether managed hooks are installed (read-only)'
-complete -c git-hooks-agent -l force -d 'Overwrite existing hooks not managed by this tool'
 complete -c git-hooks-agent -l help -d 'Display help message and exit'

--- a/fish/completions/git-hooks-multiplexer.fish
+++ b/fish/completions/git-hooks-multiplexer.fish
@@ -1,0 +1,4 @@
+complete -c git-hooks-multiplexer -f
+complete -c git-hooks-multiplexer -n __fish_use_subcommand -a install -d 'Install a sub-hook into the multiplexer'
+complete -c git-hooks-multiplexer -n __fish_use_subcommand -a doctor -d 'Verify the installation of a multiplexed hook (read-only)'
+complete -c git-hooks-multiplexer -l help -d 'Display help message and exit'

--- a/fish/completions/git-setup.fish
+++ b/fish/completions/git-setup.fish
@@ -20,4 +20,3 @@ complete -f -c git -n __fish_git_setup_needs_command -a doctor -d 'Diagnose this
 
 # Complete flags
 complete -c git -f -n __fish_git_setup_using_command -l help -d 'Display help message and exit'
-complete -c git -f -n __fish_git_setup_using_command -l force -d 'Overwrite a foreign commit-msg hook'

--- a/tests/test-git-hooks-multiplexer
+++ b/tests/test-git-hooks-multiplexer
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Tests: tests/test-git-hooks-multiplexer
+
+set -u
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+BIN="$DIR/../bin/git-hooks-multiplexer"
+
+# Isolate from the user's/system git config (signing, hooks, templates).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+echo "1..9"
+
+# Test 1: --help exits zero and documents both commands
+if out=$("$BIN" --help 2>&1) &&
+  printf '%s' "$out" | grep -q 'install' &&
+  printf '%s' "$out" | grep -q 'doctor'; then
+  echo "ok 1 - --help documents install and doctor"
+else
+  echo "not ok 1 - --help missing or incomplete"
+fi
+
+# Test 2: bare invocation is an explicit help request (exit 0)
+if "$BIN" >/dev/null 2>&1; then
+  echo "ok 2 - bare invocation prints help and exits zero"
+else
+  echo "not ok 2 - bare invocation should exit zero"
+fi
+
+REPO=$(mktemp -d "/tmp/hooks-multiplexer-test.XXXXXX")
+trap 'rm -rf "$REPO"' EXIT
+git -C "$REPO" init -q
+
+SUB_A="$REPO/sub-a"
+# shellcheck disable=SC2016 # $1 is expanded by the sub-hook at run time, not here
+printf '#!/bin/sh\necho "a:$1" >> "%s/log.txt"\ncat >> "%s/log.txt"\n' "$REPO" "$REPO" >"$SUB_A"
+chmod +x "$SUB_A"
+
+# Test 3: doctor reports a missing multiplexer before install
+if ! status=$(cd "$REPO" && "$BIN" doctor commit-msg 10-a) &&
+  [ "$status" = "missing_multiplexer" ]; then
+  echo "ok 3 - doctor reports missing_multiplexer before install"
+else
+  echo "not ok 3 - unexpected doctor output: $status"
+fi
+
+# Test 4: install writes a managed multiplexer and executable sub-hook
+if (cd "$REPO" && "$BIN" install commit-msg 10-a "$SUB_A") >/dev/null 2>&1 &&
+  [ -x "$REPO/.git/hooks/commit-msg" ] &&
+  grep -q 'git-hooks-multiplexer' "$REPO/.git/hooks/commit-msg" &&
+  [ -x "$REPO/.git/hooks/commit-msg.d/10-a" ] &&
+  status=$(cd "$REPO" && "$BIN" doctor commit-msg 10-a) &&
+  [ "$status" = "ok" ]; then
+  echo "ok 4 - install writes multiplexer and sub-hook; doctor ok"
+else
+  echo "not ok 4 - install did not produce expected layout"
+fi
+
+# Test 5: a pre-existing foreign hook is preserved as 00-legacy and runs first
+LEGACY_REPO=$(mktemp -d "/tmp/hooks-multiplexer-test-legacy.XXXXXX")
+trap 'rm -rf "$REPO" "$LEGACY_REPO"' EXIT
+git -C "$LEGACY_REPO" init -q
+printf '#!/bin/sh\necho legacy >> "%s/log.txt"\n' "$LEGACY_REPO" >"$LEGACY_REPO/.git/hooks/commit-msg"
+chmod +x "$LEGACY_REPO/.git/hooks/commit-msg"
+printf '#!/bin/sh\necho agent >> "%s/log.txt"\n' "$LEGACY_REPO" >"$LEGACY_REPO/sub"
+chmod +x "$LEGACY_REPO/sub"
+(cd "$LEGACY_REPO" && "$BIN" install commit-msg 10-a "$LEGACY_REPO/sub") >/dev/null 2>&1
+"$LEGACY_REPO/.git/hooks/commit-msg" msgfile </dev/null
+if [ -x "$LEGACY_REPO/.git/hooks/commit-msg.d/00-legacy" ] &&
+  [ "$(cat "$LEGACY_REPO/log.txt")" = "legacy
+agent" ]; then
+  echo "ok 5 - foreign hook preserved as 00-legacy and runs first"
+else
+  echo "not ok 5 - legacy hook not preserved or wrong order"
+fi
+
+# Test 6: a failing sub-hook aborts the chain with its exit code
+printf '#!/bin/sh\nexit 42\n' >"$LEGACY_REPO/.git/hooks/commit-msg.d/05-fail"
+chmod +x "$LEGACY_REPO/.git/hooks/commit-msg.d/05-fail"
+rm -f "$LEGACY_REPO/log.txt"
+"$LEGACY_REPO/.git/hooks/commit-msg" msgfile </dev/null 2>/dev/null
+rc=$?
+if [ "$rc" -eq 42 ] && grep -q 'legacy' "$LEGACY_REPO/log.txt" &&
+  ! grep -q 'agent' "$LEGACY_REPO/log.txt"; then
+  echo "ok 6 - failing sub-hook propagates exit code and stops the chain"
+else
+  echo "not ok 6 - expected exit 42 and no later hooks (got rc=$rc)"
+fi
+rm -f "$LEGACY_REPO/.git/hooks/commit-msg.d/05-fail"
+
+# Test 7: reinstall is idempotent (managed multiplexer is not demoted to legacy)
+(cd "$REPO" && "$BIN" install commit-msg 10-a "$SUB_A") >/dev/null 2>&1
+if [ ! -e "$REPO/.git/hooks/commit-msg.d/00-legacy" ] &&
+  status=$(cd "$REPO" && "$BIN" doctor commit-msg 10-a) &&
+  [ "$status" = "ok" ]; then
+  echo "ok 7 - reinstall is idempotent"
+else
+  echo "not ok 7 - reinstall created 00-legacy or broke doctor"
+fi
+
+# Test 8: every sub-hook sees the full stdin (buffered, not consumed)
+printf '#!/bin/sh\ncat >> "%s/stdin.txt"\n' "$REPO" >"$REPO/sub-b"
+chmod +x "$REPO/sub-b"
+(cd "$REPO" && "$BIN" install commit-msg 20-b "$REPO/sub-b") >/dev/null 2>&1
+rm -f "$REPO/log.txt" "$REPO/stdin.txt"
+printf 'refs\n' | "$REPO/.git/hooks/commit-msg" msgfile
+if grep -q 'refs' "$REPO/log.txt" && grep -q 'refs' "$REPO/stdin.txt"; then
+  echo "ok 8 - stdin is buffered and replayed to every sub-hook"
+else
+  echo "not ok 8 - sub-hooks did not each receive stdin"
+fi
+
+# Test 9: doctor reports an unmanaged multiplexer
+printf '#!/bin/sh\n' >"$REPO/.git/hooks/commit-msg"
+if ! status=$(cd "$REPO" && "$BIN" doctor commit-msg 10-a) &&
+  [ "$status" = "unmanaged_multiplexer" ]; then
+  echo "ok 9 - doctor reports unmanaged_multiplexer"
+else
+  echo "not ok 9 - unexpected doctor output: $status"
+fi

--- a/tests/test-git-setup
+++ b/tests/test-git-setup
@@ -42,10 +42,10 @@ export PATH="$MOCK_BIN:$PATH"
 
 echo "1..7"
 
-# Test 1: --help succeeds and documents --force
+# Test 1: --help succeeds and documents doctor
 if out=$("$BIN" --help 2>&1) &&
-  printf '%s' "$out" | grep -q '\--force'; then
-  echo "ok 1 - --help documents --force"
+  printf '%s' "$out" | grep -q 'doctor'; then
+  echo "ok 1 - --help documents doctor"
 else
   echo "not ok 1 - --help missing or docs absent"
 fi


### PR DESCRIPTION
## Summary

Refactor hook installation to use `git-hooks-multiplexer` for managing multiple hooks, eliminating the need for the `--force` flag. The multiplexer automatically preserves pre-existing hooks as `00-legacy` and runs them first, providing a cleaner solution for coexisting with other tools.

## Key Changes

- **git-hooks-multiplexer**: Enhanced with comprehensive documentation, stdin buffering for terminal safety, and proper `--git-path` resolution for linked worktrees
- **git-hooks-agent**: Removed `--force` flag and refactored to delegate hook installation to `git-hooks-multiplexer`; updated `doctor` command to report drift when an unmanaged multiplexer is detected
- **git-setup**: Removed `--force` flag and simplified hook installation to call `git-hooks-agent` without arguments
- **git-hooks-gerrit**: Added `git-hooks-multiplexer` as a required dependency
- **Tests**: Added comprehensive test suite (`tests/test-git-hooks-multiplexer`) covering install, doctor, legacy hook preservation, failure handling, idempotency, stdin buffering, and unmanaged multiplexer detection
- **Fish completions**: Updated `git-hooks-agent.fish` and `git-setup.fish` to remove `--force` flag; added `git-hooks-multiplexer.fish` for new command

## Implementation Details

- The multiplexer uses `git rev-parse --git-path hooks` to properly resolve hook directories in linked worktrees
- Stdin is buffered via temporary file to allow multiple sub-hooks to read the same input, with terminal detection to avoid blocking when run interactively
- Sub-hooks run in lexical key order; the first failure aborts the chain with that exit code
- Pre-existing hooks not managed by the multiplexer are automatically preserved as `.git/hooks/<name>.d/00-legacy` and run first
- The `doctor` command now distinguishes between missing multiplexer, unmanaged multiplexer, and missing sub-hook states

https://claude.ai/code/session_01MYWTEppZWBQDXfAMgRAZTJ