### PR TITLE
feat(skill): phrase doctor drift hints as env/disk sync directions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -148,25 +148,29 @@ to install `scrcpy` for optimal performance.
 
 ## Clarify remediation choices in skill preflight and doctor error messages (2026-07-15) — done
 
-Restructured the "Required Skills" remediation hints in `cmd_doctor` (shared by
-`skill doctor` and `skill preflight`) in `skills/workspace-config/scripts/skill`
-to group commands by which source of truth the user considers correct, instead
-of listing commands without explaining what state each overwrites. The hints now
-open with "To resolve: pick the fix for whichever side -- declared or on-disk --
-you consider correct." followed by intent-based paths: *environment is
-authoritative* — `skill apply`, with its concrete effects spelled out per
-finding (creates missing symlinks, re-links mismatched ones, and explicitly
-"deletes the N extra/stale symlink(s) from disk"); *disk is authoritative* —
-`envrc add skills <names>` (or the raw `export AGENT_REQUIRED_SKILLS=...`
-variant when not using `.envrc`), noted as keeping the symlinks; *manual
-removal* — `skill remove <names>`. When the plan's destructive-action policy
-blocks pruning (stale environment or an unresolvable declared spec), the apply
-hint no longer promises deletion; a note explains why apply will hold off.
-Negated (excluded) skills are never suggested for re-declaration. Tests
-41/42/45/65 updated and new tests 79–81 in
-`skills/workspace-config/tests/test-skill` assert the intent-grouped hint shape,
-the `.envrc` vs. export variants, and the blocked-prune wording (suite now 81
-cases, all passing).
+Reworked (second pass — the first "authoritative side" wording proved unclear)
+the "Required Skills" reporting in `cmd_doctor` (shared by `skill doctor` and
+`skill preflight`) in `skills/workspace-config/scripts/skill` around two short
+side labels, defined where they are used instead of in a standing preamble:
+*env* (the declared set, `AGENT_REQUIRED_SKILLS`) and *disk* (the symlinks in
+the destination dirs). The summary line reads "environment and disk disagree
+(…)" (or "cannot resolve the declared skill set (…)" when only
+declaration-side defects exist), findings render as one aligned per-item list
+(`emumanager   disk only (linked in .claude/skills, not in
+AGENT_REQUIRED_SKILLS)`), and remediation is phrased as sync directions with
+concrete effects: "Make disk match env (link X; delete the Y symlink): skill
+apply" versus "Make env match disk (declare Y; keep the symlink): envrc add
+skills Y && direnv reload" (raw `export` variant without `.envrc`). Every
+suggested `envrc` command carries the `direnv reload` step, since the
+environment stays stale until then. A per-skill mixing hint prints only when
+there are two or more differences. The blocked-prune note is self-contained
+(preflight suppresses the freshness WARNING it used to reference) and names
+the by-hand `skill remove` fallback; when stale, `envrc add` is not suggested
+for names `.envrc` already declares. Negated (excluded) skills are still never
+suggested for re-declaration, and the verbose success banner lost its `✔`
+glyph per the doctor output style. Tests 41/42/45/62/65 and 79–81 updated in
+`skills/workspace-config/tests/test-skill`; the doctor example in
+`skills/coding-standards/references/cli-tools.md` follows the new summary.
 
 ## Unify skill doctor/apply behind a shared reconciliation planner (2026-07-14) — done
 

--- a/skills/coding-standards/references/cli-tools.md
+++ b/skills/coding-standards/references/cli-tools.md
@@ -80,7 +80,7 @@ common width so lines align, e.g.:
 ```text
 [OK]    Workspace: Git repository
 [WARN]  Low disk space: 3.2G available at ANDROID_HOME
-[ERROR] Required Skills: Mismatched skill configuration (1 missing)
+[ERROR] Required Skills: environment and disk disagree (1 missing)
 ```
 
 - Tags are greppable and fully legible with color stripped

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -1889,7 +1889,7 @@ def cmd_apply(args):
             names = " ".join(extra_skills)
             if is_using_envrc(ws):
                 print(
-                    f"skill: to keep any of them, run: envrc add skills {names}",
+                    f"skill: to keep any of them, run: envrc add skills {names} && direnv reload",
                     file=sys.stderr,
                 )
             else:
@@ -2520,41 +2520,54 @@ def cmd_doctor(
     negated_extra = plan.negated_extra
     collisions = plan.collisions
 
-    skill_details = []
-    if collisions:
-        skill_details.append(
-            "Conflicting skills (multiple declarations target the same symlink basename):"
-        )
-        for s in collisions:
-            skill_details.append(f"  - {s}")
-    if missing:
-        skill_details.append("Missing skills (declared but not linked on disk):")
-        for s in missing:
-            skill_details.append(f"  - {s}")
-    if unresolvable:
+    # Render the divergence as one aligned item list. The two sides get short
+    # stable labels -- 'env' is the declared set (AGENT_REQUIRED_SKILLS),
+    # 'disk' the symlinks in the destination dirs -- and the first item of
+    # each kind carries the full gloss, so the labels are defined where they
+    # are used instead of in a standing preamble that repeats on every run.
+    disk_label = ", ".join(str(rel(d)) for d in dest_dirs) if dest_dirs else "disk"
+
+    # The plan reports some conditions once per destination dir (e.g. a skill
+    # missing from both .claude/skills and .agents/skills counts twice), but
+    # the report and the command hints below are per-name.
+    def uniq(names):
+        seen = set()
+        return [n for n in names if not (n in seen or seen.add(n))]
+
+    # 'missing' and 'mismatched' carry per-destination labels from the planner
+    # ("spec (missing in .claude/skills)"); specs themselves are env-var tokens
+    # and can never contain whitespace, so the first word is always the spec.
+    skill_items = []
+    for i, lbl in enumerate(uniq(missing)):
+        spec, _, det = lbl.partition(" ")
+        inner = det[1:-1] if det.startswith("(") else det
+        if i == 0:
+            inner = "in AGENT_REQUIRED_SKILLS, " + (
+                inner or f"not linked in {disk_label}"
+            )
+        skill_items.append((spec, f"env only ({inner})" if inner else "env only"))
+    for s in unresolvable:
         # This bucket also catches ambiguous specs (multiple catalog matches,
         # fixed by qualifying the namespace) and remote-fetch failures, not
         # only "no match at all" -- unresolvable_errors carries the specific
-        # reason for each, so the header stays deliberately generic.
-        skill_details.append("Unresolvable skills (declared but cannot be resolved):")
-        for s in unresolvable:
-            skill_details.append(f"  - {s} ({unresolvable_errors[s]})")
-    if mismatched_target:
-        skill_details.append(
-            "Mismatched symlink targets (linked on disk but pointing to unexpected source):"
+        # reason for each, so the label stays deliberately generic.
+        skill_items.append((s, f"unresolvable ({unresolvable_errors[s]})"))
+    for lbl in uniq(mismatched_target):
+        spec, _, det = lbl.partition(" ")
+        skill_items.append((spec, f"wrong target {det}".rstrip()))
+    for i, s in enumerate(uniq(negated_extra)):
+        gloss = " (negated in AGENT_REQUIRED_SKILLS but still linked)" if i == 0 else ""
+        skill_items.append((s, f"disk only, negated{gloss}"))
+    for i, s in enumerate(uniq(extra)):
+        gloss = (
+            f" (linked in {disk_label}, not in AGENT_REQUIRED_SKILLS)" if i == 0 else ""
         )
-        for s in mismatched_target:
-            skill_details.append(f"  - {s}")
-    if negated_extra:
-        skill_details.append(
-            "Stale excluded skills (linked on disk but explicitly negated in env):"
-        )
-        for s in negated_extra:
-            skill_details.append(f"  - {s}")
-    if extra:
-        skill_details.append("Extra skills (linked on disk but not declared):")
-        for s in extra:
-            skill_details.append(f"  - {s}")
+        skill_items.append((s, f"disk only{gloss}"))
+    name_width = max((len(n) for n, _ in skill_items), default=0)
+    # Collision "names" are whole sentences from the planner, so they get
+    # full-width lines instead of a slot in the aligned name column.
+    skill_details = [f"conflicting: {c}" for c in collisions]
+    skill_details += [f"{n.ljust(name_width)}   {a}" for n, a in skill_items]
 
     if (
         missing
@@ -2577,11 +2590,18 @@ def cmd_doctor(
         if num_extra:
             parts.append(f"{num_extra} extra/stale")
         summary_str = ", ".join(parts)
+        # Collisions and unresolvable specs are declaration-side defects, not
+        # an env-vs-disk divergence; only call the sides out when at least one
+        # item actually differs between them.
+        if missing or mismatched_target or extra or negated_extra:
+            summary = f"environment and disk disagree ({summary_str})"
+        else:
+            summary = f"cannot resolve the declared skill set ({summary_str})"
         checks.append(
             {
                 "name": "Required Skills",
                 "status": "ERROR",
-                "summary": f"Mismatched skill configuration ({summary_str})",
+                "summary": summary,
                 "details": skill_details,
             }
         )
@@ -2931,64 +2951,92 @@ def cmd_doctor(
                 "  direnv reload   # or start a new prompt, then re-run 'skill apply'"
             )
         elif name == "Required Skills":
-            # Several commands can clear these findings, but they honor
-            # different sources of truth and overwrite different state --
-            # notably, 'skill apply' treats the environment as authoritative
-            # and deletes extra symlinks, while declaring the extras keeps
-            # them. Group the hints by which side the user considers correct
-            # so picking one is a decision, not a guess.
-            prune_names = extra + negated_extra
+            # Several commands can clear these findings, but they push state
+            # in opposite directions: 'skill apply' makes disk match env (and
+            # deletes undeclared symlinks), while 'envrc' edits make env match
+            # disk (and keep them). Phrase each option as a direction with its
+            # concrete effects so choosing one is a decision, not a guess.
+            missing_names = uniq(lbl.partition(" ")[0] for lbl in missing)
+            mismatched_names = uniq(lbl.partition(" ")[0] for lbl in mismatched_target)
+            prune_names = uniq(extra + negated_extra)
             apply_effects = []
-            if missing:
-                apply_effects.append("creates the missing symlink(s)")
-            if mismatched_target:
-                apply_effects.append("re-links the mismatched symlink(s)")
+            if missing_names:
+                apply_effects.append(f"link {', '.join(missing_names)}")
+            if mismatched_names:
+                apply_effects.append(f"re-link {', '.join(mismatched_names)}")
             if prune_names and not plan.destructive_blocked:
+                plural = "s" if len(prune_names) > 1 else ""
                 apply_effects.append(
-                    f"deletes the {len(prune_names)} extra/stale symlink(s) from disk"
+                    f"delete the {', '.join(prune_names)} symlink{plural}"
                 )
-            if apply_effects or prune_names:
+            # 'skill apply' refuses to run at all while declarations collide,
+            # so don't advertise it as a fix then.
+            if apply_effects and not collisions:
                 check["details"].append(
-                    "To resolve: pick the fix for whichever side -- declared or on-disk -- you consider correct."
+                    f"Make disk match env ({'; '.join(apply_effects)}):"
                 )
-            if apply_effects:
+                check["details"].append("  skill apply")
+            # The env-side path never re-declares negated skills, and when the
+            # environment is stale it skips names .envrc already declares --
+            # suggesting 'envrc add' for those would re-add what only needs a
+            # reload.
+            fresh_declared = (
+                {f.lower() for f in plan.freshness[0]} if plan.stale else set()
+            )
+            declare_names = [s for s in uniq(extra) if s.lower() not in fresh_declared]
+            env_effects = []
+            if missing_names:
+                env_effects.append(f"undeclare {', '.join(missing_names)}")
+            if declare_names:
+                plural = "s" if len(declare_names) > 1 else ""
+                env_effects.append(f"declare {', '.join(declare_names)}")
+                env_effects.append(f"keep the symlink{plural}")
+            if env_effects:
                 check["details"].append(
-                    "If the declared skill set (AGENT_REQUIRED_SKILLS) is "
-                    f"correct, make the disk match it ({'; '.join(apply_effects)}):"
+                    f"Make env match disk ({'; '.join(env_effects)}):"
                 )
-                check["details"].append("  skill apply   # 'git-setup' also runs this")
-            if extra:
                 if is_using_envrc(ws):
-                    check["details"].append(
-                        "If the skills on disk are correct, declare the extra "
-                        "skill(s) instead (keeps the symlinks; updates .envrc):"
-                    )
-                    check["details"].append(f"  envrc add skills {' '.join(extra)}")
+                    cmd_parts = []
+                    if missing_names:
+                        cmd_parts.append(
+                            f"envrc remove skills {' '.join(missing_names)}"
+                        )
+                    if declare_names:
+                        cmd_parts.append(f"envrc add skills {' '.join(declare_names)}")
+                    cmd_parts.append("direnv reload")
+                    check["details"].append("  " + " && ".join(cmd_parts))
                 else:
-                    check["details"].append(
-                        "If the skills on disk are correct, declare the extra "
-                        "skill(s) instead (keeps the symlinks):"
-                    )
-                    check["details"].append(
-                        f'  export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS {" ".join(extra)}"'
-                    )
-            if prune_names:
-                check["details"].append(
-                    "To delete individual symlink(s) by hand instead:"
+                    if declare_names:
+                        check["details"].append(
+                            f'  export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS {" ".join(declare_names)}"'
+                        )
+                    if missing_names:
+                        conj = "and " if declare_names else ""
+                        check["details"].append(
+                            f"  # {conj}remove {', '.join(missing_names)} from AGENT_REQUIRED_SKILLS in your shell config"
+                        )
+            # With a single difference, whole-side resolution IS per-item
+            # resolution, so the mixing hint would be noise.
+            n_diffs = len(missing_names) + len(mismatched_names) + len(prune_names)
+            if n_diffs >= 2 and (apply_effects or env_effects):
+                env_edit = (
+                    "'envrc add/remove skills NAME' edits env"
+                    if is_using_envrc(ws)
+                    else "editing AGENT_REQUIRED_SKILLS changes env"
                 )
-                check["details"].append(f"  skill remove {' '.join(prune_names)}")
+                check["details"].append(
+                    f"Or mix per skill: 'skill remove NAME' edits disk; {env_edit}."
+                )
             if unresolvable:
                 check["details"].append(
-                    "To resolve: 'skill apply' cannot fix this -- these "
-                    "spec(s) fail the same catalog lookup doctor just "
-                    "performed (see the reason next to each above: fix the "
+                    "Unresolvable declarations: 'skill apply' cannot fix "
+                    "these (the reason is shown per skill above). Fix the "
                     "catalog registration, qualify an ambiguous name with "
-                    "its namespace, or remove the unresolvable "
-                    "declaration(s)):"
+                    "its namespace, or undeclare:"
                 )
                 if is_using_envrc(ws):
                     check["details"].append(
-                        f"  envrc remove skills {' '.join(unresolvable)}"
+                        f"  envrc remove skills {' '.join(uniq(unresolvable))} && direnv reload"
                     )
                 else:
                     check["details"].append(
@@ -2996,28 +3044,43 @@ def cmd_doctor(
                     )
             if collisions:
                 check["details"].append(
-                    "To resolve: 'skill apply' cannot fix this -- multiple declared "
-                    "skills map to the same symlink basename but different targets. "
-                    "You must remove the conflicting declaration(s) from .envrc:"
+                    "Conflicting declarations: 'skill apply' cannot fix "
+                    "these -- undeclare the unwanted spec(s):"
                 )
                 if is_using_envrc(ws):
                     check["details"].append(
-                        "  # run 'envrc remove skills <spec>' for the unwanted declaration"
+                        "  # envrc remove skills <spec> for the unwanted declaration, then 'direnv reload'"
                     )
                 else:
                     check["details"].append(
                         "  # remove the unwanted declaration from the AGENT_REQUIRED_SKILLS environment variable"
                     )
             if prune_names and plan.destructive_blocked:
-                check["details"].append(
-                    "Note: 'skill apply' will not delete the extra/stale "
-                    "symlink(s) while "
-                    + (
-                        "the environment is stale (see Environment Freshness)"
-                        if plan.stale
-                        else "a declared spec is unresolvable"
+                # Self-contained on purpose: preflight suppresses WARNING
+                # checks, so referring the reader to Environment Freshness
+                # would point at a check that is not rendered there.
+                plural = "s" if len(prune_names) > 1 else ""
+                if plan.stale:
+                    fresh_missing, fresh_negated = plan.freshness
+                    reasons = []
+                    if fresh_missing:
+                        reasons.append(
+                            f".envrc declares {', '.join(fresh_missing)} not yet in AGENT_REQUIRED_SKILLS"
+                        )
+                    if fresh_negated:
+                        reasons.append(
+                            f".envrc negates {', '.join(fresh_negated)} still in AGENT_REQUIRED_SKILLS"
+                        )
+                    why = (
+                        f"the environment is stale ({'; '.join(reasons)} "
+                        "-- run 'direnv reload' first)"
                     )
-                    + "."
+                else:
+                    why = "a declared spec is unresolvable (fix or undeclare it first)"
+                check["details"].append(
+                    f"Note: 'skill apply' will not delete the "
+                    f"{', '.join(prune_names)} symlink{plural} while {why}. "
+                    f"'skill remove {' '.join(prune_names)}' deletes by hand."
                 )
         elif name == "Symlink Health":
             if stray_dangling:
@@ -3074,7 +3137,7 @@ def cmd_doctor(
     if verbose:
         print(
             colorize(
-                "\n✔ Workspace is healthy and skills are fully synchronized!",
+                "\nWorkspace is healthy and skills are fully synchronized.",
                 "green",
                 use_color,
             ),

--- a/skills/workspace-config/tests/test-skill
+++ b/skills/workspace-config/tests/test-skill
@@ -723,8 +723,8 @@ if doctor_fail_out=$("${SCRIPT}" doctor 2>&1); then
   echo "not ok 41 - [Doctor UI] doctor succeeded unexpectedly in unhealthy workspace"
 else
   if printf '%s\n' "$doctor_fail_out" | grep -q "\[ERROR\] Required Skills:" &&
-    printf '%s\n' "$doctor_fail_out" | grep -q "To resolve:" &&
-    printf '%s\n' "$doctor_fail_out" | grep -q "If the declared skill set (AGENT_REQUIRED_SKILLS) is correct" &&
+    printf '%s\n' "$doctor_fail_out" | grep -q "env only" &&
+    printf '%s\n' "$doctor_fail_out" | grep -q "Make disk match env (link " &&
     printf '%s\n' "$doctor_fail_out" | grep -q "skill apply"; then
     echo "ok 41 - [Doctor UI] failure outputs failing checks and resolution steps"
   else
@@ -738,7 +738,7 @@ if preflight_fail_out=$("${SCRIPT}" preflight 2>&1); then
 else
   if printf '%s\n' "$preflight_fail_out" | grep -q "\[ERROR\] Required Skills:" &&
     ! printf '%s\n' "$preflight_fail_out" | grep -q "Workspace is healthy" &&
-    printf '%s\n' "$preflight_fail_out" | grep -q "To resolve:" &&
+    printf '%s\n' "$preflight_fail_out" | grep -q "Make disk match env (link " &&
     printf '%s\n' "$preflight_fail_out" | grep -q "preflight check failed in workspace:"; then
     echo "ok 42 - [Preflight UI] failure emits report to stderr"
   else
@@ -838,13 +838,11 @@ export AGENT_REQUIRED_SKILLS="coding-standards !emumanager"
 if doctor_out=$("${SCRIPT}" doctor 2>&1); then
   echo "not ok 45 - [Negated skills] doctor should have failed but succeeded"
 else
-  if printf '%s\n' "$doctor_out" | grep -q "Stale excluded skills (linked on disk but explicitly negated in env):" &&
-    printf '%s\n' "$doctor_out" | grep -q "  - emumanager" &&
+  if printf '%s\n' "$doctor_out" | grep -q "emumanager .*disk only, negated (negated in AGENT_REQUIRED_SKILLS but still linked)" &&
     ! printf '%s\n' "$doctor_out" | grep -q "export AGENT_REQUIRED_SKILLS.*emumanager" &&
-    ! printf '%s\n' "$doctor_out" | grep -q "If the skills on disk are correct" &&
-    printf '%s\n' "$doctor_out" | grep -q "deletes the 1 extra/stale symlink(s) from disk" &&
-    printf '%s\n' "$doctor_out" | grep -q "skill apply" &&
-    printf '%s\n' "$doctor_out" | grep -q "skill remove emumanager"; then
+    ! printf '%s\n' "$doctor_out" | grep -q "declare emumanager" &&
+    printf '%s\n' "$doctor_out" | grep -q "delete the emumanager symlink" &&
+    printf '%s\n' "$doctor_out" | grep -q "skill apply"; then
 
     # Run apply to prune the stale symlink
     if "${SCRIPT}" apply >/dev/null 2>&1; then
@@ -1299,9 +1297,9 @@ if doc_out=$(SKILL_SOURCE_DIRS="${MOCK_MISMATCH_DIR}/src2" AGENT_REQUIRED_SKILLS
   echo "not ok 62 - [Mismatch reporting] doctor should have failed on mismatched symlink target"
 else
   if printf '%s\n' "$doc_out" | grep -q "1 mismatched target" &&
-    printf '%s\n' "$doc_out" | grep -q "Mismatched symlink targets (linked on disk but pointing to unexpected source):" &&
-    ! printf '%s\n' "$doc_out" | grep -q "Missing skills (declared but not linked on disk)" &&
-    ! printf '%s\n' "$doc_out" | grep -q "Extra skills (linked on disk but not declared)"; then
+    printf '%s\n' "$doc_out" | grep -q "my-skill .*wrong target (linked to .*, expected .*)" &&
+    ! printf '%s\n' "$doc_out" | grep -q "env only" &&
+    ! printf '%s\n' "$doc_out" | grep -q "disk only"; then
     echo "ok 62 - [Mismatch reporting] doctor reports mismatched symlink target clearly and accurately"
   else
     echo "not ok 62 - [Mismatch reporting] unexpected doctor output: $doc_out"
@@ -1379,17 +1377,15 @@ doctor2_out=$("${SCRIPT}" doctor 2>&1) || doctor2_rc=$?
 # bogus spec -- both are reported, each under its own bucket.
 if [ "$doctor_rc" -ne 0 ] &&
   printf '%s\n' "$doctor_out" | grep -q "2 missing, 1 unresolvable" &&
-  printf '%s\n' "$doctor_out" | grep -q "Missing skills (declared but not linked on disk):" &&
-  printf '%s\n' "$doctor_out" | grep -q "  - coding-standards" &&
-  printf '%s\n' "$doctor_out" | grep -q "Unresolvable skills (declared but cannot be resolved):" &&
-  printf '%s\n' "$doctor_out" | grep -q "  - totally-bogus-unresolvable-skill" &&
-  printf '%s\n' "$doctor_out" | grep -q "'skill apply' cannot fix this" &&
+  printf '%s\n' "$doctor_out" | grep -q "coding-standards .*env only (in AGENT_REQUIRED_SKILLS, missing in " &&
+  printf '%s\n' "$doctor_out" | grep -q "totally-bogus-unresolvable-skill .*unresolvable (" &&
+  printf '%s\n' "$doctor_out" | grep -q "Unresolvable declarations: 'skill apply' cannot fix these" &&
   printf '%s\n' "$apply_out" | grep -q "failed to resolve 'totally-bogus-unresolvable-skill'" &&
   [ -L .claude/skills/coding-standards ] &&
   [ "$doctor2_rc" -ne 0 ] &&
-  printf '%s\n' "$doctor2_out" | grep -q "Unresolvable skills" &&
-  ! printf '%s\n' "$doctor2_out" | grep -q "Missing skills (declared but not linked on disk):" &&
-  ! printf '%s\n' "$doctor2_out" | grep -q "If the declared skill set"; then
+  printf '%s\n' "$doctor2_out" | grep -q "unresolvable (" &&
+  ! printf '%s\n' "$doctor2_out" | grep -q "env only" &&
+  ! printf '%s\n' "$doctor2_out" | grep -q "Make disk match env"; then
   echo "ok 65 - [Doctor] unresolvable declared spec reported separately from missing, with different remediation"
 else
   echo "not ok 65 - [Doctor] unresolvable spec not distinguished correctly: $doctor_out"
@@ -1831,15 +1827,15 @@ fi
 cd "$TMPDIR"
 
 # ==============================================================================
-# PART 16: Intent-Grouped Remediation Hints
+# PART 16: Direction-Grouped Remediation Hints
 # ==============================================================================
-# The remediation hints for extra/missing/mismatched skills honor different
-# sources of truth: 'skill apply' treats AGENT_REQUIRED_SKILLS as
-# authoritative and deletes extra symlinks, while declaring the extras keeps
-# them. Doctor must group the commands under intent-based headers so the user
-# picks by which state they consider correct.
+# The remediation hints for extra/missing/mismatched skills push state in
+# opposite directions: 'skill apply' makes disk match env (deleting extra
+# symlinks), while declaring the extras makes env match disk (keeping them).
+# Doctor must phrase each option as a direction with its concrete effects so
+# the user picks by which state they consider correct.
 
-# Test 79: extra skill hints are grouped by intent (plain environment variable)
+# Test 79: extra skill hints are grouped by direction (plain environment variable)
 EXTRA_HINT_DIR="${TMPDIR}/extra-hint"
 mkdir -p "$EXTRA_HINT_DIR"
 cd "$EXTRA_HINT_DIR"
@@ -1853,34 +1849,31 @@ if doctor_out=$(env -u DIRENV_DIR "${SCRIPT}" doctor 2>&1); then
   echo "not ok 79 - [Hints] doctor should have failed with an extra skill"
 else
   # shellcheck disable=SC2016  # the literal '$AGENT_REQUIRED_SKILLS' text is the expected hint
-  if printf '%s\n' "$doctor_out" | grep -q "Extra skills (linked on disk but not declared):" &&
-    printf '%s\n' "$doctor_out" | grep -q "To resolve: pick the fix for whichever side -- declared or on-disk -- you consider correct." &&
-    printf '%s\n' "$doctor_out" | grep -q "If the declared skill set (AGENT_REQUIRED_SKILLS) is correct" &&
-    printf '%s\n' "$doctor_out" | grep -q "deletes the 1 extra/stale symlink(s) from disk" &&
+  if printf '%s\n' "$doctor_out" | grep -q "environment and disk disagree" &&
+    printf '%s\n' "$doctor_out" | grep -q "emumanager .*disk only (linked in .*, not in AGENT_REQUIRED_SKILLS)" &&
+    printf '%s\n' "$doctor_out" | grep -q "Make disk match env (delete the emumanager symlink):" &&
     printf '%s\n' "$doctor_out" | grep -q "skill apply" &&
-    printf '%s\n' "$doctor_out" | grep -q "If the skills on disk are correct" &&
-    printf '%s\n' "$doctor_out" | grep -q "keeps the symlinks" &&
-    printf '%s\n' "$doctor_out" | grep -qF 'export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS emumanager"' &&
-    printf '%s\n' "$doctor_out" | grep -q "skill remove emumanager"; then
-    echo "ok 79 - [Hints] extra-skill remediation is grouped by source-of-truth intent"
+    printf '%s\n' "$doctor_out" | grep -q "Make env match disk (declare emumanager; keep the symlink):" &&
+    printf '%s\n' "$doctor_out" | grep -qF 'export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS emumanager"'; then
+    echo "ok 79 - [Hints] extra-skill remediation is grouped by sync direction"
   else
-    echo "not ok 79 - [Hints] extra-skill remediation missing intent grouping: $doctor_out"
+    echo "not ok 79 - [Hints] extra-skill remediation missing direction grouping: $doctor_out"
   fi
 fi
 
-# Test 80: with an .envrc present, the disk-is-correct path suggests
-# 'envrc add skills' (not a raw export) and still warns apply deletes extras
+# Test 80: with an .envrc present, the env-side path suggests 'envrc add
+# skills' plus a direnv reload (not a raw export) and still states that
+# 'skill apply' deletes the extra symlink
 touch .envrc
 if doctor_out=$(env -u DIRENV_DIR "${SCRIPT}" doctor 2>&1); then
   echo "not ok 80 - [Hints] doctor should have failed with an extra skill (.envrc)"
 else
   # shellcheck disable=SC2016  # the literal '$AGENT_REQUIRED_SKILLS' text is the expected hint
-  if printf '%s\n' "$doctor_out" | grep -q "If the skills on disk are correct" &&
-    printf '%s\n' "$doctor_out" | grep -q "updates .envrc" &&
-    printf '%s\n' "$doctor_out" | grep -q "envrc add skills emumanager" &&
+  if printf '%s\n' "$doctor_out" | grep -q "Make env match disk (declare emumanager; keep the symlink):" &&
+    printf '%s\n' "$doctor_out" | grep -q "envrc add skills emumanager && direnv reload" &&
     ! printf '%s\n' "$doctor_out" | grep -qF 'export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS emumanager"' &&
-    printf '%s\n' "$doctor_out" | grep -q "deletes the 1 extra/stale symlink(s) from disk"; then
-    echo "ok 80 - [Hints] envrc workspace suggests 'envrc add skills' for the disk-is-correct path"
+    printf '%s\n' "$doctor_out" | grep -q "Make disk match env (delete the emumanager symlink):"; then
+    echo "ok 80 - [Hints] envrc workspace suggests 'envrc add skills && direnv reload' for the env-side path"
   else
     echo "not ok 80 - [Hints] envrc variant hint wrong: $doctor_out"
   fi
@@ -1889,8 +1882,10 @@ export AGENT_REQUIRED_SKILLS=""
 cd "$TMPDIR"
 
 # Test 81: when the destructive-action policy blocks pruning (a declared spec
-# is unresolvable), the environment-is-correct hint must not promise that
-# 'skill apply' deletes the extras -- it won't. Doctor notes the hold instead.
+# is unresolvable), the disk-match-env hint must not promise that 'skill
+# apply' deletes the extras -- it won't. Doctor notes the hold instead, with
+# a self-contained reason (preflight suppresses the freshness WARNING, so the
+# note may not reference other checks) and a by-hand deletion command.
 BLOCKED_HINT_DIR="${TMPDIR}/blocked-hint"
 mkdir -p "$BLOCKED_HINT_DIR"
 cd "$BLOCKED_HINT_DIR"
@@ -1904,11 +1899,10 @@ export AGENT_REQUIRED_SKILLS="coding-standards totally-bogus-unresolvable-skill"
 if doctor_out=$(env -u DIRENV_DIR "${SCRIPT}" doctor 2>&1); then
   echo "not ok 81 - [Hints] doctor should have failed with extra + unresolvable"
 else
-  if ! printf '%s\n' "$doctor_out" | grep -q "If the declared skill set" &&
-    ! printf '%s\n' "$doctor_out" | grep -q "deletes the 1 extra/stale symlink(s)" &&
-    printf '%s\n' "$doctor_out" | grep -q "If the skills on disk are correct" &&
-    printf '%s\n' "$doctor_out" | grep -q "skill remove emumanager" &&
-    printf '%s\n' "$doctor_out" | grep -q "Note: 'skill apply' will not delete the extra/stale symlink(s) while a declared spec is unresolvable."; then
+  if ! printf '%s\n' "$doctor_out" | grep -q "Make disk match env" &&
+    ! printf '%s\n' "$doctor_out" | grep -q "delete the emumanager symlink)" &&
+    printf '%s\n' "$doctor_out" | grep -q "Make env match disk (declare emumanager; keep the symlink):" &&
+    printf '%s\n' "$doctor_out" | grep -q "Note: 'skill apply' will not delete the emumanager symlink while a declared spec is unresolvable (fix or undeclare it first). 'skill remove emumanager' deletes by hand."; then
     echo "ok 81 - [Hints] blocked prune is not promised as an apply effect and is noted"
   else
     echo "not ok 81 - [Hints] blocked-prune hint wrong: $doctor_out"
@@ -2010,8 +2004,9 @@ doctor_conflict_out=$("${SCRIPT}" doctor 2>&1) || true
 apply_conflict_rc=0
 apply_conflict_out=$("${SCRIPT}" apply 2>&1) || apply_conflict_rc=$?
 
-if printf '%s\n' "$doctor_conflict_out" | grep -q "Conflicting skills" &&
+if printf '%s\n' "$doctor_conflict_out" | grep -q "conflicting: " &&
   printf '%s\n' "$doctor_conflict_out" | grep -q "1 conflicting" &&
+  ! printf '%s\n' "$doctor_conflict_out" | grep -q "Make disk match env" &&
   [ "$apply_conflict_rc" -ne 0 ] &&
   printf '%s\n' "$apply_conflict_out" | grep -q "conflicting skill declarations"; then
   echo "ok 85 - [CLI] doctor and apply handle conflicting specs cleanly without infinite loop"


### PR DESCRIPTION
Second pass at "Clarify remediation choices in skill preflight and doctor error messages" — the previous "pick whichever side is authoritative" wording asked the user to adjudicate between data stores instead of stating the choice in terms they can answer. This rewords the `Required Skills` reporting in `skill doctor`/`skill preflight` around two short side labels, **env** (`AGENT_REQUIRED_SKILLS`) and **disk** (the destination symlinks), borrowing the whole-side/per-hunk structure of merge-conflict resolution while keeping the envrc/skill structural separation intact.

## Before

```
[ERROR] Required Skills: Mismatched skill configuration (1 extra/stale)
    Extra skills (linked on disk but not declared):
      - emumanager
    To resolve: pick the fix for whichever side -- declared or on-disk -- you consider correct.
    If the declared skill set (AGENT_REQUIRED_SKILLS) is correct, make the disk match it (deletes the 1 extra/stale symlink(s) from disk):
      skill apply   # 'git-setup' also runs this
    If the skills on disk are correct, declare the extra skill(s) instead (keeps the symlinks):
      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS emumanager"
    To delete individual symlink(s) by hand instead:
      skill remove emumanager
```

## After

```
[ERROR] Required Skills: environment and disk disagree (1 extra/stale)
    emumanager   disk only (linked in .claude/skills, not in AGENT_REQUIRED_SKILLS)
    Make disk match env (delete the emumanager symlink):
      skill apply
    Make env match disk (declare emumanager; keep the symlink):
      export AGENT_REQUIRED_SKILLS="$AGENT_REQUIRED_SKILLS emumanager"
```

And with several buckets at once (envrc workspace):

```
[ERROR] Required Skills: environment and disk disagree (1 missing, 1 extra/stale)
    jetpack      env only (in AGENT_REQUIRED_SKILLS, not linked in .claude/skills)
    emumanager   disk only (linked in .claude/skills, not in AGENT_REQUIRED_SKILLS)
    Make disk match env (link jetpack; delete the emumanager symlink):
      skill apply
    Make env match disk (undeclare jetpack; declare emumanager; keep the symlink):
      envrc remove skills jetpack && envrc add skills emumanager && direnv reload
    Or mix per skill: 'skill remove NAME' edits disk; 'envrc add/remove skills NAME' edits env.
```

## Changes

- **Summary line** names the sides: `environment and disk disagree (…)`, or `cannot resolve the declared skill set (…)` when only declaration-side defects (unresolvable/conflicting specs) exist.
- **Findings render as one aligned per-item list** (`env only` / `disk only` / `disk only, negated` / `wrong target` / `unresolvable`), with the defining gloss attached to the first item of each kind instead of per-bucket headers that restate the direction in different words. Per-destination planner labels (`spec (missing in .claude/skills)`) keep their detail in the annotation; hints always use bare spec names, deduplicated.
- **Remediation is phrased as sync directions with concrete effects**: `Make disk match env (…): skill apply` vs `Make env match disk (…): envrc … && direnv reload`. The env-side path now also covers missing skills (undeclare), not just extras.
- **Every suggested `envrc` command carries the `direnv reload` step** — previously a user who followed the hint and re-ran doctor still saw the same error because the environment stays stale until the next prompt. `skill apply`'s keep-hint gets the same suffix.
- **The per-skill mixing hint prints only with two or more differences** — with one, whole-side resolution *is* per-item resolution.
- **The blocked-prune note is self-contained**: it no longer says "see Environment Freshness", which `preflight` suppresses (errors-only), and it names the `skill remove` by-hand fallback. When the environment is stale, `envrc add` is not suggested for names `.envrc` already declares (they only need a reload).
- **`skill apply` is not advertised while declarations collide** — it refuses to run in that state.
- **The verbose success banner drops its `✔` glyph** per the doctor output style in `cli-tools.md`; the doctor example in `cli-tools.md` and the TODO.md entry are updated to match.

## Tests

Tests 41, 42, 45, 62, 65, and 79–81 updated to assert the new shape (direction-grouped hints, `&& direnv reload`, self-contained blocked-prune note, collision handling). Full suite: 85/85 passing. `bin/command-index-sync --check --all` clean (no help text changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCy2ZiGwJKC5dca4owTAPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCy2ZiGwJKC5dca4owTAPq)_