### PR TITLE
Add offline mode and HTTP caching to jetpack and related tools

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,31 +86,35 @@ and the network fails, the behaviour is unchanged (still an error) except that
 the message now names the cached copy and the switch that would use it, which is
 the one thing an agent that just lost its network can act on alone.
 
-The cold-environment question the original sketch left open is answered by (a):
-`jetpack warm cache [ARTIFACT]...` fetches the index plus each artifact's
-metadata and POM (`--index-only`, `--with-source`, `--version TYPE`), and
-refuses to run while offline, since it is the step that needs the network. (b),
-a snapshot checked into the repo, was rejected: the GMaven class index is ~10MB
-compressed and changes daily, so a checked-in copy would be both large and
-misleading. `jetpack doctor` is the other half of the CI/sandbox story —
-read-only, reports dependencies, offline mode, cache location and index age, and
-exits non-zero on any WARN/ERROR so a job can gate on it before trusting an
-offline answer. It reports missing dependencies rather than exiting 127 on the
-first one, and treats a missing index as INFO online (self-healing) but ERROR
-offline.
+The cold-environment question the original sketch left open is answered by none
+of (a), (b) or (c) as written: write-through already covers it. Running a
+command with network caches every resource that same command needs offline, so
+the warm-up *is* the command, and a miss quotes the failing invocation back
+(`run this where there is network to populate the cache: jetpack version androidx.wear.tiles:tiles ALPHA`)
+— a more precise remedy than any generic warm command, because it cannot be
+wrong about what was wanted. A `warm cache` subcommand was built first and then
+removed: it could only ever guess which version, and with or without sources, a
+later run would ask for, and each wrong guess is a miss the caller still hits.
+(b), a snapshot checked into the repo, was rejected outright: the GMaven class
+index is ~10MB compressed and changes daily. `jetpack doctor` is the other half
+of the CI/sandbox story — read-only, reports dependencies, offline mode, cache
+location and index age, and exits non-zero on any WARN/ERROR so a job can gate
+on it before trusting an offline answer. It reports missing dependencies rather
+than exiting 127 on the first one, and treats a missing index as INFO online
+(self-healing) but ERROR offline.
 
 Two guards exist because they destroy the only copy otherwise: `search --force`
 refuses while offline (it deletes the index before rebuilding), and cache writes
 are best-effort so an unwritable cache directory — a read-only sandbox — never
 fails the command the user actually asked for.
 
-`skills/jetpack/tests/test-jetpack-offline` covers all of this hermetically: 21
+`skills/jetpack/tests/test-jetpack-offline` covers all of this hermetically: 28
 cases against a hand-seeded fixture cache with every request aimed at
 `http://127.0.0.1:1/`, so a cached answer proves the cache was read and a "could
 not reach" proves it was not, with no dependence on the machine's network. Fixed
-along the way, found by `warm cache` exercising it: `list dependencies` routed
-every version through `cmd_version`, which only accepts symbolic types, so a
-pinned version (`list dependencies foo 1.6.1`) failed with "invalid version
+along the way, found while exercising a pinned version: `list dependencies`
+routed every version through `cmd_version`, which only accepts symbolic types,
+so a pinned version (`list dependencies foo 1.6.1`) failed with "invalid version
 type" and then built a POM URL out of an empty string.
 
 ## Normalize cache-directory and offline-mode conventions across skill scripts (2026-07-27) — done
@@ -134,8 +138,8 @@ them; a `--offline` flag alone cannot do that, so the variable is primary.
 
 Audit of the five scripts that cache something:
 
-- `jetpack` — `JETPACK_CACHE_DIR` + offline mode + `warm cache` + `doctor` (see
-  the item above).
+- `jetpack` — `JETPACK_CACHE_DIR` + offline mode + `doctor` (see the item
+  above).
 - `skill` — `SKILL_CACHE_DIR` meant the *base*
   (`$SKILL_CACHE_DIR/skill/remotes`); now it names the cache directory itself,
   via a new `get_cache_dir()` that both `get_cache_base()` and

--- a/TODO.md
+++ b/TODO.md
@@ -6,153 +6,164 @@
 `library-lookup`, 6 `trigger`) exists but has barely been exercised. This
 session ran exactly one case (`pos-version-stable`) through
 `skill-benchmark prepare`/`run-codex`/`benchmark`, repeatedly, to shake out
-tooling problems rather than to actually evaluate the skill — and it still
-found two real, distinct issues on the way: `scripts/jetpack` required bash
-4.0 for one `mapfile` call (fixed, commit `050b3eb`), and `run-codex`
-hardcodes `--sandbox read-only`, which blocks `mktemp`/network entirely and
-made an already-correct script look broken (worked around per-invocation
-with `--codex-cmd "codex exec --json --sandbox workspace-write -c
-sandbox_workspace_write.network_access=true"`, not yet a permanent fix). Only
-after both were understood did `pos-version-stable` show a clean lift
-(`with_skill` 1.0 vs `without_skill` 0.5, `case_flags` empty). The other 5
-`library-lookup` cases and all 6 `trigger` cases (which need
-`skill-trigger-matrix`, not `benchmark`) haven't been run at all.
+tooling problems rather than to actually evaluate the skill — and it still found
+two real, distinct issues on the way: `scripts/jetpack` required bash 4.0 for
+one `mapfile` call (fixed, commit `050b3eb`), and `run-codex` hardcodes
+`--sandbox read-only`, which blocks `mktemp`/network entirely and made an
+already-correct script look broken (worked around per-invocation with
+`--codex-cmd "codex exec --json --sandbox workspace-write -c sandbox_workspace_write.network_access=true"`,
+not yet a permanent fix). Only after both were understood did
+`pos-version-stable` show a clean lift (`with_skill` 1.0 vs `without_skill` 0.5,
+`case_flags` empty). The other 5 `library-lookup` cases and all 6 `trigger`
+cases (which need `skill-trigger-matrix`, not `benchmark`) haven't been run at
+all.
 
 **Goal:** Reach one of two explicit end states, not just "ran it a few more
 times": either (a) `jetpack` has been iterated on, using whatever the harness
-surfaces, until there's confidence the skill is solid across its case set —
-or (b) a written verdict that `skill-eval-harness` isn't worth continuing to
-invest in for this skill. This is a continuation of the smoke-testing already
-underway, not a restart; it depends on known jetpack bugs being fixed as
-they're found (as `050b3eb` already was), not on some separate fixed-up
-prerequisite state.
+surfaces, until there's confidence the skill is solid across its case set — or
+(b) a written verdict that `skill-eval-harness` isn't worth continuing to invest
+in for this skill. This is a continuation of the smoke-testing already underway,
+not a restart; it depends on known jetpack bugs being fixed as they're found (as
+`050b3eb` already was), not on some separate fixed-up prerequisite state.
 
 **Criteria:**
 
 - All 6 `library-lookup` tune cases have been run (`with_skill`/`without_skill`,
   Codex, workspace-write + network) and graded; each case's `case_flags` is
-  either clean or has a recorded, justified reason (e.g. base-saturated —
-  not a real regression).
+  either clean or has a recorded, justified reason (e.g. base-saturated — not a
+  real regression).
 - The 6 `trigger` cases have been run through `skill-trigger-matrix`, or their
   deferral is explicitly noted with why.
-- Either one or more jetpack fixes have landed as a direct result (each its
-  own commit, as with `050b3eb`), or this item (or a follow-up) records a
+- Either one or more jetpack fixes have landed as a direct result (each its own
+  commit, as with `050b3eb`), or this item (or a follow-up) records a
   one-paragraph verdict on whether the harness earned its keep here — citing
   what it did and didn't catch, not just a feeling.
 
 **Sketch:**
 
 - Pick up where this session left off:
-  `skill-benchmark prepare skills/jetpack/evals/shared-benchmark.json --split
-  tune --runs-per-variant 1 --out tasks.jsonl` emits only the 6 `pos-*` rows
-  (the `trig-*` cases are for `skill-trigger-matrix`, a separate tool, not
-  `prepare`/`benchmark`).
+  `skill-benchmark prepare skills/jetpack/evals/shared-benchmark.json --split tune --runs-per-variant 1 --out tasks.jsonl`
+  emits only the 6 `pos-*` rows (the `trig-*` cases are for
+  `skill-trigger-matrix`, a separate tool, not `prepare`/`benchmark`).
 - Keep using the `--codex-cmd` override above until sandbox permissions are
-  addressed some other way — `run-codex`'s own default makes a correct
-  script fail, which is easy to misdiagnose as a jetpack bug (it already was,
-  once, this session).
+  addressed some other way — `run-codex`'s own default makes a correct script
+  fail, which is easy to misdiagnose as a jetpack bug (it already was, once,
+  this session).
 - Once single-run signal looks stable per case, raise `--runs-per-variant` to
-  catch flakiness — the harness's pass@k/pass^k reliability plumbing exists
-  for exactly this and hasn't been exercised yet.
+  catch flakiness — the harness's pass@k/pass^k reliability plumbing exists for
+  exactly this and hasn't been exercised yet.
 - No case declares `files`, so no fixture directory work is needed alongside
   this.
-- Related but not a hard blocker: "Make jetpack work offline with a
-  pre-warmed cache" below — once jetpack has a cache/offline mode, it may be
-  possible to eval it under the harness's safer default sandbox instead of
-  the workspace-write override, worth revisiting then.
+- Worth revisiting now: "Make jetpack work offline with a pre-warmed cache"
+  below is done, so `version`/`resolve`/`list dependencies`/`source` all answer
+  from `$JETPACK_CACHE_DIR` under `AGENT_OFFLINE=1`. A run that warms the cache
+  first (network-enabled, outside the sandbox) should be evaluable under
+  `run-codex`'s default `read-only` sandbox — except that sandbox also blocks
+  `mktemp`, which several jetpack paths still need, so check that before
+  assuming the `--codex-cmd` override can be dropped.
 
-## Make jetpack work offline with a pre-warmed cache (2026-07-27)
+## Make jetpack work offline with a pre-warmed cache (2026-07-27) — done
 
-**Problem:** `scripts/jetpack` hits the network on nearly every subcommand —
-`version`, `list dependencies`, and `source`/`inspect` all shell out to `curl`
-against Maven metadata / `dl.google.com` with zero caching, and even
-`search`/`resolve`'s GMaven index cache (`~/.cache/jetpack/androidx-index.json`,
-24h TTL) has no way to force offline reuse: `is_index_fresh` only skips a
-rebuild attempt when the cache is younger than 24h, so a run with no network
-still pays for (and fails) a rebuild attempt before falling back to a stale
-cache. Surfaced via a `skill-eval-harness` smoke run: in Codex's default
-`read-only` sandbox (no writes, no network), `version` failed outright; even
-after relaxing to `--sandbox workspace-write -c
-sandbox_workspace_write.network_access=true`, the run only succeeded because
-that specific sandbox happened to allow live network egress — nothing here
-works with network genuinely unavailable (CI without egress, an agent
-sandboxed for safety).
+`scripts/jetpack` now has a single HTTP primitive (`http_get`) that every
+network call goes through — `fetch_maven_metadata`, the source JAR and POM
+downloads in `source`/`inspect` (including the KMP platform artifacts), and the
+snapshot version metadata in `list dependencies`. It writes every successful
+response through to `$CACHE_DIR/http/<host>/<path>`, mirroring the URL rather
+than hashing it so the cache can be listed, seeded by a test fixture, and pruned
+by hand. The cache is only *read* when offline, so adding it cannot change what
+an online run answers: warming is a side effect of normal use rather than a new
+staleness window. The GMaven index keeps its existing 24h TTL and its
+`CACHE_DIR`/`INDEX_FILE` location, which the HTTP cache sits beside rather than
+replacing.
 
-**Goal:** `jetpack` can answer version/resolve/dependency/source-lookup
-questions entirely from a local cache when told to run offline, with an
-explicit signal rather than silently guessing or hard-failing on the first
-missing network call.
+`JETPACK_OFFLINE` (falling back to `AGENT_OFFLINE`) makes every subcommand skip
+the network entirely. Cached answers are served at any age with that age on
+stderr (`offline: using cached <url> (cached 3 days ago)`), so stdout stays
+parseable and an agent has the caveat it needs. A miss names the exact URL and
+the command that would have warmed it, and exits 1 — the `3a410bf` "report a
+failure, don't guess" contract, extended to the offline case. When *not* offline
+and the network fails, the behaviour is unchanged (still an error) except that
+the message now names the cached copy and the switch that would use it, which is
+the one thing an agent that just lost its network can act on alone.
 
-**Criteria:**
+The cold-environment question the original sketch left open is answered by (a):
+`jetpack warm cache [ARTIFACT]...` fetches the index plus each artifact's
+metadata and POM (`--index-only`, `--with-source`, `--version TYPE`), and
+refuses to run while offline, since it is the step that needs the network. (b),
+a snapshot checked into the repo, was rejected: the GMaven class index is ~10MB
+compressed and changes daily, so a checked-in copy would be both large and
+misleading. `jetpack doctor` is the other half of the CI/sandbox story —
+read-only, reports dependencies, offline mode, cache location and index age, and
+exits non-zero on any WARN/ERROR so a job can gate on it before trusting an
+offline answer. It reports missing dependencies rather than exiting 127 on the
+first one, and treats a missing index as INFO online (self-healing) but ERROR
+offline.
 
-- A single environment variable (e.g. `JETPACK_OFFLINE=1` — see the companion
-  item below on naming this consistently across skills) makes every subcommand
-  skip network calls entirely and serve from cache, using stale data rather
-  than erroring, but always noting the cache's age in its output so an
-  agent/user isn't left thinking the answer is current.
-- `version`, `list dependencies`, and `source`/`inspect` gain a cache layer
-  (they currently have none) — extend the existing `CACHE_DIR`/`INDEX_FILE`
-  convention rather than inventing a second cache location.
-- Cache-miss-while-offline is a clear, actionable error (per the existing
-  `3a410bf` "report a failure, don't guess" behavior), not a silent fallback to
-  training-data knowledge.
-- `tests/test-jetpack*` cover the offline path with a pre-warmed fixture cache,
-  mirroring `test-jetpack-search`'s existing `TEST_CACHE_DIR` mocking.
+Two guards exist because they destroy the only copy otherwise: `search --force`
+refuses while offline (it deletes the index before rebuilding), and cache writes
+are best-effort so an unwritable cache directory — a read-only sandbox — never
+fails the command the user actually asked for.
 
-**Sketch:**
+`skills/jetpack/tests/test-jetpack-offline` covers all of this hermetically: 21
+cases against a hand-seeded fixture cache with every request aimed at
+`http://127.0.0.1:1/`, so a cached answer proves the cache was read and a "could
+not reach" proves it was not, with no dependence on the machine's network. Fixed
+along the way, found by `warm cache` exercising it: `list dependencies` routed
+every version through `cmd_version`, which only accepts symbolic types, so a
+pinned version (`list dependencies foo 1.6.1`) failed with "invalid version
+type" and then built a POM URL out of an empty string.
 
-- Reuse `CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/jetpack"`, already used by
-  `search`/`resolve`; extend it to `version`/`list dependencies`/`source`
-  rather than a second cache location.
-- Model the offline toggle and the "warm then freeze" workflow directly on
-  `skills/workspace-config/tests/common.sh`'s existing pre-warmed-cache
-  pattern: run once with real network to populate `CACHE_DIR`, then set the
-  offline env var for everything after.
-- Open question, not yet resolved: how does a *fresh* environment with no
-  prior local cache and no network (a clean CI runner, a from-scratch
-  sandboxed agent) get a warm cache in the first place? Candidates to weigh:
-  (a) a `jetpack cache warm` subcommand run once in a network-enabled setup
-  step before the offline job runs; (b) checking a periodically-refreshed
-  snapshot of the GMaven index (and/or common coordinates' metadata) into the
-  repo or a release artifact for CI to seed from; (c) documenting cold+offline
-  as unsupported rather than solving it. Needs a decision before
-  implementation, not just a mechanism.
-- Depends on deciding the naming/semantics question in the companion item
-  below before committing to `JETPACK_OFFLINE` specifically.
+## Normalize cache-directory and offline-mode conventions across skill scripts (2026-07-27) — done
 
-## Normalize cache-directory and offline-mode conventions across skill scripts (2026-07-27)
+The convention is written up in `skills/coding-standards/references/caching.md`,
+referenced from `cli-tools.md` (interface), `shell.md` (the two bash traps:
+guarding cache writes under `set -euo pipefail`, and distinguishing "no
+response" from "an error response"), and the `coding-standards` SKILL.md. Cache
+location is `${<TOOL>_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/<tool>}`, where
+`<TOOL>_CACHE_DIR` names the tool's own directory rather than the base it sits
+in, one root per tool.
 
-**Problem:** Cache-directory handling is already inconsistent across scripts
-that cache network responses: `context`, `oracle`, and `photo-query` (all in
-`agent-tools`) use a plain `${XDG_CACHE_HOME:-~/.cache}/<tool>` path with no
-per-tool override; `skill` (`workspace-config`) supports a dedicated
-`SKILL_CACHE_DIR` override ahead of `XDG_CACHE_HOME`; `jetpack` uses the plain
-form again, but only for its `search`/`resolve` GMaven index. None of these
-share a documented offline-mode convention; each would otherwise reinvent one
-ad hoc, which is exactly what the companion "Make jetpack work offline" item
-above was about to do in isolation.
+The naming question is decided as both, not either: `<TOOL>_OFFLINE` wins when
+set (including when set to `0`, to opt one tool out), otherwise the
+workspace-wide `AGENT_OFFLINE` applies. That is not a compromise but the
+existing two-tier rule in `workspace-config`'s SKILL.md — `AGENT_*` is policy a
+human sets for an environment, `<TOOL>_*` is per-tool plumbing — and it matches
+`UV_OFFLINE`, which the test suites already set. A caller who cannot enumerate
+every command a build or agent session will invoke needs one switch for all of
+them; a `--offline` flag alone cannot do that, so the variable is primary.
 
-**Goal:** One documented convention, discoverable from `coding-standards`, that
-any network-calling script in this repo follows for (a) where its cache lives
-and (b) how a caller forces it to run offline against that cache.
+Audit of the five scripts that cache something:
 
-**Criteria:**
+- `jetpack` — `JETPACK_CACHE_DIR` + offline mode + `warm cache` + `doctor` (see
+  the item above).
+- `skill` — `SKILL_CACHE_DIR` meant the *base*
+  (`$SKILL_CACHE_DIR/skill/remotes`); now it names the cache directory itself,
+  via a new `get_cache_dir()` that both `get_cache_base()` and
+  `get_catalog_dir()` derive from. Gained `SKILL_OFFLINE` /`AGENT_OFFLINE`:
+  `fetch_github` serves a previously downloaded remote skill at any age
+  (ignoring `--force`, which cannot be honoured without network) and reports how
+  old it is, or dies naming `skill add <name>` if it was never fetched; catalog
+  metadata degrades quietly since it is only descriptions. This matters most for
+  `preflight`, which gates agent launch and should not depend on GitHub being
+  reachable.
+- `context` — gained `CONTEXT_CACHE_DIR` and `CONTEXT_OFFLINE`/`AGENT_OFFLINE`.
+  Only URL targets are gated; local directories and entries are built from the
+  machine itself and are left alone. Two cases added to `test-context`.
+- `photo-query` — cached under `agent-tools/photo-query`, the only script
+  grouping by skill rather than by tool; moved to `photo-query` with a
+  `PHOTO_QUERY_CACHE_DIR` override. No offline mode, recorded in its docstring:
+  the cache holds locally derived thumbnails, not fetched data, and the Gemini
+  call the tool exists to make cannot be served from it. The old directory's
+  contents are regenerated on demand.
+- `oracle` — `ORACLE_CACHE_DIR` added for symmetry, no offline mode, reason
+  recorded inline: `~/.cache/oracle` is a transcript of past consultations, not
+  a response cache. Every run is a fresh model call against a new prompt, so
+  there is nothing there to serve a later run from.
 
-- A written convention exists and is referenced from `cli-tools.md`/`shell.md`
-  (per this repo's existing pattern of centralizing cross-skill guidance in
-  `coding-standards`, not per-skill).
-- `jetpack`, `oracle`, `context`, `photo-query`, and `skill` are audited
-  against it; deviations are either fixed or have a recorded reason.
-- The offline-mode env var name and semantics are decided once — candidate:
-  mirror `uv`'s `--offline`/`UV_OFFLINE` (a per-tool `<TOOL>_OFFLINE=1`, or one
-  repo-wide var; this needs an explicit decision, not just a default) — and
-  documented alongside the "warm cache with real network, then freeze" pattern
-  already proven in `skills/workspace-config/tests/common.sh`.
-
-**Sketch:** Start from an audit (`rg` for `XDG_CACHE_HOME`, `CACHE_DIR`,
-`_CACHE_DIR` across `skills/`) to enumerate every script that already caches
-something, then decide the convention before jetpack's offline-mode work above
-implements a one-off.
+`tests/README.md` documents `AGENT_OFFLINE=1` alongside `UV_OFFLINE=1` (the two
+cover different layers: dependency resolution vs. the scripts' own calls) and
+points at `test-jetpack-offline` as the pattern for tests that need a specific
+cache state.
 
 ## Enable more of ruff's default rule set (2026-07-26) — done
 

--- a/fish/completions/jetpack.fish
+++ b/fish/completions/jetpack.fish
@@ -14,7 +14,6 @@ complete -c jetpack -n __fish_use_subcommand -a source -d 'Download and extract 
 complete -c jetpack -n __fish_use_subcommand -a inspect -d 'Resolve class name and download source'
 complete -c jetpack -n __fish_use_subcommand -a resolve-exceptions -d 'Find missing exceptions for resolve'
 complete -c jetpack -n __fish_use_subcommand -a search -d 'Search for artifacts by package or class name'
-complete -c jetpack -n __fish_use_subcommand -a warm -d 'Populate the cache for offline use'
 complete -c jetpack -n __fish_use_subcommand -a doctor -d 'Report dependencies, offline mode, and cache state'
 
 # version subcommand
@@ -52,15 +51,6 @@ complete -c jetpack -n '__fish_seen_subcommand_from list; and __fish_seen_subcom
 # search subcommand
 complete -c jetpack -n '__fish_seen_subcommand_from search' -s h -l help -d 'Display help'
 complete -c jetpack -n '__fish_seen_subcommand_from search' -l force -d 'Force cache rebuild'
-
-# warm subcommands
-complete -c jetpack -n '__fish_seen_subcommand_from warm; and not __fish_seen_subcommand_from cache' -a cache -d 'Download what later offline runs need'
-
-# warm cache
-complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -s h -l help -d 'Display help'
-complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l index-only -d 'Only refresh the GMaven class index'
-complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l with-source -d 'Also download source JARs'
-complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l version -r -a 'ALPHA BETA RC STABLE LATEST SNAPSHOT' -d 'Version to warm'
 
 # doctor subcommand
 complete -c jetpack -n '__fish_seen_subcommand_from doctor' -s h -l help -d 'Display help'

--- a/fish/completions/jetpack.fish
+++ b/fish/completions/jetpack.fish
@@ -14,6 +14,8 @@ complete -c jetpack -n __fish_use_subcommand -a source -d 'Download and extract 
 complete -c jetpack -n __fish_use_subcommand -a inspect -d 'Resolve class name and download source'
 complete -c jetpack -n __fish_use_subcommand -a resolve-exceptions -d 'Find missing exceptions for resolve'
 complete -c jetpack -n __fish_use_subcommand -a search -d 'Search for artifacts by package or class name'
+complete -c jetpack -n __fish_use_subcommand -a warm -d 'Populate the cache for offline use'
+complete -c jetpack -n __fish_use_subcommand -a doctor -d 'Report dependencies, offline mode, and cache state'
 
 # version subcommand
 complete -c jetpack -n '__fish_seen_subcommand_from version' -s h -l help -d 'Display help'
@@ -50,3 +52,15 @@ complete -c jetpack -n '__fish_seen_subcommand_from list; and __fish_seen_subcom
 # search subcommand
 complete -c jetpack -n '__fish_seen_subcommand_from search' -s h -l help -d 'Display help'
 complete -c jetpack -n '__fish_seen_subcommand_from search' -l force -d 'Force cache rebuild'
+
+# warm subcommands
+complete -c jetpack -n '__fish_seen_subcommand_from warm; and not __fish_seen_subcommand_from cache' -a cache -d 'Download what later offline runs need'
+
+# warm cache
+complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -s h -l help -d 'Display help'
+complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l index-only -d 'Only refresh the GMaven class index'
+complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l with-source -d 'Also download source JARs'
+complete -c jetpack -n '__fish_seen_subcommand_from warm; and __fish_seen_subcommand_from cache' -l version -r -a 'ALPHA BETA RC STABLE LATEST SNAPSHOT' -d 'Version to warm'
+
+# doctor subcommand
+complete -c jetpack -n '__fish_seen_subcommand_from doctor' -s h -l help -d 'Display help'

--- a/skills/agent-tools/scripts/context
+++ b/skills/agent-tools/scripts/context
@@ -1087,9 +1087,9 @@ def cache_age_human(path) -> str:
     for limit, unit, size in ((3600, "minute", 60), (86400, "hour", 3600)):
         if age < limit:
             n = int(age // size)
-            return f"{n} {unit}" if n == 1 else f"{n} {unit}s"
+            return f"{n} {unit} ago" if n == 1 else f"{n} {unit}s ago"
     n = int(age // 86400)
-    return f"{n} day" if n == 1 else f"{n} days"
+    return f"{n} day ago" if n == 1 else f"{n} days ago"
 
 
 def cmd_show(target, force, catalog):
@@ -1165,14 +1165,19 @@ def cmd_show(target, force, catalog):
             use_cache = True
 
     # Offline, a cached copy is served whatever its age (the 24h TTL above is a
-    # freshness preference, not a reason to fail), with that age reported. Only
-    # URL targets need the network; local directories and entries are built
-    # from the machine itself and are left alone.
-    if is_offline() and is_url_target:
-        if cache_file and os.path.exists(cache_file):
+    # freshness preference, not a reason to fail), with that age reported.
+    #
+    # The gate is "has a cache file", which covers catalog entries as well as
+    # URL targets: every built-in entry handler fetches over the network, and a
+    # plugin-provided one may do anything at all, so falling through to func()
+    # would break the no-network promise in precisely the sandbox this exists
+    # for. Only local directory targets, which are read from the machine
+    # itself, are exempt.
+    if is_offline() and cache_file:
+        if os.path.exists(cache_file):
             print(
                 f"context: offline ({offline_desc()}): using cached {target} "
-                f"(cached {cache_age_human(cache_file)} ago)",
+                f"(cached {cache_age_human(cache_file)})",
                 file=sys.stderr,
             )
             use_cache = True

--- a/skills/agent-tools/scripts/context
+++ b/skills/agent-tools/scripts/context
@@ -15,6 +15,7 @@ import re
 import sys
 import tarfile
 import tempfile
+import time
 from datetime import datetime
 
 import requests
@@ -1057,8 +1058,42 @@ def register(api):
 ''')
 
 
+def is_offline() -> bool:
+    """Whether network fetches are forbidden in this environment.
+
+    Per skills/coding-standards/references/caching.md: the per-tool variable
+    wins when set (including when set to 0, to opt one tool out of a
+    workspace-wide policy), otherwise the AGENT_OFFLINE policy applies.
+    """
+    value = os.environ.get("CONTEXT_OFFLINE")
+    if value is None:
+        value = os.environ.get("AGENT_OFFLINE", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def offline_desc() -> str:
+    var = "CONTEXT_OFFLINE" if "CONTEXT_OFFLINE" in os.environ else "AGENT_OFFLINE"
+    return f"{var}={os.environ.get(var, '')}"
+
+
+def cache_age_human(path) -> str:
+    """How long ago PATH was written, for qualifying a cached answer."""
+    try:
+        age = time.time() - os.path.getmtime(path)
+    except OSError:
+        return "unknown age"
+    if age < 60:
+        return "just now"
+    for limit, unit, size in ((3600, "minute", 60), (86400, "hour", 3600)):
+        if age < limit:
+            n = int(age // size)
+            return f"{n} {unit}" if n == 1 else f"{n} {unit}s"
+    n = int(age // 86400)
+    return f"{n} day" if n == 1 else f"{n} days"
+
+
 def cmd_show(target, force, catalog):
-    cache_dir = os.path.join(
+    cache_dir = os.environ.get("CONTEXT_CACHE_DIR") or os.path.join(
         os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "context"
     )
 
@@ -1123,13 +1158,35 @@ def cmd_show(target, force, catalog):
     # Check cache
     use_cache = False
     if cache_file and not force and os.path.exists(cache_file):
-        import time
-
         mtime = os.path.getmtime(cache_file)
         script_mtime = os.path.getmtime(os.path.realpath(__file__))
 
         if (time.time() - mtime) < 24 * 3600 and mtime > script_mtime:
             use_cache = True
+
+    # Offline, a cached copy is served whatever its age (the 24h TTL above is a
+    # freshness preference, not a reason to fail), with that age reported. Only
+    # URL targets need the network; local directories and entries are built
+    # from the machine itself and are left alone.
+    if is_offline() and is_url_target:
+        if cache_file and os.path.exists(cache_file):
+            print(
+                f"context: offline ({offline_desc()}): using cached {target} "
+                f"(cached {cache_age_human(cache_file)} ago)",
+                file=sys.stderr,
+            )
+            use_cache = True
+        else:
+            print(
+                f"context: offline ({offline_desc()}) and no cached copy of {target}",
+                file=sys.stderr,
+            )
+            print(
+                f"context: fetch it from a network-enabled environment first: "
+                f"context show {target}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     if use_cache and cache_file:
         with open(cache_file) as f:

--- a/skills/agent-tools/scripts/oracle
+++ b/skills/agent-tools/scripts/oracle
@@ -366,15 +366,22 @@ def main():
         payload_xml += f"  <task><![CDATA[\n{user_prompt}\n]]></task>\n"
     payload_xml += "</oracle_payload>\n"
 
-    # Save to XDG cache directory if enabled
+    # Save to the cache directory if enabled. This directory is a transcript of
+    # past consultations, not a response cache: every run is a fresh model call
+    # against a new prompt, so there is nothing here to serve a later run from
+    # and no offline mode to offer (see coding-standards references/caching.md).
+    # The location still follows the convention, so it can be pointed elsewhere.
     session_id = uuid.uuid4()
     oracle_cache_dir = None
     if serialize:
         try:
-            cache_dir = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser(
-                "~/.cache"
-            )
-            oracle_cache_dir = os.path.join(cache_dir, "oracle")
+            oracle_cache_dir = os.environ.get("ORACLE_CACHE_DIR")
+            if not oracle_cache_dir:
+                cache_dir = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser(
+                    "~/.cache"
+                )
+                oracle_cache_dir = os.path.join(cache_dir, "oracle")
+            oracle_cache_dir = os.path.expanduser(oracle_cache_dir)
             os.makedirs(oracle_cache_dir, exist_ok=True)
             payload_file_path = os.path.join(
                 oracle_cache_dir, f"payload_{session_id}.xml"

--- a/skills/agent-tools/scripts/photo-query
+++ b/skills/agent-tools/scripts/photo-query
@@ -16,9 +16,11 @@ boolean classification).
   photo-query "Is there a fireplace?" *.jpg   # free-form
   photo-query "..." --schema "has_bed bool" *.jpg
 
-Pre-processed WebP bytes are cached at ~/.cache/agent-tools/photo-query/ so
-repeated queries against the same images skip EXIF rotation, alpha flatten,
-resize, and re-encode.
+Pre-processed WebP bytes are cached at ~/.cache/photo-query/ (override with
+PHOTO_QUERY_CACHE_DIR) so repeated queries against the same images skip EXIF
+rotation, alpha flatten, resize, and re-encode. That cache holds locally
+derived thumbnails, not fetched data, so there is no offline mode: the Gemini
+call this tool exists to make cannot be served from it.
 """
 
 import argparse
@@ -49,8 +51,12 @@ DEFAULT_MAX_SIZE = 768
 
 
 def cache_dir() -> Path:
-    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
-    d = Path(base) / "agent-tools" / "photo-query"
+    override = os.environ.get("PHOTO_QUERY_CACHE_DIR")
+    if override:
+        d = Path(override).expanduser()
+    else:
+        base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+        d = Path(base) / "photo-query"
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/skills/agent-tools/tests/test-context
+++ b/skills/agent-tools/tests/test-context
@@ -7,7 +7,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 BIN="$DIR/../scripts/context"
 
-echo "1..5"
+echo "1..7"
 
 # Test 1: Usage (no args)
 OUTPUT=$(mktemp)
@@ -79,4 +79,35 @@ if ! "$BIN" invalid-command >"$OUTPUT" 2>&1; then
   fi
 else
   echo "not ok 5 - Invalid subcommand succeeded, expected failure"
+fi
+
+# Test 6: Offline mode with no cached copy of a URL target fails with an
+# actionable error rather than reaching for the network.
+CACHE_DIR=$(mktemp -d)
+trap 'rm -f "$OUTPUT"; rm -rf "$TMP_DIR" "$CACHE_DIR"' EXIT
+
+if ! CONTEXT_CACHE_DIR="$CACHE_DIR" AGENT_OFFLINE=1 \
+  "$BIN" show "https://github.com/example/repo" >"$OUTPUT" 2>&1; then
+  if grep -q "no cached copy" "$OUTPUT" && grep -q "AGENT_OFFLINE=1" "$OUTPUT"; then
+    echo "ok 6 - Offline with a cold cache fails and names the missing URL"
+  else
+    echo "not ok 6 - Offline cold-cache error missing expected text"
+    sed 's/^/# /' "$OUTPUT"
+  fi
+else
+  echo "not ok 6 - Offline with a cold cache succeeded, expected failure"
+fi
+
+# Test 7: A local directory target needs no network, so offline mode must not
+# get in its way.
+if RESPONSE=$(CONTEXT_CACHE_DIR="$CACHE_DIR" AGENT_OFFLINE=1 "$BIN" show "$TMP_DIR"); then
+  if echo "$RESPONSE" | grep -q "Hello World"; then
+    echo "ok 7 - Offline mode leaves local directory targets alone"
+  else
+    echo "not ok 7 - Offline local directory output missing expected content"
+    # shellcheck disable=SC2001  # matches the diagnostic dumps above
+    echo "$RESPONSE" | sed 's/^/# /'
+  fi
+else
+  echo "not ok 7 - Offline mode broke a local directory target"
 fi

--- a/skills/agent-tools/tests/test-context
+++ b/skills/agent-tools/tests/test-context
@@ -7,7 +7,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 BIN="$DIR/../scripts/context"
 
-echo "1..7"
+echo "1..8"
 
 # Test 1: Usage (no args)
 OUTPUT=$(mktemp)
@@ -110,4 +110,19 @@ if RESPONSE=$(CONTEXT_CACHE_DIR="$CACHE_DIR" AGENT_OFFLINE=1 "$BIN" show "$TMP_D
   fi
 else
   echo "not ok 7 - Offline mode broke a local directory target"
+fi
+
+# Test 8: Offline mode must also gate catalog entries, whose handlers all fetch
+# over the network -- otherwise `context show <entry>` reaches the network in a
+# sandbox that forbids it.
+if ! CONTEXT_CACHE_DIR="$CACHE_DIR" AGENT_OFFLINE=1 \
+  "$BIN" show gemini-api >"$OUTPUT" 2>&1; then
+  if grep -q "no cached copy" "$OUTPUT"; then
+    echo "ok 8 - Offline catalog entry fails instead of fetching"
+  else
+    echo "not ok 8 - Offline catalog entry failed for the wrong reason"
+    sed 's/^/# /' "$OUTPUT"
+  fi
+else
+  echo "not ok 8 - Offline catalog entry succeeded, expected a cache-miss failure"
 fi

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -73,6 +73,14 @@ standards in `cli-tools.md`.
 
 @references/shell.md
 
+### Caching and Offline Mode
+
+The cross-cutting convention for scripts that fetch over the network: where the
+cache lives, how a caller forces the tool offline against it, and what CI jobs
+and sandboxed agents need from both.
+
+@references/caching.md
+
 ### Android Development
 
 Tools for working with Android Jetpack libraries, ADB operations, APK analysis,

--- a/skills/coding-standards/references/caching.md
+++ b/skills/coding-standards/references/caching.md
@@ -64,11 +64,20 @@ them at once. A flag is fine as an addition, never as the only switch.
 - **State the age of what it served, on stderr, every time.**
   `(cached 3 days ago)` is the difference between an agent reporting a version
   confidently and an agent reporting it with the caveat that makes it useful.
-  Age goes to stderr so stdout stays parseable.
+  Age goes to stderr so stdout stays parseable. *Every time* includes the paths
+  a freshness TTL would have short-circuited: check offline mode **before** any
+  "cache is younger than the TTL, return early" branch, or the common
+  warm-then-freeze workflow — where the cache is usually fresh — is exactly the
+  case that answers silently.
 - **Fail loudly and actionably on a cache miss.** Name the resource that is
   missing and the command that would have warmed it, and exit non-zero. Never
   fall back to a guess — for an agent, an unsourced answer from training data is
   indistinguishable from a real one.
+- **Gate on "could this need the network", not on the obvious remote case.** A
+  handler that is cached is cached because it was expensive, which usually means
+  remote; a plugin-provided or third-party one may do anything at all. If the
+  tool cannot prove a code path is local, route it through the offline check
+  rather than letting it fall through and dial out.
 
 ```text
 jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
@@ -76,6 +85,23 @@ jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
 jetpack version: warm the cache from a network-enabled environment first:
   jetpack warm cache androidx.wear.tiles:tiles
 ```
+
+#### Optional Resources
+
+Some fetches are best-effort online: their absence is normal and the command
+still produces a correct result. Two rules keep them from becoming a hole in the
+guarantee above:
+
+- A resource whose absence *changes the answer* is not optional, whatever the
+  online path does with it. `jetpack source` fetches a POM only to detect Kotlin
+  Multiplatform targets, and tolerates a missing one online — but offline, a
+  missing POM means the answer silently omits every platform target's sources,
+  so it is fatal there.
+- Where the miss really is tolerable — the resource may legitimately not exist,
+  so a warmed cache can be correctly missing it and a hard error would be
+  unfixable — warn on stderr naming what is absent and how to warm it, and carry
+  on. What is never acceptable is passing over it in silence: the caller cannot
+  see the gap in a result that looks complete.
 
 ### What the Online Path Must Do
 

--- a/skills/coding-standards/references/caching.md
+++ b/skills/coding-standards/references/caching.md
@@ -1,0 +1,201 @@
+# Caching and Offline Mode
+
+This is the cross-cutting convention for any script in this repository that
+fetches something over the network and can usefully reuse the response. It
+covers two questions every such script would otherwise answer ad hoc:
+
+1. Where does the cache live, and how does a caller move it?
+1. How does a caller force the script to run **offline**, against that cache?
+
+Interface rules (flag and command naming, help text, errors) come from
+`cli-tools.md`; the bash idioms come from `shell.md`. This file adds only what
+is specific to caching and offline operation.
+
+## Where the Cache Lives
+
+```text
+${<TOOL>_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/<tool>}
+```
+
+- `<TOOL>_CACHE_DIR` names **the tool's own cache directory**, not the base
+  directory it sits in. `JETPACK_CACHE_DIR=/tmp/jp` puts the cache in `/tmp/jp`,
+  not `/tmp/jp/jetpack`. (`XDG_CACHE_HOME`, by contrast, is the base — that is
+  what the XDG spec says it is.)
+- One cache root per tool. Subdivide *inside* it (`<cache>/http/`,
+  `<cache>/catalog/`) rather than adding a second top-level location. A tool
+  whose cache is spread over two roots cannot be warmed, inspected, pruned, or
+  restored by a CI cache step as one unit.
+- The directory is disposable by definition: deleting it must only cost time,
+  never correctness. Nothing that is not re-derivable belongs in it.
+- Never cache credentialed or user-specific responses in it. The cache is
+  assumed to be safe to share between CI jobs and to hand to a sandboxed agent.
+
+## Forcing Offline Operation
+
+```text
+<TOOL>_OFFLINE    per-tool switch (checked first; wins when set, including
+                  when set to 0 to opt one tool out)
+AGENT_OFFLINE     workspace-wide policy (used when <TOOL>_OFFLINE is unset)
+```
+
+Truthy values are `1`, `true`, `yes`, `on` (case-insensitive); anything else,
+including empty, is false.
+
+This mirrors the two-tier naming rule already documented in `workspace-config`:
+`AGENT_*` variables are **policy** a human (or a CI job, or a sandbox harness)
+sets once for an environment, while `<TOOL>_*` variables are **plumbing** for a
+single tool. It also matches the `<TOOL>_OFFLINE` precedent set by `uv`
+(`UV_OFFLINE`), which this repo's test suites already rely on, so an environment
+that sets `UV_OFFLINE=1` and `AGENT_OFFLINE=1` reads consistently.
+
+Do not add an `--offline` flag as the primary interface. The point of the
+convention is that a caller who cannot enumerate every command that a build,
+test run, or agent session will invoke can still turn off the network for all of
+them at once. A flag is fine as an addition, never as the only switch.
+
+### What Offline Mode Must Do
+
+- **Make no network calls at all.** Not "try and fall back" — in a sandbox every
+  attempt costs a DNS or connect timeout, and the resulting error usually looks
+  like a missing resource rather than a missing network.
+- **Serve stale data rather than erroring.** Offline is a promise that the tool
+  will answer from what it has; a TTL that is meaningful online is not a reason
+  to fail offline.
+- **State the age of what it served, on stderr, every time.**
+  `(cached 3 days ago)` is the difference between an agent reporting a version
+  confidently and an agent reporting it with the caveat that makes it useful.
+  Age goes to stderr so stdout stays parseable.
+- **Fail loudly and actionably on a cache miss.** Name the resource that is
+  missing and the command that would have warmed it, and exit non-zero. Never
+  fall back to a guess — for an agent, an unsourced answer from training data is
+  indistinguishable from a real one.
+
+```text
+jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
+  https://dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
+jetpack version: warm the cache from a network-enabled environment first:
+  jetpack warm cache androidx.wear.tiles:tiles
+```
+
+### What the Online Path Must Do
+
+- **Write through on every successful fetch.** Normal online use is what makes a
+  later offline run possible; a cache that only fills when explicitly warmed
+  will be empty exactly when it is needed.
+- **Do not start serving stale answers online.** Adding a cache must not change
+  what an online run returns. Reserve read-side TTLs for resources that are
+  expensive and slow-moving (a whole-index download), document the TTL in the
+  help text, and leave everything else fetching fresh.
+- **On a network failure, name the cache instead of using it.** A run that was
+  not told to go offline should not quietly answer from a week-old copy. Report
+  the failure, and if a cached copy exists, say so and name the switch:
+  `a cached copy from 3 days ago exists; re-run with AGENT_OFFLINE=1 to use it`.
+  That keeps "report a failure, don't guess" intact while still giving an agent
+  a next step it can take without human help.
+- **Never let cache maintenance fail the run.** In a read-only sandbox the cache
+  directory may not be writable. Failing to store a response is not an error;
+  skip it and continue.
+
+## Cache Layout
+
+When the cached resources are URLs with path-shaped identity, mirror the URL
+under the cache root instead of hashing it:
+
+```text
+<cache>/http/dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
+```
+
+A hash is opaque: it cannot be listed for review, seeded by a test fixture,
+pruned selectively, or diffed between CI runs. A mirrored path can. Reject or
+sanitize path components that would escape the cache root (`..`, empty segments)
+and fall back to not caching if the URL cannot be mapped safely.
+
+## Warming the Cache
+
+Every tool with an offline mode needs an answer to "how does a cold environment
+with no network get a warm cache?" — a fresh CI runner and a from-scratch
+sandboxed agent both start with nothing.
+
+- Provide a **`warm cache` subcommand** (verb-noun, per `cli-tools.md`) that
+  populates the cache for named targets in one network-enabled step, so warming
+  is declarative rather than "remember to run the six commands the job will
+  later need".
+- Because the online path writes through, `warm cache` is a convenience, not the
+  only route: running the real commands once with network is equivalent.
+- Cold **and** offline **and** unwarmed is an unsupported state, and must fail
+  with the actionable error above rather than being papered over.
+
+## Documenting It
+
+The tool's help text lists both variables under `Environment`, with the cache
+default spelled out:
+
+```text
+Environment:
+  JETPACK_OFFLINE     Answer only from the local cache; never use the network.
+                      Falls back to AGENT_OFFLINE when unset.
+  AGENT_OFFLINE       Workspace-wide offline policy (see JETPACK_OFFLINE).
+  JETPACK_CACHE_DIR   Cache directory
+                      (default: ${XDG_CACHE_HOME:-$HOME/.cache}/jetpack)
+```
+
+If the tool has a `doctor` command, it reports the cache location, the age of
+what is in it, and whether offline mode is active — that is the pre-flight check
+a CI job or an agent runs before trusting an offline answer.
+
+## Two Environments This Is For
+
+### CI
+
+CI usually *has* network, which is why the constraint is easy to miss. The
+constraints are different ones: shared egress that is rate-limited or
+occasionally blocked, third-party endpoints that go down independently of your
+change, and a hard requirement that two runs of the same commit behave the same.
+A network call in the middle of a job is a flake source and a reproducibility
+hole even when it succeeds.
+
+The shape that solves all three:
+
+```yaml
+- name: Restore tool cache
+  uses: actions/cache@v4
+  with:
+    path: ~/.cache/jetpack
+    key: jetpack-${{ hashFiles('deps.txt') }}
+
+- name: Warm cache            # the only step allowed to touch the network
+  run: jetpack warm cache $(cat deps.txt)
+
+- name: Build                 # deterministic; a network blip cannot reach it
+  run: make build
+  env:
+    AGENT_OFFLINE: 1
+```
+
+One step owns the network, the cache restore makes it a no-op on most runs, and
+everything after it is pinned to data that was fetched once and can be
+inspected. `AGENT_OFFLINE` is set on the job rather than per-command precisely
+because the job does not know which tools `make build` will reach for.
+
+### Sandboxed Agents
+
+Agent sandboxes increasingly deny network access outright — Codex's `read-only`
+sandbox and `workspace-write` without
+`sandbox_workspace_write.network_access=true` both do — and the denial is a
+safety feature, not a misconfiguration to work around. Two consequences:
+
+- **Set `AGENT_OFFLINE=1` in the sandbox environment.** Then the tools skip
+  calls they cannot make, instead of spending the sandbox's time on connect
+  timeouts and reporting failures that read like "this library does not exist".
+- **Behave sanely when it is *not* set**, because often it will not be. The
+  network is simply gone and the tool finds out by failing. Distinguish "the
+  server said no" from "no server was reached" (an HTTP status vs. no response
+  at all), report which one happened, and point at offline mode when a cached
+  copy exists. Never present a remembered answer as a fetched one.
+- A read-only sandbox may also make the cache unwritable — see "Never let cache
+  maintenance fail the run" above.
+
+The same reasoning applies to the repo's own test suites, which run under
+`UV_OFFLINE=1` with a pre-warmed `uv` cache for exactly these reasons; see
+`skills/workspace-config/tests/common.sh` for the "warm with real network, then
+freeze" pattern, and `tests/README.md` for how to run the suite offline.

--- a/skills/coding-standards/references/caching.md
+++ b/skills/coding-standards/references/caching.md
@@ -1,161 +1,143 @@
 # Caching and Offline Mode
 
-The convention for any script here that fetches over the network and can reuse
-the response: where its cache lives, and how a caller forces it to run offline
-against that cache. Interface rules (flags, help text, errors) come from
-`cli-tools.md`; the bash idioms from `shell.md`.
+This document defines the conventions for caching network responses and
+supporting offline mode in scripts. For interface rules (flags, help text,
+errors) see `cli-tools.md`; for bash idioms see `shell.md`.
 
 ## The Goal
 
 **A caller with no network gets an answer it can trust, or a clear reason it has
 none.**
 
-Three principles follow, and every rule below is one of them applied:
+Three core principles apply:
 
-1. **Trust needs provenance.** Stale data is useful; undated stale data is not,
-   because the caller cannot tell March's answer from today's.
-1. **A gap must look like a gap.** Inventing an answer and quietly returning
-   less than was asked for are the same failure — both read as success.
-1. **The fix travels with the failure.** Whoever hits a cold cache is by
-   definition in the environment that cannot fix it, so the error has to name
-   the command that can.
+1. **Include Provenance:** The caller must know how old the cached data is.
+1. **Expose Gaps:** Never silently ignore missing data. Gaps must be explicitly
+   reported.
+1. **Provide Actionable Errors:** If a cache miss occurs offline, the error must
+   show the command required to fix it (which must be run in an online
+   environment).
 
 ## Where the Cache Lives
 
-```text
+Store cached resources in a tool-specific directory:
+
+```bash
 ${<TOOL>_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/<tool>}
 ```
 
-- `<TOOL>_CACHE_DIR` names the tool's own directory, not the base it sits in:
-  `JETPACK_CACHE_DIR=/tmp/jp` caches in `/tmp/jp`. (`XDG_CACHE_HOME` is the base
-  — that is what the XDG spec makes it.)
-- One root per tool, subdivided inside (`<cache>/http/`, `<cache>/catalog/`). A
-  cache split across two roots cannot be warmed, inspected, pruned, or restored
-  by a CI cache step as one unit.
-- Disposable: deleting it costs time, never correctness.
-- Nothing credentialed or user-specific. The cache is assumed safe to share
-  between CI jobs and to hand to a sandboxed agent.
+- **Tool-specific roots:** `<TOOL>_CACHE_DIR` names the tool's own directory
+  (e.g., `JETPACK_CACHE_DIR=/tmp/jp`), not the base directory.
+- **Subdivide by category:** Use subdirectories (e.g., `<cache>/http/`,
+  `<cache>/catalog/`). Do not split a tool's cache across multiple roots.
+- **Disposable:** Deleting the cache must only cost time, never correctness.
+- **No sensitive data:** The cache must be safe to share across CI jobs and
+  sandboxed agents. Never cache credentials or user-specific data.
 
 ## The Offline Switch
 
+Control offline behavior via environment variables:
+
 ```text
-<TOOL>_OFFLINE   per-tool; wins whenever set, including =0 to opt one tool out
-AGENT_OFFLINE    workspace-wide policy; used when <TOOL>_OFFLINE is unset
+<TOOL>_OFFLINE   Per-tool override; takes precedence (e.g., set to 0 to opt out).
+AGENT_OFFLINE    Workspace-wide policy; used when <TOOL>_OFFLINE is unset.
 ```
 
-Truthy values are `1`, `true`, `yes`, `on` (case-insensitive); anything else,
-empty included, is false.
+Treat `1`, `true`, `yes`, and `on` (case-insensitive) as true. Anything else is
+false.
 
-Two tiers because `workspace-config` already fixes that split: `AGENT_*` is
-policy an environment sets once, `<TOOL>_*` is plumbing for one tool. `uv`'s
-`UV_OFFLINE` sets the same precedent, and this repo's suites already run under
-it.
+Do not use an `--offline` flag as the *only* way to trigger offline mode.
+Callers running multiple commands (e.g., CI jobs, agent sessions) need a way to
+disable network access globally without appending flags to every command.
 
-An `--offline` flag may be added, but never as the only switch: a caller who
-cannot enumerate every command a build, test run, or agent session will invoke
-still has to turn the network off for all of them at once.
+### Offline Behavior
 
-### Offline
+- **Make no network calls:** Never attempt network requests in offline mode. Do
+  not "try, then fall back"—network timeouts slow down execution and produce
+  confusing error messages in sandboxes.
+- **Serve stale rather than fail:** Ignore Time-To-Live (TTL) freshness
+  preferences when offline. Return the cached data regardless of its age.
+- **Timestamp every answer on stderr:** Output the cache age to stderr (e.g.,
+  `(cached 3 days ago)`) so stdout remains parseable. Ensure you check for
+  offline mode *before* returning early based on TTL.
+- **Exit non-zero on a miss:** If data is missing, fail clearly. State the
+  missing resource and provide the exact command needed to warm the cache.
+- **Gate unproven paths:** Assume all third-party handlers or plugins might
+  attempt network calls. Route them through the offline check.
 
-- **Make no network calls.** Not "try, then fall back" — in a sandbox each
-  attempt buys a connect timeout and an error that reads like a missing resource
-  rather than a missing network.
-- **Serve stale rather than fail.** A TTL is a freshness preference online, not
-  a reason to refuse offline.
-- **Date every answer, on stderr** (`(cached 3 days ago)`), so stdout stays
-  parseable. Check offline mode *before* any "younger than the TTL, return
-  early" branch: under warm-then-freeze the cache is nearly always fresh, so
-  testing it second skips the signal in exactly the common case.
-- **On a miss, name the resource and the fix, and exit non-zero.** The fix is
-  normally this same command run where there is network — see *Warming*.
-- **Gate every path you cannot prove is local.** A path is cached because it was
-  expensive, which usually means remote, and a plugin or third-party handler may
-  do anything at all. Route it through the check rather than let it dial out.
+Example cache miss error:
 
 ```text
 jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
-  https://dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
+  https://dl.google.com/android/maven2/.../maven-metadata.xml
 jetpack version: run this where there is network to populate the cache:
   jetpack version androidx.wear.tiles:tiles ALPHA
 ```
 
-#### Incomplete Answers
+#### Handling Incomplete Answers
 
-Answering one question often takes several fetches, and online a tool may let
-some of them fail without complaint: it carries on and the result is still
-right. Offline, that same shrug turns a cache miss into a wrong answer wearing a
-right answer's clothes.
+Some operations require multiple network requests. Online, a tool might silently
+ignore a failed network request if it's considered optional, returning a partial
+result. **Offline, this is unacceptable.**
 
-So for each fetch the online path lets slide, ask: **if this one is missing, is
-the result still complete?**
+For every network request that the tool treats as optional when running online
+(i.e., where a network failure is quietly ignored), ask: *If this data is
+missing offline, is the result still complete and accurate?*
 
-- **No — then it is not optional offline, whatever the online path does.**
-  `jetpack source` fetches a POM only to learn whether a library has Kotlin
-  Multiplatform targets. Online, missing it costs nothing. Offline it means
-  nobody can tell whether platform sources belonged in the output, so the
-  extracted source omits them and says nothing. Fatal.
-- **Yes, and it may genuinely not exist — then warn, don't fail.** Some KMP
-  targets never publish a sources JAR, so a correctly warmed cache can be
-  missing one and a hard error would be unfixable. Name what is absent and how
-  to cache it, then carry on.
+- **No (Critical gap):** Fail the command. For example, if you cannot fetch
+  metadata to determine if platform sources exist, you cannot return a valid
+  package.
+- **Yes (Genuinely optional):** Warn the user on stderr, but do not fail the
+  command. State what is missing and how to cache it.
 
-What is never allowed is dropping it in silence: a result that looks complete
-and isn't breaks *a gap must look like a gap* as surely as an invented answer
-does.
+**Never silently ignore missing resources.** A partial result that looks
+complete is actively misleading. A gap in the data must be clearly identifiable
+to the user.
 
-### Online
+### Online Behavior
 
-- **Write through on every success.** Ordinary online use is what makes a later
-  offline run possible; a cache that fills only when explicitly warmed is empty
-  exactly when it is needed.
-- **Don't start answering stale.** Adding a cache must not change what an online
-  run returns. Reserve read-side TTLs for the expensive and slow-moving (a
-  whole-index download) and document them in the help text.
-- **On a network failure, name the cache instead of using it:**
-  `a copy cached 3 days ago is on disk; re-run with AGENT_OFFLINE=1 to use it`.
-  A run that was not told to go offline should not answer from a week-old file
-  behind the caller's back — but it can still hand over the next step.
-- **Never let cache maintenance fail the run.** A read-only sandbox may make the
-  directory unwritable; skip the write and carry on.
+- **Write-through on every success:** Populate the cache automatically during
+  normal online use. Do not require a separate "warm up" command.
+- **Maintain normal behavior:** Adding a cache must not change the behavior of
+  online runs. Only use read-side TTLs for expensive, slow-moving operations
+  (e.g., full index downloads).
+- **Do not fallback to cache on network failure:** If a network call fails
+  online, do not serve stale data behind the caller's back. Instead, inform the
+  user that a cached copy exists and instruct them to re-run with
+  `AGENT_OFFLINE=1`.
+- **Never let cache writes fail the run:** In read-only sandboxes, the cache
+  directory may be unwritable. Silently skip the cache write and continue
+  execution.
 
 ## Cache Layout
 
-Where cached resources are URLs with path-shaped identity, mirror the URL under
-the cache root instead of hashing it:
+For URLs with path-like structures, mirror the URL directly under the cache root
+rather than hashing it:
 
 ```text
-<cache>/http/dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
+<cache>/http/dl.google.com/android/maven2/.../maven-metadata.xml
 ```
 
-A hash cannot be listed for review, seeded by a test fixture, pruned
-selectively, or diffed between CI runs; a mirrored path can. Reject components
-that would escape the cache root (`..`, empty segments), and simply don't cache
-a URL that cannot be mapped safely.
+A mirrored path is human-readable, easy to diff between CI runs, and simple to
+prune. Hashes are opaque. Reject components that would escape the cache root
+(e.g., `..`, empty segments), and do not cache URLs that cannot be safely
+mapped.
 
-## Warming
+## Warming the Cache
 
-Every offline mode needs an answer to "how does a cold environment with no
-network get a warm cache?" — a fresh CI runner and a from-scratch agent both
-start with nothing.
+The standard way to warm a cache is **write-through**: running a command online
+automatically caches the required data for subsequent offline runs.
 
-Write-through is that answer. **Running the command once with network is the
-warm-up**, which is why the miss above quotes the failing invocation back: the
-command that fixes a miss is the one that hit it.
-
-Resist adding a `warm`/`prefetch` subcommand on top of that. It cannot be more
-reliable than re-running the real command, only less: it has to *guess* what a
-later run will ask for — which version, with sources or without — and every
-guess it gets wrong is a miss the caller still hits offline. It also duplicates
-the fetching logic it is warming. Reach for one only when a caller genuinely
-cannot know the commands in advance but does know the inputs (a dependency
-manifest), and then say plainly in its help that it approximates.
-
-Cold **and** offline **and** unwarmed stays unsupported, and fails with the
-error above rather than being papered over.
+Do not create a dedicated `warm` or `prefetch` subcommand unless strictly
+necessary. Such commands must guess what data future runs will need, which leads
+to incomplete caches and duplicated fetching logic. Only use a `warm` command
+when a caller knows the required inputs in advance (e.g., from a dependency
+manifest) but cannot know the exact commands that will be run.
 
 ## Help Text
 
-Both variables belong under `Environment`, with the cache default spelled out:
+Document both environment variables under an `Environment:` section in the
+tool's help output, including the default cache location:
 
 ```text
 Environment:
@@ -166,9 +148,8 @@ Environment:
                       (default: ${XDG_CACHE_HOME:-$HOME/.cache}/jetpack)
 ```
 
-A `doctor` command reports the cache location, the age of what is in it, and
-whether offline mode is active — the pre-flight check a CI job or an agent runs
-before trusting an offline answer.
+Consider adding a `doctor` command to report the cache location, its age, and
+whether offline mode is currently active.
 
 ## Where This Pays Off
 
@@ -216,8 +197,8 @@ safety feature, not a misconfiguration to route around.
   server said no" from "no server was reached" (an HTTP status versus no
   response at all), say which happened, and point at offline mode when a cached
   copy exists. Never present a remembered answer as a fetched one.
-- A read-only sandbox may also make the cache unwritable — see **never let cache
-  maintenance fail the run** above.
+- A read-only sandbox may also make the cache unwritable — see **Never let cache
+  writes fail the run** above.
 
 The repo's own suites run this way, under `UV_OFFLINE=1` against a pre-warmed
 `uv` cache. See `skills/workspace-config/tests/common.sh` for the "warm with

--- a/skills/coding-standards/references/caching.md
+++ b/skills/coding-standards/references/caching.md
@@ -66,7 +66,8 @@ still has to turn the network off for all of them at once.
   parseable. Check offline mode *before* any "younger than the TTL, return
   early" branch: under warm-then-freeze the cache is nearly always fresh, so
   testing it second skips the signal in exactly the common case.
-- **On a miss, name the resource and the fix, and exit non-zero.**
+- **On a miss, name the resource and the fix, and exit non-zero.** The fix is
+  normally this same command run where there is network — see *Warming*.
 - **Gate every path you cannot prove is local.** A path is cached because it was
   expensive, which usually means remote, and a plugin or third-party handler may
   do anything at all. Route it through the check rather than let it dial out.
@@ -74,8 +75,8 @@ still has to turn the network off for all of them at once.
 ```text
 jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
   https://dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
-jetpack version: warm the cache from a network-enabled environment first:
-  jetpack warm cache androidx.wear.tiles:tiles
+jetpack version: run this where there is network to populate the cache:
+  jetpack version androidx.wear.tiles:tiles ALPHA
 ```
 
 #### Incomplete Answers
@@ -96,7 +97,7 @@ the result still complete?**
 - **Yes, and it may genuinely not exist — then warn, don't fail.** Some KMP
   targets never publish a sources JAR, so a correctly warmed cache can be
   missing one and a hard error would be unfixable. Name what is absent and how
-  to warm it, then carry on.
+  to cache it, then carry on.
 
 What is never allowed is dropping it in silence: a result that looks complete
 and isn't breaks *a gap must look like a gap* as surely as an invented answer
@@ -137,14 +138,20 @@ Every offline mode needs an answer to "how does a cold environment with no
 network get a warm cache?" — a fresh CI runner and a from-scratch agent both
 start with nothing.
 
-- Provide a **`warm cache` subcommand** (verb-noun, per `cli-tools.md`) that
-  populates the cache for named targets in one network-enabled step, so warming
-  is declarative rather than "remember to run the six commands the job will
-  later need".
-- Because the online path writes through, it is a convenience rather than the
-  only route: running the real commands once with network is equivalent.
-- Cold **and** offline **and** unwarmed is unsupported, and fails with the error
-  above rather than being papered over.
+Write-through is that answer. **Running the command once with network is the
+warm-up**, which is why the miss above quotes the failing invocation back: the
+command that fixes a miss is the one that hit it.
+
+Resist adding a `warm`/`prefetch` subcommand on top of that. It cannot be more
+reliable than re-running the real command, only less: it has to *guess* what a
+later run will ask for — which version, with sources or without — and every
+guess it gets wrong is a miss the caller still hits offline. It also duplicates
+the fetching logic it is warming. Reach for one only when a caller genuinely
+cannot know the commands in advance but does know the inputs (a dependency
+manifest), and then say plainly in its help that it approximates.
+
+Cold **and** offline **and** unwarmed stays unsupported, and fails with the
+error above rather than being papered over.
 
 ## Help Text
 
@@ -180,8 +187,8 @@ reproducibility hole even when it succeeds.
     path: ~/.cache/jetpack
     key: jetpack-${{ hashFiles('deps.txt') }}
 
-- name: Warm cache            # the only step allowed to touch the network
-  run: jetpack warm cache $(cat deps.txt)
+- name: Prime the cache       # the only step allowed to touch the network
+  run: for a in $(cat deps.txt); do jetpack list dependencies "$a"; done
 
 - name: Build                 # deterministic; a network blip cannot reach it
   run: make build

--- a/skills/coding-standards/references/caching.md
+++ b/skills/coding-standards/references/caching.md
@@ -1,15 +1,24 @@
 # Caching and Offline Mode
 
-This is the cross-cutting convention for any script in this repository that
-fetches something over the network and can usefully reuse the response. It
-covers two questions every such script would otherwise answer ad hoc:
+The convention for any script here that fetches over the network and can reuse
+the response: where its cache lives, and how a caller forces it to run offline
+against that cache. Interface rules (flags, help text, errors) come from
+`cli-tools.md`; the bash idioms from `shell.md`.
 
-1. Where does the cache live, and how does a caller move it?
-1. How does a caller force the script to run **offline**, against that cache?
+## The Goal
 
-Interface rules (flag and command naming, help text, errors) come from
-`cli-tools.md`; the bash idioms come from `shell.md`. This file adds only what
-is specific to caching and offline operation.
+**A caller with no network gets an answer it can trust, or a clear reason it has
+none.**
+
+Three principles follow, and every rule below is one of them applied:
+
+1. **Trust needs provenance.** Stale data is useful; undated stale data is not,
+   because the caller cannot tell March's answer from today's.
+1. **A gap must look like a gap.** Inventing an answer and quietly returning
+   less than was asked for are the same failure — both read as success.
+1. **The fix travels with the failure.** Whoever hits a cold cache is by
+   definition in the environment that cannot fix it, so the error has to name
+   the command that can.
 
 ## Where the Cache Lives
 
@@ -17,67 +26,50 @@ is specific to caching and offline operation.
 ${<TOOL>_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/<tool>}
 ```
 
-- `<TOOL>_CACHE_DIR` names **the tool's own cache directory**, not the base
-  directory it sits in. `JETPACK_CACHE_DIR=/tmp/jp` puts the cache in `/tmp/jp`,
-  not `/tmp/jp/jetpack`. (`XDG_CACHE_HOME`, by contrast, is the base — that is
-  what the XDG spec says it is.)
-- One cache root per tool. Subdivide *inside* it (`<cache>/http/`,
-  `<cache>/catalog/`) rather than adding a second top-level location. A tool
-  whose cache is spread over two roots cannot be warmed, inspected, pruned, or
-  restored by a CI cache step as one unit.
-- The directory is disposable by definition: deleting it must only cost time,
-  never correctness. Nothing that is not re-derivable belongs in it.
-- Never cache credentialed or user-specific responses in it. The cache is
-  assumed to be safe to share between CI jobs and to hand to a sandboxed agent.
+- `<TOOL>_CACHE_DIR` names the tool's own directory, not the base it sits in:
+  `JETPACK_CACHE_DIR=/tmp/jp` caches in `/tmp/jp`. (`XDG_CACHE_HOME` is the base
+  — that is what the XDG spec makes it.)
+- One root per tool, subdivided inside (`<cache>/http/`, `<cache>/catalog/`). A
+  cache split across two roots cannot be warmed, inspected, pruned, or restored
+  by a CI cache step as one unit.
+- Disposable: deleting it costs time, never correctness.
+- Nothing credentialed or user-specific. The cache is assumed safe to share
+  between CI jobs and to hand to a sandboxed agent.
 
-## Forcing Offline Operation
+## The Offline Switch
 
 ```text
-<TOOL>_OFFLINE    per-tool switch (checked first; wins when set, including
-                  when set to 0 to opt one tool out)
-AGENT_OFFLINE     workspace-wide policy (used when <TOOL>_OFFLINE is unset)
+<TOOL>_OFFLINE   per-tool; wins whenever set, including =0 to opt one tool out
+AGENT_OFFLINE    workspace-wide policy; used when <TOOL>_OFFLINE is unset
 ```
 
 Truthy values are `1`, `true`, `yes`, `on` (case-insensitive); anything else,
-including empty, is false.
+empty included, is false.
 
-This mirrors the two-tier naming rule already documented in `workspace-config`:
-`AGENT_*` variables are **policy** a human (or a CI job, or a sandbox harness)
-sets once for an environment, while `<TOOL>_*` variables are **plumbing** for a
-single tool. It also matches the `<TOOL>_OFFLINE` precedent set by `uv`
-(`UV_OFFLINE`), which this repo's test suites already rely on, so an environment
-that sets `UV_OFFLINE=1` and `AGENT_OFFLINE=1` reads consistently.
+Two tiers because `workspace-config` already fixes that split: `AGENT_*` is
+policy an environment sets once, `<TOOL>_*` is plumbing for one tool. `uv`'s
+`UV_OFFLINE` sets the same precedent, and this repo's suites already run under
+it.
 
-Do not add an `--offline` flag as the primary interface. The point of the
-convention is that a caller who cannot enumerate every command that a build,
-test run, or agent session will invoke can still turn off the network for all of
-them at once. A flag is fine as an addition, never as the only switch.
+An `--offline` flag may be added, but never as the only switch: a caller who
+cannot enumerate every command a build, test run, or agent session will invoke
+still has to turn the network off for all of them at once.
 
-### What Offline Mode Must Do
+### Offline
 
-- **Make no network calls at all.** Not "try and fall back" — in a sandbox every
-  attempt costs a DNS or connect timeout, and the resulting error usually looks
-  like a missing resource rather than a missing network.
-- **Serve stale data rather than erroring.** Offline is a promise that the tool
-  will answer from what it has; a TTL that is meaningful online is not a reason
-  to fail offline.
-- **State the age of what it served, on stderr, every time.**
-  `(cached 3 days ago)` is the difference between an agent reporting a version
-  confidently and an agent reporting it with the caveat that makes it useful.
-  Age goes to stderr so stdout stays parseable. *Every time* includes the paths
-  a freshness TTL would have short-circuited: check offline mode **before** any
-  "cache is younger than the TTL, return early" branch, or the common
-  warm-then-freeze workflow — where the cache is usually fresh — is exactly the
-  case that answers silently.
-- **Fail loudly and actionably on a cache miss.** Name the resource that is
-  missing and the command that would have warmed it, and exit non-zero. Never
-  fall back to a guess — for an agent, an unsourced answer from training data is
-  indistinguishable from a real one.
-- **Gate on "could this need the network", not on the obvious remote case.** A
-  handler that is cached is cached because it was expensive, which usually means
-  remote; a plugin-provided or third-party one may do anything at all. If the
-  tool cannot prove a code path is local, route it through the offline check
-  rather than letting it fall through and dial out.
+- **Make no network calls.** Not "try, then fall back" — in a sandbox each
+  attempt buys a connect timeout and an error that reads like a missing resource
+  rather than a missing network.
+- **Serve stale rather than fail.** A TTL is a freshness preference online, not
+  a reason to refuse offline.
+- **Date every answer, on stderr** (`(cached 3 days ago)`), so stdout stays
+  parseable. Check offline mode *before* any "younger than the TTL, return
+  early" branch: under warm-then-freeze the cache is nearly always fresh, so
+  testing it second skips the signal in exactly the common case.
+- **On a miss, name the resource and the fix, and exit non-zero.**
+- **Gate every path you cannot prove is local.** A path is cached because it was
+  expensive, which usually means remote, and a plugin or third-party handler may
+  do anything at all. Route it through the check rather than let it dial out.
 
 ```text
 jetpack version: offline (AGENT_OFFLINE=1) and no cached copy of
@@ -86,75 +78,77 @@ jetpack version: warm the cache from a network-enabled environment first:
   jetpack warm cache androidx.wear.tiles:tiles
 ```
 
-#### Optional Resources
+#### Incomplete Answers
 
-Some fetches are best-effort online: their absence is normal and the command
-still produces a correct result. Two rules keep them from becoming a hole in the
-guarantee above:
+Answering one question often takes several fetches, and online a tool may let
+some of them fail without complaint: it carries on and the result is still
+right. Offline, that same shrug turns a cache miss into a wrong answer wearing a
+right answer's clothes.
 
-- A resource whose absence *changes the answer* is not optional, whatever the
-  online path does with it. `jetpack source` fetches a POM only to detect Kotlin
-  Multiplatform targets, and tolerates a missing one online — but offline, a
-  missing POM means the answer silently omits every platform target's sources,
-  so it is fatal there.
-- Where the miss really is tolerable — the resource may legitimately not exist,
-  so a warmed cache can be correctly missing it and a hard error would be
-  unfixable — warn on stderr naming what is absent and how to warm it, and carry
-  on. What is never acceptable is passing over it in silence: the caller cannot
-  see the gap in a result that looks complete.
+So for each fetch the online path lets slide, ask: **if this one is missing, is
+the result still complete?**
 
-### What the Online Path Must Do
+- **No — then it is not optional offline, whatever the online path does.**
+  `jetpack source` fetches a POM only to learn whether a library has Kotlin
+  Multiplatform targets. Online, missing it costs nothing. Offline it means
+  nobody can tell whether platform sources belonged in the output, so the
+  extracted source omits them and says nothing. Fatal.
+- **Yes, and it may genuinely not exist — then warn, don't fail.** Some KMP
+  targets never publish a sources JAR, so a correctly warmed cache can be
+  missing one and a hard error would be unfixable. Name what is absent and how
+  to warm it, then carry on.
 
-- **Write through on every successful fetch.** Normal online use is what makes a
-  later offline run possible; a cache that only fills when explicitly warmed
-  will be empty exactly when it is needed.
-- **Do not start serving stale answers online.** Adding a cache must not change
-  what an online run returns. Reserve read-side TTLs for resources that are
-  expensive and slow-moving (a whole-index download), document the TTL in the
-  help text, and leave everything else fetching fresh.
-- **On a network failure, name the cache instead of using it.** A run that was
-  not told to go offline should not quietly answer from a week-old copy. Report
-  the failure, and if a cached copy exists, say so and name the switch:
-  `a cached copy from 3 days ago exists; re-run with AGENT_OFFLINE=1 to use it`.
-  That keeps "report a failure, don't guess" intact while still giving an agent
-  a next step it can take without human help.
-- **Never let cache maintenance fail the run.** In a read-only sandbox the cache
-  directory may not be writable. Failing to store a response is not an error;
-  skip it and continue.
+What is never allowed is dropping it in silence: a result that looks complete
+and isn't breaks *a gap must look like a gap* as surely as an invented answer
+does.
+
+### Online
+
+- **Write through on every success.** Ordinary online use is what makes a later
+  offline run possible; a cache that fills only when explicitly warmed is empty
+  exactly when it is needed.
+- **Don't start answering stale.** Adding a cache must not change what an online
+  run returns. Reserve read-side TTLs for the expensive and slow-moving (a
+  whole-index download) and document them in the help text.
+- **On a network failure, name the cache instead of using it:**
+  `a copy cached 3 days ago is on disk; re-run with AGENT_OFFLINE=1 to use it`.
+  A run that was not told to go offline should not answer from a week-old file
+  behind the caller's back — but it can still hand over the next step.
+- **Never let cache maintenance fail the run.** A read-only sandbox may make the
+  directory unwritable; skip the write and carry on.
 
 ## Cache Layout
 
-When the cached resources are URLs with path-shaped identity, mirror the URL
-under the cache root instead of hashing it:
+Where cached resources are URLs with path-shaped identity, mirror the URL under
+the cache root instead of hashing it:
 
 ```text
 <cache>/http/dl.google.com/android/maven2/androidx/wear/tiles/tiles/maven-metadata.xml
 ```
 
-A hash is opaque: it cannot be listed for review, seeded by a test fixture,
-pruned selectively, or diffed between CI runs. A mirrored path can. Reject or
-sanitize path components that would escape the cache root (`..`, empty segments)
-and fall back to not caching if the URL cannot be mapped safely.
+A hash cannot be listed for review, seeded by a test fixture, pruned
+selectively, or diffed between CI runs; a mirrored path can. Reject components
+that would escape the cache root (`..`, empty segments), and simply don't cache
+a URL that cannot be mapped safely.
 
-## Warming the Cache
+## Warming
 
-Every tool with an offline mode needs an answer to "how does a cold environment
-with no network get a warm cache?" — a fresh CI runner and a from-scratch
-sandboxed agent both start with nothing.
+Every offline mode needs an answer to "how does a cold environment with no
+network get a warm cache?" — a fresh CI runner and a from-scratch agent both
+start with nothing.
 
 - Provide a **`warm cache` subcommand** (verb-noun, per `cli-tools.md`) that
   populates the cache for named targets in one network-enabled step, so warming
   is declarative rather than "remember to run the six commands the job will
   later need".
-- Because the online path writes through, `warm cache` is a convenience, not the
+- Because the online path writes through, it is a convenience rather than the
   only route: running the real commands once with network is equivalent.
-- Cold **and** offline **and** unwarmed is an unsupported state, and must fail
-  with the actionable error above rather than being papered over.
+- Cold **and** offline **and** unwarmed is unsupported, and fails with the error
+  above rather than being papered over.
 
-## Documenting It
+## Help Text
 
-The tool's help text lists both variables under `Environment`, with the cache
-default spelled out:
+Both variables belong under `Environment`, with the cache default spelled out:
 
 ```text
 Environment:
@@ -165,22 +159,19 @@ Environment:
                       (default: ${XDG_CACHE_HOME:-$HOME/.cache}/jetpack)
 ```
 
-If the tool has a `doctor` command, it reports the cache location, the age of
-what is in it, and whether offline mode is active — that is the pre-flight check
-a CI job or an agent runs before trusting an offline answer.
+A `doctor` command reports the cache location, the age of what is in it, and
+whether offline mode is active — the pre-flight check a CI job or an agent runs
+before trusting an offline answer.
 
-## Two Environments This Is For
+## Where This Pays Off
 
 ### CI
 
 CI usually *has* network, which is why the constraint is easy to miss. The
-constraints are different ones: shared egress that is rate-limited or
-occasionally blocked, third-party endpoints that go down independently of your
-change, and a hard requirement that two runs of the same commit behave the same.
-A network call in the middle of a job is a flake source and a reproducibility
-hole even when it succeeds.
-
-The shape that solves all three:
+problems are elsewhere: shared egress that gets rate-limited or blocked,
+third-party endpoints that fail independently of your change, and two runs of
+one commit that have to behave the same. A mid-job network call is a flake and a
+reproducibility hole even when it succeeds.
 
 ```yaml
 - name: Restore tool cache
@@ -199,29 +190,29 @@ The shape that solves all three:
 ```
 
 One step owns the network, the cache restore makes it a no-op on most runs, and
-everything after it is pinned to data that was fetched once and can be
-inspected. `AGENT_OFFLINE` is set on the job rather than per-command precisely
-because the job does not know which tools `make build` will reach for.
+everything after is pinned to data fetched once and open to inspection.
+`AGENT_OFFLINE` goes on the job rather than each command precisely because the
+job cannot know what `make build` will reach for.
 
 ### Sandboxed Agents
 
 Agent sandboxes increasingly deny network access outright — Codex's `read-only`
-sandbox and `workspace-write` without
-`sandbox_workspace_write.network_access=true` both do — and the denial is a
-safety feature, not a misconfiguration to work around. Two consequences:
+sandbox, and `workspace-write` without
+`sandbox_workspace_write.network_access=true`, both do — and that denial is a
+safety feature, not a misconfiguration to route around.
 
-- **Set `AGENT_OFFLINE=1` in the sandbox environment.** Then the tools skip
-  calls they cannot make, instead of spending the sandbox's time on connect
-  timeouts and reporting failures that read like "this library does not exist".
-- **Behave sanely when it is *not* set**, because often it will not be. The
+- **Set `AGENT_OFFLINE=1` in the sandbox environment**, so tools skip calls they
+  cannot make instead of spending the session's time on connect timeouts and
+  reporting failures that read like "this library does not exist".
+- **Behave sanely when it is not set**, because often it will not be: the
   network is simply gone and the tool finds out by failing. Distinguish "the
-  server said no" from "no server was reached" (an HTTP status vs. no response
-  at all), report which one happened, and point at offline mode when a cached
+  server said no" from "no server was reached" (an HTTP status versus no
+  response at all), say which happened, and point at offline mode when a cached
   copy exists. Never present a remembered answer as a fetched one.
-- A read-only sandbox may also make the cache unwritable — see "Never let cache
-  maintenance fail the run" above.
+- A read-only sandbox may also make the cache unwritable — see **never let cache
+  maintenance fail the run** above.
 
-The same reasoning applies to the repo's own test suites, which run under
-`UV_OFFLINE=1` with a pre-warmed `uv` cache for exactly these reasons; see
-`skills/workspace-config/tests/common.sh` for the "warm with real network, then
-freeze" pattern, and `tests/README.md` for how to run the suite offline.
+The repo's own suites run this way, under `UV_OFFLINE=1` against a pre-warmed
+`uv` cache. See `skills/workspace-config/tests/common.sh` for the "warm with
+real network, then freeze" pattern, and `tests/README.md` for running the suite
+offline.

--- a/skills/coding-standards/references/cli-tools.md
+++ b/skills/coding-standards/references/cli-tools.md
@@ -143,7 +143,7 @@ Tools that fetch over the network and cache the result follow one repo-wide
 convention for where the cache lives (`<TOOL>_CACHE_DIR`, else
 `${XDG_CACHE_HOME:-$HOME/.cache}/<tool>`) and how a caller forces them offline
 against it (`<TOOL>_OFFLINE`, else the workspace-wide `AGENT_OFFLINE`),
-including the `warm cache` subcommand, the required age reporting, and the
+including how a cold cache gets warmed, the required age reporting, and the
 cache-miss error. It is defined in `caching.md`, which also covers what CI jobs
 and sandboxed agents need from it.
 

--- a/skills/coding-standards/references/cli-tools.md
+++ b/skills/coding-standards/references/cli-tools.md
@@ -137,6 +137,16 @@ interpretation:
   (e.g., every 10%) when stdout is not a TTY.
 - **`doctor` output:** the canonical tag style above.
 
+## Caching and Offline Mode
+
+Tools that fetch over the network and cache the result follow one repo-wide
+convention for where the cache lives (`<TOOL>_CACHE_DIR`, else
+`${XDG_CACHE_HOME:-$HOME/.cache}/<tool>`) and how a caller forces them offline
+against it (`<TOOL>_OFFLINE`, else the workspace-wide `AGENT_OFFLINE`),
+including the `warm cache` subcommand, the required age reporting, and the
+cache-miss error. It is defined in `caching.md`, which also covers what CI jobs
+and sandboxed agents need from it.
+
 ## `--output`/`-o` Contract
 
 Any script that produces a new file or directory as output must support an

--- a/skills/coding-standards/references/shell.md
+++ b/skills/coding-standards/references/shell.md
@@ -263,6 +263,29 @@ require jq
 require curl
 ```
 
+### Caching and Offline Mode
+
+Scripts that cache network responses must follow the cache-location and
+offline-mode convention in `caching.md` (`<TOOL>_CACHE_DIR` / `<TOOL>_OFFLINE` /
+`AGENT_OFFLINE`). Two bash-specific points from it are worth restating here,
+because both are easy to get wrong under `set -euo pipefail`:
+
+- **Storing a response must never fail the run.** The cache directory can be
+  unwritable (a read-only sandbox), so guard every write and carry on:
+
+  ```bash
+  if mkdir -p "$(dirname "$dest")" 2>/dev/null; then
+    cp "$src" "$dest.tmp.$$" 2>/dev/null && mv "$dest.tmp.$$" "$dest" 2>/dev/null
+    rm -f "$dest.tmp.$$" 2>/dev/null
+  fi
+  return 0
+  ```
+
+- **Distinguish "no response" from "an error response"** so offline and
+  network-failure paths can be reported differently. Read `curl`'s
+  `-w '%{http_code}'` (which is `000` only when nothing was received) rather
+  than relying on `curl -f`'s exit code; see the error-message guidance above.
+
 ## Handling Large Inputs with jq
 
 When using `jq` to process data, you must account for the system's `ARG_MAX`

--- a/skills/jetpack/SKILL.md
+++ b/skills/jetpack/SKILL.md
@@ -10,7 +10,8 @@ description: >
   jetpack source, library version, snapshot, alpha, beta.
 compatibility: >-
   Requires curl, xmllint (libxml2-utils), jar (JDK), jq, perl. Needs network
-  access to dl.google.com, androidx.dev, and cs.android.com.
+  access to dl.google.com, androidx.dev, and cs.android.com, or a pre-warmed
+  cache plus JETPACK_OFFLINE/AGENT_OFFLINE where there is no egress.
 ---
 
 # Jetpack Library Utilities
@@ -40,6 +41,14 @@ often enough that a memorized answer can be confidently wrong. Report the
 failure (missing dependency, network error, unresolved package) to the user,
 including the script's own error message, and consult
 [references/troubleshooting.md](references/troubleshooting.md) before retrying.
+
+**If you have no network, say that too.** In a sandbox that denies egress, run
+`scripts/jetpack doctor` first: it reports whether the cache can answer at all.
+Then set `AGENT_OFFLINE=1` so the script serves cached answers instead of
+spending timeouts on calls it cannot make. Every cached answer arrives with its
+age on stderr (`(cached 3 days ago)`) — pass that age on rather than presenting
+a stale version as current. A cache miss is an error naming the artifact to
+warm; it is never a reason to answer from memory.
 
 ## Quick Start
 
@@ -101,6 +110,19 @@ fails.
 
 **Purpose**: List direct Maven dependencies for an artifact. **Usage**:
 `scripts/jetpack list dependencies ARTIFACT [VERSION]`
+
+### `warm cache`
+
+**Purpose**: Download what later runs need so they can work with no network.
+**Usage**: `scripts/jetpack warm cache [ARTIFACT]...` **Options**:
+`--index-only`, `--with-source`, `--version TYPE`. **Note**: Run it where there
+*is* network; it refuses to run in offline mode.
+
+### `doctor`
+
+**Purpose**: Report dependencies, offline mode, and cache state. **Usage**:
+`scripts/jetpack doctor` **Note**: Read-only; exits non-zero if anything needs
+attention.
 
 ### `resolve-exceptions`
 
@@ -180,10 +202,30 @@ scripts/jetpack resolve androidx.core.splashscreen.SplashScreen
 # Output: androidx.core:core-splashscreen
 ```
 
+### Working Without Network (CI, Sandboxed Agents)
+
+```bash
+# Where there is network: warm the cache once
+scripts/jetpack warm cache --with-source androidx.wear.tiles:tiles
+
+# Where there is not: answer from it, and check first if unsure
+AGENT_OFFLINE=1 scripts/jetpack doctor
+AGENT_OFFLINE=1 scripts/jetpack version androidx.wear.tiles:tiles
+AGENT_OFFLINE=1 scripts/jetpack inspect androidx.wear.tiles.TileService
+```
+
+Normal online runs already write what they fetch into
+`${JETPACK_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/jetpack}`, so warming is
+only needed when the offline run happens somewhere the online one never did. See
+[caching and offline mode](../coding-standards/references/caching.md) for the
+repo-wide convention.
+
 ## Safety Notes
 
 - **Network Access**: Requires access to `dl.google.com`, `androidx.dev`, and
-  `cs.android.com`.
+  `cs.android.com` — or a pre-warmed cache and `AGENT_OFFLINE=1`.
+- **Cached answers are dated, not current**: offline answers carry their age on
+  stderr. Report that age; do not present a stale version as the latest.
 - **SNAPSHOTs**: Change frequently; use pinned versions or Build IDs for
   reproducibility.
 - **Kotlin Multiplatform**: `source` and `inspect` automatically download

--- a/skills/jetpack/SKILL.md
+++ b/skills/jetpack/SKILL.md
@@ -10,8 +10,8 @@ description: >
   jetpack source, library version, snapshot, alpha, beta.
 compatibility: >-
   Requires curl, xmllint (libxml2-utils), jar (JDK), jq, perl. Needs network
-  access to dl.google.com, androidx.dev, and cs.android.com, or a pre-warmed
-  cache plus JETPACK_OFFLINE/AGENT_OFFLINE where there is no egress.
+  access to dl.google.com, androidx.dev, and cs.android.com, or a cache left by
+  an earlier online run plus JETPACK_OFFLINE/AGENT_OFFLINE where there is none.
 ---
 
 # Jetpack Library Utilities
@@ -47,8 +47,8 @@ including the script's own error message, and consult
 Then set `AGENT_OFFLINE=1` so the script serves cached answers instead of
 spending timeouts on calls it cannot make. Every cached answer arrives with its
 age on stderr (`(cached 3 days ago)`) — pass that age on rather than presenting
-a stale version as current. A cache miss is an error naming the artifact to
-warm; it is never a reason to answer from memory.
+a stale version as current. A cache miss is an error quoting the command to
+re-run where there is network; it is never a reason to answer from memory.
 
 ## Quick Start
 
@@ -110,13 +110,6 @@ fails.
 
 **Purpose**: List direct Maven dependencies for an artifact. **Usage**:
 `scripts/jetpack list dependencies ARTIFACT [VERSION]`
-
-### `warm cache`
-
-**Purpose**: Download what later runs need so they can work with no network.
-**Usage**: `scripts/jetpack warm cache [ARTIFACT]...` **Options**:
-`--index-only`, `--with-source`, `--version TYPE`. **Note**: Run it where there
-*is* network; it refuses to run in offline mode.
 
 ### `doctor`
 
@@ -204,26 +197,32 @@ scripts/jetpack resolve androidx.core.splashscreen.SplashScreen
 
 ### Working Without Network (CI, Sandboxed Agents)
 
-```bash
-# Where there is network: warm the cache once
-scripts/jetpack warm cache --with-source androidx.wear.tiles:tiles
+Every online run writes what it fetched into
+`${JETPACK_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/jetpack}`, so preparing
+for an offline run means nothing more than asking the same question once where
+there is network:
 
-# Where there is not: answer from it, and check first if unsure
-AGENT_OFFLINE=1 scripts/jetpack doctor
+```bash
+# Where there is network: ask, and the answers are cached as a side effect
+scripts/jetpack version androidx.wear.tiles:tiles
+scripts/jetpack inspect androidx.wear.tiles.TileService
+
+# Where there is not: the same commands answer from the cache
+AGENT_OFFLINE=1 scripts/jetpack doctor       # is the cache good enough?
 AGENT_OFFLINE=1 scripts/jetpack version androidx.wear.tiles:tiles
 AGENT_OFFLINE=1 scripts/jetpack inspect androidx.wear.tiles.TileService
 ```
 
-Normal online runs already write what they fetch into
-`${JETPACK_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/jetpack}`, so warming is
-only needed when the offline run happens somewhere the online one never did. See
+A miss quotes the command to re-run, so the fix is always the invocation that
+just failed. See
 [caching and offline mode](../coding-standards/references/caching.md) for the
 repo-wide convention.
 
 ## Safety Notes
 
 - **Network Access**: Requires access to `dl.google.com`, `androidx.dev`, and
-  `cs.android.com` — or a pre-warmed cache and `AGENT_OFFLINE=1`.
+  `cs.android.com` — or a cache warmed by an earlier online run, plus
+  `AGENT_OFFLINE=1`.
 - **Cached answers are dated, not current**: offline answers carry their age on
   stderr. Report that age; do not present a stale version as the latest.
 - **SNAPSHOTs**: Change frequently; use pinned versions or Build IDs for

--- a/skills/jetpack/references/command-index.md
+++ b/skills/jetpack/references/command-index.md
@@ -12,6 +12,8 @@
 - [search](#search)
 - [source](#source)
 - [inspect](#inspect)
+- [warm cache](#warm-cache)
+- [doctor](#doctor)
 - [resolve-exceptions](#resolve-exceptions)
 - [Exceptions Table](#exceptions-table)
 
@@ -54,10 +56,26 @@ Commands:
   inspect <name> [version]
                       Convenience wrapper that resolves a class name to an artifact
                       and then downloads its source.
+  warm cache [artifact]...
+                      Download what later runs need, so they can work with no
+                      network. Options: --index-only, --with-source,
+                      --version <type>.
+  doctor              Report dependencies, offline mode, and cache state.
+                      Exits non-zero if anything needs attention.
+
 Options:
   --help              Display this help message and exit
 
 Environment Variables:
+  JETPACK_OFFLINE     Set to 1 to answer only from the local cache and never
+                      use the network. Cached answers are served whatever their
+                      age, with that age noted on stderr; a cache miss is an
+                      error naming the artifact to warm, never a guess.
+  AGENT_OFFLINE       Workspace-wide offline policy, used when JETPACK_OFFLINE
+                      is unset. Set this in a CI job or an agent sandbox that
+                      has no egress.
+  JETPACK_CACHE_DIR   Cache directory
+                      (default: ${XDG_CACHE_HOME:-$HOME/.cache}/jetpack)
   XDG_CACHE_HOME      Base directory for cache (default: $HOME/.cache)
 
 Examples:
@@ -88,6 +106,10 @@ Examples:
 
   # Download specific snapshot build by ID
   jetpack source androidx.wear.tiles:tiles 14765146
+
+  # Warm the cache where there is network, then answer without any
+  jetpack warm cache androidx.wear.tiles:tiles
+  AGENT_OFFLINE=1 jetpack version androidx.wear.tiles:tiles
 ```
 
 <!-- /generated -->
@@ -209,6 +231,38 @@ jar xf sources.jar
 - `scripts/jetpack inspect RemoteImage SNAPSHOT`
 
 **Raw Commands**: Combines logic from `resolve`, `search`, and `source`.
+
+## warm cache
+
+**Purpose**: Download what later offline runs need. **Synopsis**:
+`scripts/jetpack warm cache [OPTIONS] [ARTIFACT]...` **Arguments**:
+
+- `ARTIFACT`: Maven coordinate(s) to warm (version metadata + POM of the
+  resolved version). **Options**:
+- `--version TYPE`: Version to warm for each artifact (default: `STABLE`).
+- `--index-only`: Only refresh the GMaven class index.
+- `--with-source`: Also download source JARs (what `source`/`inspect` need
+  offline). **Examples**:
+- `scripts/jetpack warm cache --index-only`
+- `scripts/jetpack warm cache androidx.wear.tiles:tiles androidx.core:core`
+- `scripts/jetpack warm cache --with-source androidx.wear.tiles:tiles`
+
+**Notes**: Refuses to run when `JETPACK_OFFLINE`/`AGENT_OFFLINE` is set — it is
+the step that needs the network, not the one that avoids it. Online runs write
+what they fetch into the cache anyway, so this is a convenience for environments
+where the offline run happens somewhere the online one never did.
+
+## doctor
+
+**Purpose**: Report whether this environment can answer, and from what.
+**Synopsis**: `scripts/jetpack doctor` **Examples**:
+
+- `scripts/jetpack doctor`
+- `AGENT_OFFLINE=1 scripts/jetpack doctor || scripts/jetpack warm cache`
+
+**Notes**: Read-only. Exits non-zero on any `WARN`/`ERROR`, so an offline CI job
+or agent session can gate on it. Reports missing dependencies rather than
+exiting `127` on the first one.
 
 ## resolve-exceptions
 

--- a/skills/jetpack/references/command-index.md
+++ b/skills/jetpack/references/command-index.md
@@ -12,7 +12,6 @@
 - [search](#search)
 - [source](#source)
 - [inspect](#inspect)
-- [warm cache](#warm-cache)
 - [doctor](#doctor)
 - [resolve-exceptions](#resolve-exceptions)
 - [Exceptions Table](#exceptions-table)
@@ -56,10 +55,6 @@ Commands:
   inspect <name> [version]
                       Convenience wrapper that resolves a class name to an artifact
                       and then downloads its source.
-  warm cache [artifact]...
-                      Download what later runs need, so they can work with no
-                      network. Options: --index-only, --with-source,
-                      --version <type>.
   doctor              Report dependencies, offline mode, and cache state.
                       Exits non-zero if anything needs attention.
 
@@ -69,8 +64,8 @@ Options:
 Environment Variables:
   JETPACK_OFFLINE     Set to 1 to answer only from the local cache and never
                       use the network. Cached answers are served whatever their
-                      age, with that age noted on stderr; a cache miss is an
-                      error naming the artifact to warm, never a guess.
+                      age, with that age noted on stderr; a cache miss names
+                      the command to re-run with network, never a guess.
   AGENT_OFFLINE       Workspace-wide offline policy, used when JETPACK_OFFLINE
                       is unset. Set this in a CI job or an agent sandbox that
                       has no egress.
@@ -107,8 +102,9 @@ Examples:
   # Download specific snapshot build by ID
   jetpack source androidx.wear.tiles:tiles 14765146
 
-  # Warm the cache where there is network, then answer without any
-  jetpack warm cache androidx.wear.tiles:tiles
+  # Run once where there is network (which caches what it fetched), then
+  # answer the same question with none
+  jetpack version androidx.wear.tiles:tiles
   AGENT_OFFLINE=1 jetpack version androidx.wear.tiles:tiles
 ```
 
@@ -232,37 +228,33 @@ jar xf sources.jar
 
 **Raw Commands**: Combines logic from `resolve`, `search`, and `source`.
 
-## warm cache
-
-**Purpose**: Download what later offline runs need. **Synopsis**:
-`scripts/jetpack warm cache [OPTIONS] [ARTIFACT]...` **Arguments**:
-
-- `ARTIFACT`: Maven coordinate(s) to warm (version metadata + POM of the
-  resolved version). **Options**:
-- `--version TYPE`: Version to warm for each artifact (default: `STABLE`).
-- `--index-only`: Only refresh the GMaven class index.
-- `--with-source`: Also download source JARs (what `source`/`inspect` need
-  offline). **Examples**:
-- `scripts/jetpack warm cache --index-only`
-- `scripts/jetpack warm cache androidx.wear.tiles:tiles androidx.core:core`
-- `scripts/jetpack warm cache --with-source androidx.wear.tiles:tiles`
-
-**Notes**: Refuses to run when `JETPACK_OFFLINE`/`AGENT_OFFLINE` is set — it is
-the step that needs the network, not the one that avoids it. Online runs write
-what they fetch into the cache anyway, so this is a convenience for environments
-where the offline run happens somewhere the online one never did.
-
 ## doctor
 
 **Purpose**: Report whether this environment can answer, and from what.
 **Synopsis**: `scripts/jetpack doctor` **Examples**:
 
 - `scripts/jetpack doctor`
-- `AGENT_OFFLINE=1 scripts/jetpack doctor || scripts/jetpack warm cache`
+- `AGENT_OFFLINE=1 scripts/jetpack doctor`
 
 **Notes**: Read-only. Exits non-zero on any `WARN`/`ERROR`, so an offline CI job
 or agent session can gate on it. Reports missing dependencies rather than
 exiting `127` on the first one.
+
+## Offline Use
+
+There is no warm-cache command: every online run writes what it fetched into
+`${JETPACK_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/jetpack}/http/`, mirroring
+the URL. Preparing for an offline run therefore means running the same command
+once where there is network, and a cache miss quotes that command back:
+
+```bash
+scripts/jetpack inspect androidx.wear.tiles.TileService              # caches
+AGENT_OFFLINE=1 scripts/jetpack inspect androidx.wear.tiles.TileService
+```
+
+The GMaven class index behind `search`/`resolve` is refreshed by
+`scripts/jetpack search --force QUERY` (which refuses to run offline, since it
+deletes the index it cannot then rebuild).
 
 ## resolve-exceptions
 

--- a/skills/jetpack/scripts/jetpack
+++ b/skills/jetpack/scripts/jetpack
@@ -234,15 +234,15 @@ http_print_hint() {
   fi
 }
 
-# The remediation line appended to every offline cache miss: an agent or CI job
-# that hits one needs to know which network-enabled command fixes it.
+# The remediation line appended to every offline cache miss. Because the online
+# path writes through, the command that fixes a miss is the one that just hit
+# it, so quote that back verbatim rather than naming some other command the
+# caller would then have to translate into their own case.
+INVOCATION=("$@")
+
 warm_hint() {
-  local target="${1:-}"
-  if [[ -n "$target" ]]; then
-    echo "$SCRIPT_NAME: warm the cache from a network-enabled environment first: $SCRIPT_NAME warm cache $target" >&2
-  else
-    echo "$SCRIPT_NAME: warm the cache from a network-enabled environment first: $SCRIPT_NAME warm cache" >&2
-  fi
+  echo "$SCRIPT_NAME: run this where there is network to populate the cache:" >&2
+  echo "  $SCRIPT_NAME ${INVOCATION[*]:-}" >&2
 }
 
 # Verify external dependencies. Deferred until a real command runs so that
@@ -286,7 +286,7 @@ fetch_maven_metadata() {
     echo "$SCRIPT_NAME: $HTTP_ERROR; cannot determine whether '$group_id:$artifact_id' exists" >&2
     http_print_hint
     if is_offline; then
-      warm_hint "$group_id:$artifact_id"
+      warm_hint
     fi
     return 1
   fi
@@ -381,10 +381,6 @@ Commands:
   inspect <name> [version]
                       Convenience wrapper that resolves a class name to an artifact
                       and then downloads its source.
-  warm cache [artifact]...
-                      Download what later runs need, so they can work with no
-                      network. Options: --index-only, --with-source,
-                      --version <type>.
   doctor              Report dependencies, offline mode, and cache state.
                       Exits non-zero if anything needs attention.
 
@@ -394,8 +390,8 @@ Options:
 Environment Variables:
   JETPACK_OFFLINE     Set to 1 to answer only from the local cache and never
                       use the network. Cached answers are served whatever their
-                      age, with that age noted on stderr; a cache miss is an
-                      error naming the artifact to warm, never a guess.
+                      age, with that age noted on stderr; a cache miss names
+                      the command to re-run with network, never a guess.
   AGENT_OFFLINE       Workspace-wide offline policy, used when JETPACK_OFFLINE
                       is unset. Set this in a CI job or an agent sandbox that
                       has no egress.
@@ -432,8 +428,9 @@ Examples:
   # Download specific snapshot build by ID
   $SCRIPT_NAME source androidx.wear.tiles:tiles 14765146
 
-  # Warm the cache where there is network, then answer without any
-  $SCRIPT_NAME warm cache androidx.wear.tiles:tiles
+  # Run once where there is network (which caches what it fetched), then
+  # answer the same question with none
+  $SCRIPT_NAME version androidx.wear.tiles:tiles
   AGENT_OFFLINE=1 $SCRIPT_NAME version androidx.wear.tiles:tiles
 EOF
   exit "${1:-0}"
@@ -507,7 +504,7 @@ update_index() {
   # that was never going to be attempted.
   if is_offline; then
     echo "$SCRIPT_NAME: offline ($(offline_desc)) and the GMaven index has never been downloaded to $INDEX_FILE" >&2
-    warm_hint "--index-only"
+    warm_hint
     return 1
   fi
 
@@ -1291,7 +1288,7 @@ cmd_source() {
       echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
       http_print_hint
       if is_offline; then
-        warm_hint "--with-source $artifact"
+        warm_hint
       fi
       exit 1
     fi
@@ -1356,7 +1353,7 @@ cmd_source() {
       echo "$SCRIPT_NAME source: failed to download $source_jar_url: $HTTP_ERROR" >&2
       http_print_hint
       if is_offline; then
-        warm_hint "--with-source $artifact"
+        warm_hint
       fi
       exit 1
     fi
@@ -1383,7 +1380,7 @@ cmd_source() {
       rm -f "$pom_file"
       echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
       echo "$SCRIPT_NAME source: without it, whether $artifact has Kotlin Multiplatform sources cannot be determined, and the extracted sources may be incomplete" >&2
-      warm_hint "--with-source $artifact"
+      warm_hint
       exit 1
     fi
     rm -f "$pom_file"
@@ -1425,7 +1422,7 @@ cmd_source() {
             # JAR, so a warmed cache can be legitimately missing this one and a
             # hard error would be unfixable. Silence is what is not acceptable.
             echo "$SCRIPT_NAME source: warning: no cached sources for platform artifact ${platform_artifact}; the extracted sources are missing its classes" >&2
-            echo "$SCRIPT_NAME source: warm them where there is network: $SCRIPT_NAME warm cache --with-source $artifact" >&2
+            echo "$SCRIPT_NAME source: re-run this where there is network to cache them" >&2
           fi
         done
       fi
@@ -1703,7 +1700,7 @@ cmd_dependencies() {
     echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
     http_print_hint
     if is_offline; then
-      warm_hint "$artifact"
+      warm_hint
     fi
     exit 1
   fi
@@ -1731,150 +1728,6 @@ cmd_dependencies() {
 }
 
 # =============================================================================
-# WARM SUBCOMMAND
-# =============================================================================
-
-usage_warm() {
-  cat <<EOF
-Usage: $SCRIPT_NAME warm cache [OPTIONS] [ARTIFACT]...
-
-Download everything later runs will need, so they can work with no network.
-
-Normal online runs already write what they fetch into the cache, so warming is
-only needed where the offline run happens somewhere the online one never did:
-a CI job whose build step has no egress, or an agent sandbox that denies it.
-Run this in a network-enabled setup step, then set AGENT_OFFLINE=1 for the
-work itself.
-
-Arguments:
-  ARTIFACT        Maven artifact (GROUP_ID:ARTIFACT_ID) to warm. Fetches its
-                  version metadata and the POM of the resolved version.
-
-Options:
-  --version TYPE  Version to warm for each artifact (default: STABLE)
-  --index-only    Only refresh the GMaven class index
-  --with-source   Also download each artifact's source JAR (large, but this is
-                  what 'source' and 'inspect' need offline)
-  --help, -h      Display this help message and exit
-
-Examples:
-  # Refresh the class index that 'search' and 'resolve' read
-  $SCRIPT_NAME warm cache --index-only
-
-  # Warm the index plus two artifacts, then answer from the cache alone
-  $SCRIPT_NAME warm cache androidx.wear.tiles:tiles androidx.core:core
-  AGENT_OFFLINE=1 $SCRIPT_NAME version androidx.wear.tiles:tiles
-
-  # Warm sources too, for offline 'inspect'
-  $SCRIPT_NAME warm cache --with-source androidx.wear.tiles:tiles
-
-The cache lives in \$JETPACK_CACHE_DIR (default:
-\${XDG_CACHE_HOME:-\$HOME/.cache}/jetpack) and is safe to copy between machines
-or restore from a CI cache: it holds nothing but fetched public artifacts.
-EOF
-  exit "${1:-0}"
-}
-
-cmd_warm_cache() {
-  local version_string="STABLE"
-  local index_only=0 with_source=0
-  local -a artifacts=()
-
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --help | -h)
-        usage_warm
-        ;;
-      --version)
-        if [[ -z "${2:-}" ]]; then
-          echo "$SCRIPT_NAME warm cache: option '--version' requires an argument" >&2
-          exit 1
-        fi
-        version_string=$(echo "$2" | tr '[:lower:]' '[:upper:]')
-        shift 2
-        ;;
-      --index-only)
-        index_only=1
-        shift
-        ;;
-      --with-source)
-        with_source=1
-        shift
-        ;;
-      -*)
-        echo "$SCRIPT_NAME warm cache: unknown option: $1" >&2
-        exit 1
-        ;;
-      *)
-        artifacts+=("$1")
-        shift
-        ;;
-    esac
-  done
-
-  if is_offline; then
-    echo "$SCRIPT_NAME warm cache: needs network access, but $(offline_desc) is set" >&2
-    echo "$SCRIPT_NAME warm cache: run this in a network-enabled setup step, not in the offline job itself" >&2
-    exit 1
-  fi
-
-  local failures=0
-
-  # The class index backs search/resolve and is the one download every offline
-  # run needs, artifacts or not.
-  if ! update_index; then
-    failures=$((failures + 1))
-  fi
-
-  if [[ $index_only -eq 1 ]]; then
-    if [[ ${#artifacts[@]} -gt 0 ]]; then
-      echo "$SCRIPT_NAME warm cache: --index-only given, ignoring ${#artifacts[@]} artifact(s)" >&2
-    fi
-    [[ $failures -eq 0 ]] || exit 1
-    return 0
-  fi
-
-  local artifact version tmp_dir
-  for artifact in "${artifacts[@]}"; do
-    validate_artifact_format "$artifact"
-
-    # Each helper runs in a subshell so that one artifact's failure (they exit
-    # rather than return) does not abandon the rest of the warm.
-    if ! version=$(cmd_version "$artifact" "$version_string"); then
-      echo "$SCRIPT_NAME warm cache: $artifact: could not resolve $version_string version" >&2
-      failures=$((failures + 1))
-      continue
-    fi
-
-    if (cmd_dependencies "$artifact" "$version" >/dev/null); then
-      echo "warmed $artifact $version (metadata, pom)" >&2
-    else
-      echo "$SCRIPT_NAME warm cache: $artifact $version: could not fetch pom" >&2
-      failures=$((failures + 1))
-      continue
-    fi
-
-    if [[ $with_source -eq 1 ]]; then
-      tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/jetpack-warm.XXXXXXXXXX")
-      if (cmd_source --output "$tmp_dir" "$artifact" "$version" >/dev/null); then
-        echo "warmed $artifact $version (sources)" >&2
-      else
-        echo "$SCRIPT_NAME warm cache: $artifact $version: could not fetch sources" >&2
-        failures=$((failures + 1))
-      fi
-      rm -rf "$tmp_dir"
-    fi
-  done
-
-  if [[ $failures -gt 0 ]]; then
-    echo "$SCRIPT_NAME warm cache: $failures target(s) failed; the cache is incomplete" >&2
-    exit 1
-  fi
-
-  echo "$SCRIPT_NAME warm cache: cache ready at $CACHE_DIR" >&2
-}
-
-# =============================================================================
 # DOCTOR SUBCOMMAND
 # =============================================================================
 
@@ -1893,7 +1746,7 @@ Options:
 
 Examples:
   $SCRIPT_NAME doctor
-  AGENT_OFFLINE=1 $SCRIPT_NAME doctor || $SCRIPT_NAME warm cache
+  AGENT_OFFLINE=1 $SCRIPT_NAME doctor
 EOF
   exit "${1:-0}"
 }
@@ -1954,8 +1807,8 @@ cmd_doctor() {
     fi
   elif [[ $offline -eq 1 ]]; then
     doctor_report ERROR "Cache: $CACHE_DIR does not exist" \
-      "Nothing can be answered offline. Warm it where there is network:" \
-      "  $SCRIPT_NAME warm cache <artifact>..."
+      "Nothing can be answered offline. Run the commands this workspace needs" \
+      "once where there is network, which caches what they fetch."
   else
     doctor_report INFO "Cache: $CACHE_DIR does not exist yet (created on first fetch)"
   fi
@@ -1968,11 +1821,11 @@ cmd_doctor() {
       doctor_report OK "GMaven index: cached $index_age"
     else
       doctor_report WARN "GMaven index: cached $index_age (older than 24h)" \
-        "Refresh it with: $SCRIPT_NAME warm cache --index-only"
+        "Refresh it with: $SCRIPT_NAME search --force <query>"
     fi
   elif [[ $offline -eq 1 ]]; then
     doctor_report ERROR "GMaven index: missing, so search and resolve cannot answer" \
-      "Download it where there is network: $SCRIPT_NAME warm cache --index-only"
+      "Download it by running 'search' or 'resolve' once where there is network"
   else
     doctor_report INFO "GMaven index: not downloaded yet (fetched on first search or resolve)"
   fi
@@ -1986,8 +1839,8 @@ cmd_doctor() {
     doctor_report OK "Cached responses: $responses under $HTTP_CACHE_DIR"
   elif [[ $offline -eq 1 ]]; then
     doctor_report WARN "Cached responses: none, so only search and resolve can answer offline" \
-      "Warm the artifacts this workspace asks about, where there is network:" \
-      "  $SCRIPT_NAME warm cache <artifact>..."
+      "Ask about the artifacts this workspace needs once where there is" \
+      "network; every answer fetched is cached for a later offline run."
   else
     doctor_report INFO "Cached responses: none yet (recorded as commands run)"
   fi
@@ -2024,7 +1877,6 @@ case "$1" in
         source) usage_source ;;
         inspect) usage_inspect ;;
         dependencies) usage_dependencies ;;
-        warm) usage_warm ;;
         doctor) usage_doctor ;;
         *)
           echo "$SCRIPT_NAME: unknown command '$2'" >&2
@@ -2076,27 +1928,6 @@ case "$1" in
   inspect)
     shift
     cmd_inspect "$@"
-    ;;
-  warm)
-    shift
-    if [[ $# -eq 0 ]]; then
-      echo "$SCRIPT_NAME: warm requires a sub-command (cache)" >&2
-      echo "Run '$SCRIPT_NAME warm cache --help' for usage" >&2
-      exit 1
-    fi
-    if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]]; then
-      usage_warm 0
-    fi
-    subcmd="$1"
-    shift
-    case "$subcmd" in
-      cache) cmd_warm_cache "$@" ;;
-      *)
-        echo "$SCRIPT_NAME: unknown warm command '$subcmd'" >&2
-        echo "Run '$SCRIPT_NAME warm cache --help' for usage" >&2
-        exit 1
-        ;;
-    esac
     ;;
   doctor)
     shift

--- a/skills/jetpack/scripts/jetpack
+++ b/skills/jetpack/scripts/jetpack
@@ -22,6 +22,13 @@ GOOGLE_MAVEN_URL="https://dl.google.com/android/maven2"
 SNAPSHOT_REPO_URL="https://androidx.dev/snapshots/latest/artifacts/repository"
 SNAPSHOT_BUILD_URL_PREFIX="https://androidx.dev/snapshots/builds"
 
+# Cache layout and offline switch follow the repo-wide convention in
+# skills/coding-standards/references/caching.md.
+CACHE_DIR="${JETPACK_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/jetpack}"
+INDEX_FILE="$CACHE_DIR/androidx-index.json"
+HTTP_CACHE_DIR="$CACHE_DIR/http"
+MAX_AGE_SECONDS=$((24 * 3600)) # 24 hours
+
 # =============================================================================
 # SHARED HELPERS
 # =============================================================================
@@ -31,6 +38,211 @@ require() {
     echo >&2 "$(basename "$0"): $1 not found"
     exit 127
   }
+}
+
+# =============================================================================
+# OFFLINE MODE AND HTTP CACHE
+# =============================================================================
+#
+# Online runs always fetch fresh and write the response through to the cache;
+# the cache is only *read* when offline. Adding it therefore cannot change what
+# an online run answers, and normal use warms the cache for a later offline one.
+# See skills/coding-standards/references/caching.md.
+
+# Name of the variable that put us in offline mode, for error messages.
+offline_var() {
+  if [[ -n "${JETPACK_OFFLINE+x}" ]]; then
+    echo "JETPACK_OFFLINE"
+  else
+    echo "AGENT_OFFLINE"
+  fi
+}
+
+# "JETPACK_OFFLINE=1" / "AGENT_OFFLINE=yes" -- the exact setting in force, so a
+# caller who did not set it themselves can find where it came from.
+offline_desc() {
+  local var
+  var=$(offline_var)
+  echo "$var=${!var:-}"
+}
+
+is_offline() {
+  local value
+  if [[ -n "${JETPACK_OFFLINE+x}" ]]; then
+    value="$JETPACK_OFFLINE"
+  else
+    value="${AGENT_OFFLINE:-}"
+  fi
+
+  case "$(echo "$value" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+file_mtime() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    stat -f "%m" "$1"
+  else
+    stat -c "%Y" "$1"
+  fi
+}
+
+# Human-readable age of a file, e.g. "3 days ago". Used to qualify every
+# cache-served answer so a stale one is never mistaken for a current one.
+file_age_human() {
+  local mtime now age
+  mtime=$(file_mtime "$1")
+  now=$(date +%s)
+  age=$((now - mtime))
+
+  if [[ $age -lt 60 ]]; then
+    echo "just now"
+  elif [[ $age -lt 3600 ]]; then
+    ago $((age / 60)) minute
+  elif [[ $age -lt 86400 ]]; then
+    ago $((age / 3600)) hour
+  else
+    ago $((age / 86400)) day
+  fi
+}
+
+ago() {
+  if [[ "$1" -eq 1 ]]; then
+    echo "$1 $2 ago"
+  else
+    echo "$1 ${2}s ago"
+  fi
+}
+
+# Map a URL to its path under the cache, mirroring host and path rather than
+# hashing so the cache can be listed, seeded by a test fixture, and pruned by
+# hand. Returns non-zero (and no path) for URLs that cannot be mapped safely,
+# in which case the caller simply does not cache.
+cache_path_for_url() {
+  local url="$1" rest
+  rest="${url#*://}"
+  rest="${rest//\?/_}"
+  rest="${rest//#/_}"
+
+  case "/$rest/" in
+    */../* | *//*) return 1 ;;
+  esac
+  if [[ "$rest" != */* ]]; then
+    return 1
+  fi
+
+  echo "$HTTP_CACHE_DIR/$rest"
+}
+
+# Store a fetched body in the cache. Best-effort by design: the cache directory
+# is often unwritable in a read-only sandbox, and failing to record a response
+# is never a reason to fail the command the user actually asked for.
+cache_store() {
+  local url="$1" src="$2" dest tmp
+  dest=$(cache_path_for_url "$url") || return 0
+
+  if mkdir -p "$(dirname "$dest")" 2>/dev/null; then
+    tmp="$dest.tmp.$$"
+    if cp "$src" "$tmp" 2>/dev/null; then
+      mv "$tmp" "$dest" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+    else
+      rm -f "$tmp" 2>/dev/null || true
+    fi
+  fi
+  return 0
+}
+
+# http_get URL OUTFILE
+#
+# Writes the response body to OUTFILE and sets, for the caller's error message:
+#   HTTP_STATUS  the HTTP status ("000" when no response was received at all)
+#   HTTP_ERROR   a description of the failure, without the program prefix
+#   HTTP_HINT    remediation to print on its own line after the failure, if any
+#
+# Exit codes:
+#   0  body available (fetched, or served from cache when offline)
+#   1  the server was reached and answered non-2xx (a genuine "not found")
+#   2  no response at all (network failure), or a cache miss while offline
+http_get() {
+  local url="$1" outfile="$2"
+  local cache_file curl_status=0
+  HTTP_STATUS=""
+  HTTP_ERROR=""
+  HTTP_HINT=""
+
+  cache_file=$(cache_path_for_url "$url" 2>/dev/null) || cache_file=""
+
+  if is_offline; then
+    if [[ -n "$cache_file" && -f "$cache_file" ]]; then
+      cp "$cache_file" "$outfile"
+      echo "$SCRIPT_NAME: offline: using cached $url (cached $(file_age_human "$cache_file"))" >&2
+      HTTP_STATUS="200"
+      return 0
+    fi
+    HTTP_ERROR="offline ($(offline_desc)) and no cached copy of $url"
+    return 2
+  fi
+
+  # Use -w '%{http_code}' rather than curl -f's exit code to tell "reached the
+  # server, got an error" apart from "never got an HTTP response at all":
+  # curl's own exit code for HTTP-level failures is not reliably 22 (some
+  # servers close the connection in a way curl reports as exit 56 "failure in
+  # receiving network data" even though the response body was a plain 404).
+  # http_code is authoritatively "000" only when no response was received.
+  HTTP_STATUS=$(curl -sSL --connect-timeout 10 --max-time 300 -o "$outfile" \
+    -w '%{http_code}' "$url" 2>/dev/null) || curl_status=$?
+
+  if [[ $curl_status -ne 0 || "$HTTP_STATUS" == "000" ]]; then
+    HTTP_ERROR="could not reach $url (curl exit $curl_status, http $HTTP_STATUS: network unreachable, DNS failure, or blocked egress)"
+    # Name the cached copy rather than silently serving it: a run that was not
+    # told to go offline must not answer from a week-old file behind the
+    # caller's back, but an agent that just lost its network needs to be told
+    # the next step exists.
+    if [[ -n "$cache_file" && -f "$cache_file" ]]; then
+      HTTP_HINT="a copy cached $(file_age_human "$cache_file") is on disk; re-run with $(offline_var)=1 to use it"
+    fi
+    return 2
+  fi
+
+  if [[ "$HTTP_STATUS" != 2?? ]]; then
+    HTTP_ERROR="$url returned HTTP $HTTP_STATUS"
+    return 1
+  fi
+
+  cache_store "$url" "$outfile"
+  return 0
+}
+
+# http_get_body URL -- print the response body on stdout. Same exit codes and
+# HTTP_STATUS/HTTP_ERROR contract as http_get, for callers that want a string.
+http_get_body() {
+  local url="$1" tmp status=0
+  tmp=$(mktemp)
+  http_get "$url" "$tmp" || status=$?
+  if [[ $status -eq 0 ]]; then
+    cat "$tmp"
+  fi
+  rm -f "$tmp"
+  return $status
+}
+
+# Print http_get's remediation line, if it left one, after the caller's error.
+http_print_hint() {
+  if [[ -n "${HTTP_HINT:-}" ]]; then
+    echo "$SCRIPT_NAME: $HTTP_HINT" >&2
+  fi
+}
+
+# The remediation line appended to every offline cache miss: an agent or CI job
+# that hits one needs to know which network-enabled command fixes it.
+warm_hint() {
+  local target="${1:-}"
+  if [[ -n "$target" ]]; then
+    echo "$SCRIPT_NAME: warm the cache from a network-enabled environment first: $SCRIPT_NAME warm cache $target" >&2
+  else
+    echo "$SCRIPT_NAME: warm the cache from a network-enabled environment first: $SCRIPT_NAME warm cache" >&2
+  fi
 }
 
 # Verify external dependencies. Deferred until a real command runs so that
@@ -61,29 +273,27 @@ fetch_maven_metadata() {
 
   local metadata_url="$repo_url/$group_id_path/$artifact_id/maven-metadata.xml"
 
-  # Use -w '%{http_code}' rather than curl -f's exit code to tell "reached the
-  # server, got an error" apart from "never got an HTTP response at all":
-  # curl's own exit code for HTTP-level failures is not reliably 22 (some
-  # servers close the connection in a way curl reports as exit 56 "failure in
-  # receiving network data" even though the response body was a plain 404).
-  # http_code is authoritatively "000" only when no response was received.
-  local tmp_body http_code curl_status
+  local tmp_body status
   tmp_body=$(mktemp)
-  curl_status=0
-  http_code=$(curl -sSL --connect-timeout 10 --max-time 30 -o "$tmp_body" -w '%{http_code}' "$metadata_url") || curl_status=$?
+  status=0
+  http_get "$metadata_url" "$tmp_body" || status=$?
 
-  if [[ $curl_status -ne 0 || "$http_code" == "000" ]]; then
-    # This is NOT evidence the artifact is missing, so don't call it "not
-    # found" and don't offer "did you mean" suggestions that imply a live
-    # index lookup was possible.
+  if [[ $status -eq 2 ]]; then
+    # Neither a missing network nor an unwarmed cache is evidence the artifact
+    # is missing, so don't call it "not found" and don't offer "did you mean"
+    # suggestions that imply a live index lookup was possible.
     rm -f "$tmp_body"
-    echo "$SCRIPT_NAME: could not reach $metadata_url (curl exit $curl_status, http $http_code: network unreachable, DNS failure, or blocked egress); cannot determine whether '$group_id:$artifact_id' exists" >&2
+    echo "$SCRIPT_NAME: $HTTP_ERROR; cannot determine whether '$group_id:$artifact_id' exists" >&2
+    http_print_hint
+    if is_offline; then
+      warm_hint "$group_id:$artifact_id"
+    fi
     return 1
   fi
 
-  if [[ "$http_code" != 2?? ]]; then
+  if [[ $status -ne 0 ]]; then
     rm -f "$tmp_body"
-    echo "$SCRIPT_NAME: artifact '$group_id:$artifact_id' not found at $metadata_url ($http_code)" >&2
+    echo "$SCRIPT_NAME: artifact '$group_id:$artifact_id' not found at $metadata_url ($HTTP_STATUS)" >&2
 
     # Suggest alternatives from the local index
     if [[ "$repo_url" == "$GOOGLE_MAVEN_URL" ]]; then
@@ -171,10 +381,26 @@ Commands:
   inspect <name> [version]
                       Convenience wrapper that resolves a class name to an artifact
                       and then downloads its source.
+  warm cache [artifact]...
+                      Download what later runs need, so they can work with no
+                      network. Options: --index-only, --with-source,
+                      --version <type>.
+  doctor              Report dependencies, offline mode, and cache state.
+                      Exits non-zero if anything needs attention.
+
 Options:
   --help              Display this help message and exit
 
 Environment Variables:
+  JETPACK_OFFLINE     Set to 1 to answer only from the local cache and never
+                      use the network. Cached answers are served whatever their
+                      age, with that age noted on stderr; a cache miss is an
+                      error naming the artifact to warm, never a guess.
+  AGENT_OFFLINE       Workspace-wide offline policy, used when JETPACK_OFFLINE
+                      is unset. Set this in a CI job or an agent sandbox that
+                      has no egress.
+  JETPACK_CACHE_DIR   Cache directory
+                      (default: \${XDG_CACHE_HOME:-\$HOME/.cache}/jetpack)
   XDG_CACHE_HOME      Base directory for cache (default: \$HOME/.cache)
 
 Examples:
@@ -205,6 +431,10 @@ Examples:
 
   # Download specific snapshot build by ID
   $SCRIPT_NAME source androidx.wear.tiles:tiles 14765146
+
+  # Warm the cache where there is network, then answer without any
+  $SCRIPT_NAME warm cache androidx.wear.tiles:tiles
+  AGENT_OFFLINE=1 $SCRIPT_NAME version androidx.wear.tiles:tiles
 EOF
   exit "${1:-0}"
 }
@@ -212,10 +442,6 @@ EOF
 # =============================================================================
 # SEARCH SUBCOMMAND
 # =============================================================================
-
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/jetpack"
-INDEX_FILE="$CACHE_DIR/androidx-index.json"
-MAX_AGE_SECONDS=$((24 * 3600)) # 24 hours
 
 usage_search() {
   cat <<EOF
@@ -243,14 +469,14 @@ is_index_fresh() {
     return 1
   fi
 
-  local file_age
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    file_age=$(stat -f "%m" "$INDEX_FILE")
-  else
-    file_age=$(stat -c "%Y" "$INDEX_FILE")
+  # Offline, any index is the freshest one obtainable: attempting a rebuild
+  # would only spend a connect timeout to arrive back at this same file.
+  if is_offline; then
+    return 0
   fi
 
-  local current_time
+  local file_age current_time
+  file_age=$(file_mtime "$INDEX_FILE")
   current_time=$(date +%s)
 
   local age=$((current_time - file_age))
@@ -262,6 +488,15 @@ is_index_fresh() {
 }
 
 update_index() {
+  # Offline callers reach this only with no index at all: is_index_fresh()
+  # accepts any existing one. Say so plainly rather than failing on a download
+  # that was never going to be attempted.
+  if is_offline; then
+    echo "$SCRIPT_NAME: offline ($(offline_desc)) and the GMaven index has never been downloaded to $INDEX_FILE" >&2
+    warm_hint "--index-only"
+    return 1
+  fi
+
   echo "info: Updating GMaven index..." >&2
   mkdir -p "$CACHE_DIR"
   local index_url="https://dl.google.com/android/studio/gmaven/index/release/v0.1/classes-v0.1.json.gz"
@@ -301,11 +536,11 @@ search_index() {
   local query="$1"
 
   if ! is_index_fresh; then
-    update_index
+    update_index || return 1
   fi
 
   if [[ ! -f "$INDEX_FILE" ]]; then
-    echo "error: Index file not found and update failed." >&2
+    echo "$SCRIPT_NAME search: index file not found and update failed" >&2
     return 1
   fi
 
@@ -421,6 +656,13 @@ cmd_search() {
         exit 1
         ;;
       --force)
+        # Refuse rather than delete the only copy we have: offline, the rebuild
+        # this asks for cannot happen, so honouring it would leave the cache
+        # emptier than it started.
+        if is_offline; then
+          echo "$SCRIPT_NAME search: --force needs network access but $(offline_desc) is set" >&2
+          exit 1
+        fi
         rm -f "$INDEX_FILE"
         shift
         ;;
@@ -727,7 +969,7 @@ cmd_resolve() {
 
   # 2. Ensure index is fresh
   if ! is_index_fresh; then
-    update_index >&2
+    update_index >&2 || return 1
   fi
 
   if [[ ! -f "$INDEX_FILE" ]]; then
@@ -1016,7 +1258,8 @@ cmd_source() {
   fi
 
   # Validate all artifacts before creating directories
-  local group_id artifact_id group_id_path metadata_url
+  local group_id artifact_id group_id_path metadata_url tmp_metadata
+  tmp_metadata=$(mktemp)
   for artifact in "${artifacts[@]}"; do
     validate_artifact_format "$artifact"
 
@@ -1025,11 +1268,17 @@ cmd_source() {
     group_id_path=$(echo "$group_id" | sed 's/\./\//g')
     metadata_url="${repo_url}/${group_id_path}/${artifact_id}/maven-metadata.xml"
 
-    if ! curl -sSLf "$metadata_url" >/dev/null 2>&1; then
-      echo "$SCRIPT_NAME source: failed to fetch $metadata_url" >&2
+    if ! http_get "$metadata_url" "$tmp_metadata"; then
+      rm -f "$tmp_metadata"
+      echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
+      http_print_hint
+      if is_offline; then
+        warm_hint "--with-source $artifact"
+      fi
       exit 1
     fi
   done
+  rm -f "$tmp_metadata"
 
   # Create output directory
   local build_dir
@@ -1070,7 +1319,7 @@ cmd_source() {
     jar_version="$version"
     if [[ "$version" =~ -SNAPSHOT$ ]]; then
       local version_metadata_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/maven-metadata.xml"
-      snapshot_jar_version=$(curl -sSLf "$version_metadata_url" 2>/dev/null |
+      snapshot_jar_version=$(http_get_body "$version_metadata_url" |
         xmllint --xpath "//snapshotVersion[classifier='sources' and extension='jar']/value/text()" - 2>/dev/null || true)
 
       if [[ -n "$snapshot_jar_version" ]]; then
@@ -1085,8 +1334,12 @@ cmd_source() {
     source_jar_filename="${artifact_id}-${jar_version}-sources.jar"
 
     echo "info: Downloading ${artifact} version ${version}" >&2
-    if ! curl -sSLf -o "${build_dir}/${source_jar_filename}" "${source_jar_url}"; then
-      echo "$SCRIPT_NAME source: failed to download $source_jar_url" >&2
+    if ! http_get "${source_jar_url}" "${build_dir}/${source_jar_filename}"; then
+      echo "$SCRIPT_NAME source: failed to download $source_jar_url: $HTTP_ERROR" >&2
+      http_print_hint
+      if is_offline; then
+        warm_hint "--with-source $artifact"
+      fi
       exit 1
     fi
 
@@ -1098,7 +1351,7 @@ cmd_source() {
 
     # Check for Kotlin Multiplatform platform-specific sources
     pom_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/${artifact_id}-${jar_version}.pom"
-    pom_content=$(curl -sSLf "${pom_url}" 2>/dev/null || true)
+    pom_content=$(http_get_body "${pom_url}" || true)
 
     if [[ -n "$pom_content" ]]; then
       platform_artifacts=$(echo "$pom_content" | xmllint --xpath "//*[local-name()='dependency']/*[local-name()='groupId' and text()='${group_id}']/../*[local-name()='artifactId']/text()" - 2>/dev/null | grep "^${artifact_id}-" || true)
@@ -1112,7 +1365,7 @@ cmd_source() {
           platform_jar_version="$version"
           if [[ "$version" =~ -SNAPSHOT$ ]]; then
             local platform_version_metadata_url="${repo_url}/${group_id_path}/${platform_artifact}/${version}/maven-metadata.xml"
-            platform_snapshot_jar_version=$(curl -sSLf "$platform_version_metadata_url" 2>/dev/null |
+            platform_snapshot_jar_version=$(http_get_body "$platform_version_metadata_url" |
               xmllint --xpath "//snapshotVersion[classifier='sources' and extension='jar']/value/text()" - 2>/dev/null || true)
             if [[ -n "$platform_snapshot_jar_version" ]]; then
               platform_jar_version="$platform_snapshot_jar_version"
@@ -1122,7 +1375,7 @@ cmd_source() {
           platform_source_jar_url="${repo_url}/${group_id_path}/${platform_artifact}/${version}/${platform_artifact}-${platform_jar_version}-sources.jar"
           platform_source_jar_filename="${platform_artifact}-${platform_jar_version}-sources.jar"
 
-          if curl -sSLf -o "${build_dir}/${platform_source_jar_filename}" "${platform_source_jar_url}" 2>/dev/null; then
+          if http_get "${platform_source_jar_url}" "${build_dir}/${platform_source_jar_filename}" 2>/dev/null; then
             echo "info: Downloaded ${platform_artifact} platform sources" >&2
             (
               cd "${build_dir}"
@@ -1363,8 +1616,23 @@ cmd_dependencies() {
   artifact_id=$(echo "$artifact" | cut -d: -f2)
   group_id_path=$(echo "$group_id" | sed 's/\./\//g')
 
-  local version
-  version=$(cmd_version "$artifact" "$version_string" "$repo_url")
+  # Classify first: cmd_version only accepts symbolic types, so routing a
+  # pinned version (1.6.1) or a build ID through it fails with "invalid version
+  # type" even though the POM for that exact version is what was asked for.
+  local version version_class
+  version_class=$(classify_version "$version_string")
+  case "$version_class" in
+    symbolic)
+      version=$(cmd_version "$artifact" "$version_string" "$repo_url") || exit 1
+      ;;
+    build_id)
+      repo_url="$SNAPSHOT_BUILD_URL_PREFIX/$version_string/artifacts/repository"
+      version=$(cmd_version "$artifact" "SNAPSHOT" "$repo_url") || exit 1
+      ;;
+    *)
+      version="$version_string"
+      ;;
+  esac
 
   local jar_version="$version"
   if [[ "$version" =~ -SNAPSHOT$ ]]; then
@@ -1373,7 +1641,7 @@ cmd_dependencies() {
     fi
     local version_metadata_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/maven-metadata.xml"
     local snapshot_jar_version
-    snapshot_jar_version=$(curl -sSLf "$version_metadata_url" 2>/dev/null |
+    snapshot_jar_version=$(http_get_body "$version_metadata_url" |
       xmllint --xpath "//snapshotVersion[classifier='sources' and extension='jar']/value/text()" - 2>/dev/null || true)
     if [[ -n "$snapshot_jar_version" ]]; then
       jar_version="$snapshot_jar_version"
@@ -1381,11 +1649,22 @@ cmd_dependencies() {
   fi
 
   local pom_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/${artifact_id}-${jar_version}.pom"
-  local pom_content
-  if ! pom_content=$(curl -sSLf "${pom_url}"); then
-    echo "$SCRIPT_NAME dependencies: failed to download $pom_url" >&2
+  # Fetch into a file rather than a command substitution: HTTP_ERROR is set by
+  # http_get in the shell that runs it, and a $(...) subshell would take it
+  # (and the reason this failed) with it.
+  local pom_content pom_file
+  pom_file=$(mktemp)
+  if ! http_get "${pom_url}" "$pom_file"; then
+    rm -f "$pom_file"
+    echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
+    http_print_hint
+    if is_offline; then
+      warm_hint "$artifact"
+    fi
     exit 1
   fi
+  pom_content=$(cat "$pom_file")
+  rm -f "$pom_file"
 
   local deps
   deps=$(echo "$pom_content" | perl -0777 -ne '
@@ -1408,6 +1687,276 @@ cmd_dependencies() {
 }
 
 # =============================================================================
+# WARM SUBCOMMAND
+# =============================================================================
+
+usage_warm() {
+  cat <<EOF
+Usage: $SCRIPT_NAME warm cache [OPTIONS] [ARTIFACT]...
+
+Download everything later runs will need, so they can work with no network.
+
+Normal online runs already write what they fetch into the cache, so warming is
+only needed where the offline run happens somewhere the online one never did:
+a CI job whose build step has no egress, or an agent sandbox that denies it.
+Run this in a network-enabled setup step, then set AGENT_OFFLINE=1 for the
+work itself.
+
+Arguments:
+  ARTIFACT        Maven artifact (GROUP_ID:ARTIFACT_ID) to warm. Fetches its
+                  version metadata and the POM of the resolved version.
+
+Options:
+  --version TYPE  Version to warm for each artifact (default: STABLE)
+  --index-only    Only refresh the GMaven class index
+  --with-source   Also download each artifact's source JAR (large, but this is
+                  what 'source' and 'inspect' need offline)
+  --help, -h      Display this help message and exit
+
+Examples:
+  # Refresh the class index that 'search' and 'resolve' read
+  $SCRIPT_NAME warm cache --index-only
+
+  # Warm the index plus two artifacts, then answer from the cache alone
+  $SCRIPT_NAME warm cache androidx.wear.tiles:tiles androidx.core:core
+  AGENT_OFFLINE=1 $SCRIPT_NAME version androidx.wear.tiles:tiles
+
+  # Warm sources too, for offline 'inspect'
+  $SCRIPT_NAME warm cache --with-source androidx.wear.tiles:tiles
+
+The cache lives in \$JETPACK_CACHE_DIR (default:
+\${XDG_CACHE_HOME:-\$HOME/.cache}/jetpack) and is safe to copy between machines
+or restore from a CI cache: it holds nothing but fetched public artifacts.
+EOF
+  exit "${1:-0}"
+}
+
+cmd_warm_cache() {
+  local version_string="STABLE"
+  local index_only=0 with_source=0
+  local -a artifacts=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --help | -h)
+        usage_warm
+        ;;
+      --version)
+        if [[ -z "${2:-}" ]]; then
+          echo "$SCRIPT_NAME warm cache: option '--version' requires an argument" >&2
+          exit 1
+        fi
+        version_string=$(echo "$2" | tr '[:lower:]' '[:upper:]')
+        shift 2
+        ;;
+      --index-only)
+        index_only=1
+        shift
+        ;;
+      --with-source)
+        with_source=1
+        shift
+        ;;
+      -*)
+        echo "$SCRIPT_NAME warm cache: unknown option: $1" >&2
+        exit 1
+        ;;
+      *)
+        artifacts+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if is_offline; then
+    echo "$SCRIPT_NAME warm cache: needs network access, but $(offline_desc) is set" >&2
+    echo "$SCRIPT_NAME warm cache: run this in a network-enabled setup step, not in the offline job itself" >&2
+    exit 1
+  fi
+
+  local failures=0
+
+  # The class index backs search/resolve and is the one download every offline
+  # run needs, artifacts or not.
+  if ! update_index; then
+    failures=$((failures + 1))
+  fi
+
+  if [[ $index_only -eq 1 ]]; then
+    if [[ ${#artifacts[@]} -gt 0 ]]; then
+      echo "$SCRIPT_NAME warm cache: --index-only given, ignoring ${#artifacts[@]} artifact(s)" >&2
+    fi
+    [[ $failures -eq 0 ]] || exit 1
+    return 0
+  fi
+
+  local artifact version tmp_dir
+  for artifact in "${artifacts[@]}"; do
+    validate_artifact_format "$artifact"
+
+    # Each helper runs in a subshell so that one artifact's failure (they exit
+    # rather than return) does not abandon the rest of the warm.
+    if ! version=$(cmd_version "$artifact" "$version_string"); then
+      echo "$SCRIPT_NAME warm cache: $artifact: could not resolve $version_string version" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if (cmd_dependencies "$artifact" "$version" >/dev/null); then
+      echo "warmed $artifact $version (metadata, pom)" >&2
+    else
+      echo "$SCRIPT_NAME warm cache: $artifact $version: could not fetch pom" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if [[ $with_source -eq 1 ]]; then
+      tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/jetpack-warm.XXXXXXXXXX")
+      if (cmd_source --output "$tmp_dir" "$artifact" "$version" >/dev/null); then
+        echo "warmed $artifact $version (sources)" >&2
+      else
+        echo "$SCRIPT_NAME warm cache: $artifact $version: could not fetch sources" >&2
+        failures=$((failures + 1))
+      fi
+      rm -rf "$tmp_dir"
+    fi
+  done
+
+  if [[ $failures -gt 0 ]]; then
+    echo "$SCRIPT_NAME warm cache: $failures target(s) failed; the cache is incomplete" >&2
+    exit 1
+  fi
+
+  echo "$SCRIPT_NAME warm cache: cache ready at $CACHE_DIR" >&2
+}
+
+# =============================================================================
+# DOCTOR SUBCOMMAND
+# =============================================================================
+
+usage_doctor() {
+  cat <<EOF
+Usage: $SCRIPT_NAME doctor
+
+Report whether this environment can answer Jetpack questions, and from what:
+dependencies, offline mode, and the state and age of the local cache.
+
+Read-only. Exits non-zero if any check reports WARN or ERROR, so an offline CI
+job or agent session can gate on it before trusting an answer.
+
+Options:
+  --help, -h  Display this help message and exit
+
+Examples:
+  $SCRIPT_NAME doctor
+  AGENT_OFFLINE=1 $SCRIPT_NAME doctor || $SCRIPT_NAME warm cache
+EOF
+  exit "${1:-0}"
+}
+
+DOCTOR_STATUS=0
+
+doctor_report() {
+  local tag="$1"
+  shift
+  printf '%-7s %s\n' "[$tag]" "$1"
+  shift
+  # Remediation belongs under the finding it fixes, not in a trailing block.
+  local detail
+  for detail in "$@"; do
+    printf '        %s\n' "$detail"
+  done
+  case "$tag" in
+    WARN | ERROR) DOCTOR_STATUS=1 ;;
+  esac
+}
+
+cmd_doctor() {
+  if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage_doctor
+  fi
+
+  local offline=0
+  is_offline && offline=1
+
+  # --- Dependencies (reported, not fatal: doctor's job is to say what is
+  # wrong, and exiting 127 on the first missing tool would hide the rest).
+  local dep missing=""
+  for dep in curl xmllint jq perl jar gunzip; do
+    command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"
+  done
+  if [[ -z "$missing" ]]; then
+    doctor_report OK "Dependencies: curl, xmllint, jq, perl, jar, gunzip"
+  else
+    doctor_report ERROR "Dependencies: not found:${missing}"
+  fi
+
+  # --- Mode
+  if [[ $offline -eq 1 ]]; then
+    doctor_report INFO "Mode: offline ($(offline_desc)); answers come from the cache only"
+  else
+    doctor_report INFO "Mode: online; answers are fetched fresh and written to the cache"
+  fi
+
+  # --- Cache directory
+  if [[ -d "$CACHE_DIR" ]]; then
+    if [[ -w "$CACHE_DIR" ]]; then
+      doctor_report OK "Cache: $CACHE_DIR"
+    elif [[ $offline -eq 1 ]]; then
+      doctor_report OK "Cache: $CACHE_DIR (read-only, which is all offline mode needs)"
+    else
+      doctor_report WARN "Cache: $CACHE_DIR is not writable" \
+        "Fetched responses cannot be recorded, so a later offline run will find nothing."
+    fi
+  elif [[ $offline -eq 1 ]]; then
+    doctor_report ERROR "Cache: $CACHE_DIR does not exist" \
+      "Nothing can be answered offline. Warm it where there is network:" \
+      "  $SCRIPT_NAME warm cache <artifact>..."
+  else
+    doctor_report INFO "Cache: $CACHE_DIR does not exist yet (created on first fetch)"
+  fi
+
+  # --- GMaven class index (search, resolve)
+  if [[ -f "$INDEX_FILE" ]]; then
+    local index_age
+    index_age=$(file_age_human "$INDEX_FILE")
+    if is_index_fresh; then
+      doctor_report OK "GMaven index: cached $index_age"
+    else
+      doctor_report WARN "GMaven index: cached $index_age (older than 24h)" \
+        "Refresh it with: $SCRIPT_NAME warm cache --index-only"
+    fi
+  elif [[ $offline -eq 1 ]]; then
+    doctor_report ERROR "GMaven index: missing, so search and resolve cannot answer" \
+      "Download it where there is network: $SCRIPT_NAME warm cache --index-only"
+  else
+    doctor_report INFO "GMaven index: not downloaded yet (fetched on first search or resolve)"
+  fi
+
+  # --- Cached HTTP responses (version, list dependencies, source, inspect)
+  local responses=0
+  if [[ -d "$HTTP_CACHE_DIR" ]]; then
+    responses=$(find "$HTTP_CACHE_DIR" -type f | wc -l | tr -d ' ')
+  fi
+  if [[ "$responses" -gt 0 ]]; then
+    doctor_report OK "Cached responses: $responses under $HTTP_CACHE_DIR"
+  elif [[ $offline -eq 1 ]]; then
+    doctor_report WARN "Cached responses: none, so only search and resolve can answer offline" \
+      "Warm the artifacts this workspace asks about, where there is network:" \
+      "  $SCRIPT_NAME warm cache <artifact>..."
+  else
+    doctor_report INFO "Cached responses: none yet (recorded as commands run)"
+  fi
+
+  if [[ $DOCTOR_STATUS -eq 0 ]]; then
+    echo "$SCRIPT_NAME doctor: no problems found"
+  else
+    echo "$SCRIPT_NAME doctor: problems found (see above)"
+  fi
+  return "$DOCTOR_STATUS"
+}
+
+# =============================================================================
 # MAIN DISPATCH
 # =============================================================================
 
@@ -1415,9 +1964,10 @@ if [[ $# -lt 1 ]]; then
   usage 1 >&2
 fi
 
-# Help is dependency-free; everything else needs the external tools.
+# Help is dependency-free, and doctor reports missing dependencies rather than
+# dying on them; everything else needs the external tools up front.
 case "$1" in
-  help | --help) ;;
+  help | --help | doctor) ;;
   *) check_deps ;;
 esac
 
@@ -1430,6 +1980,8 @@ case "$1" in
         source) usage_source ;;
         inspect) usage_inspect ;;
         dependencies) usage_dependencies ;;
+        warm) usage_warm ;;
+        doctor) usage_doctor ;;
         *)
           echo "$SCRIPT_NAME: unknown command '$2'" >&2
           usage 1 >&2
@@ -1480,6 +2032,31 @@ case "$1" in
   inspect)
     shift
     cmd_inspect "$@"
+    ;;
+  warm)
+    shift
+    if [[ $# -eq 0 ]]; then
+      echo "$SCRIPT_NAME: warm requires a sub-command (cache)" >&2
+      echo "Run '$SCRIPT_NAME warm cache --help' for usage" >&2
+      exit 1
+    fi
+    if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]]; then
+      usage_warm 0
+    fi
+    subcmd="$1"
+    shift
+    case "$subcmd" in
+      cache) cmd_warm_cache "$@" ;;
+      *)
+        echo "$SCRIPT_NAME: unknown warm command '$subcmd'" >&2
+        echo "Run '$SCRIPT_NAME warm cache --help' for usage" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  doctor)
+    shift
+    cmd_doctor "$@"
     ;;
   -*)
     echo "$SCRIPT_NAME: unknown option: $1" >&2

--- a/skills/jetpack/scripts/jetpack
+++ b/skills/jetpack/scripts/jetpack
@@ -464,6 +464,20 @@ EOF
   exit "${1:-0}"
 }
 
+# Announce how old the class index is when it is being served offline. Without
+# this, 'search' and 'resolve' are the one pair of subcommands that can hand
+# back a months-old coordinate with nothing to distinguish it from a live
+# lookup. Printed once per run, however many index reads a command does.
+INDEX_AGE_NOTED=0
+
+note_index_age() {
+  if ! is_offline || [[ $INDEX_AGE_NOTED -eq 1 || ! -f "$INDEX_FILE" ]]; then
+    return 0
+  fi
+  INDEX_AGE_NOTED=1
+  echo "$SCRIPT_NAME: offline: using GMaven index cached $(file_age_human "$INDEX_FILE")" >&2
+}
+
 is_index_fresh() {
   if [[ ! -f "$INDEX_FILE" ]]; then
     return 1
@@ -543,6 +557,8 @@ search_index() {
     echo "$SCRIPT_NAME search: index file not found and update failed" >&2
     return 1
   fi
+
+  note_index_age
 
   # Auto-detect format: array (old) vs object (new with .Index)
   #
@@ -977,6 +993,8 @@ cmd_resolve() {
     return 1
   fi
 
+  note_index_age
+
   # 3. Pre-compute all fallback query variations to avoid reading the large index file multiple times.
   local temp_query="$input"
   local -a query_targets=()
@@ -1292,7 +1310,7 @@ cmd_source() {
   # Download and extract each package
   local version="" jar_version snapshot_jar_version
   local source_jar_url source_jar_filename
-  local pom_url pom_content platform_artifacts
+  local pom_url pom_content pom_file pom_status platform_artifacts
 
   for artifact in "${artifacts[@]}"; do
     group_id=$(echo "$artifact" | cut -d: -f1)
@@ -1349,12 +1367,32 @@ cmd_source() {
       rm "${source_jar_filename}"
     )
 
-    # Check for Kotlin Multiplatform platform-specific sources
+    # Check for Kotlin Multiplatform platform-specific sources. Online, a
+    # missing POM stays tolerable (it costs only KMP detection). Offline it
+    # means the cache was never warmed for this version, and carrying on would
+    # hand back sources silently missing every platform target — the failure
+    # this whole mode exists to prevent — so it is fatal and says how to fix it.
     pom_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/${artifact_id}-${jar_version}.pom"
-    pom_content=$(http_get_body "${pom_url}" || true)
+    pom_status=0
+    pom_file=$(mktemp)
+    http_get "${pom_url}" "$pom_file" || pom_status=$?
+    pom_content=""
+    if [[ $pom_status -eq 0 ]]; then
+      pom_content=$(cat "$pom_file")
+    elif [[ $pom_status -eq 2 ]] && is_offline; then
+      rm -f "$pom_file"
+      echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
+      echo "$SCRIPT_NAME source: without it, whether $artifact has Kotlin Multiplatform sources cannot be determined, and the extracted sources may be incomplete" >&2
+      warm_hint "--with-source $artifact"
+      exit 1
+    fi
+    rm -f "$pom_file"
 
     if [[ -n "$pom_content" ]]; then
-      platform_artifacts=$(echo "$pom_content" | xmllint --xpath "//*[local-name()='dependency']/*[local-name()='groupId' and text()='${group_id}']/../*[local-name()='artifactId']/text()" - 2>/dev/null | grep "^${artifact_id}-" || true)
+      # sort -u because a platform artifact listed both as a compile and a
+      # runtime dependency would otherwise be downloaded (and, offline, warned
+      # about) once per listing.
+      platform_artifacts=$(echo "$pom_content" | xmllint --xpath "//*[local-name()='dependency']/*[local-name()='groupId' and text()='${group_id}']/../*[local-name()='artifactId']/text()" - 2>/dev/null | grep "^${artifact_id}-" | sort -u || true)
 
       if [[ -n "$platform_artifacts" ]]; then
         echo "info: Detected Kotlin Multiplatform library, downloading platform-specific sources..." >&2
@@ -1382,6 +1420,12 @@ cmd_source() {
               jar xf "${platform_source_jar_filename}"
               rm "${platform_source_jar_filename}"
             )
+          elif is_offline; then
+            # Warn rather than fail: not every KMP target publishes a sources
+            # JAR, so a warmed cache can be legitimately missing this one and a
+            # hard error would be unfixable. Silence is what is not acceptable.
+            echo "$SCRIPT_NAME source: warning: no cached sources for platform artifact ${platform_artifact}; the extracted sources are missing its classes" >&2
+            echo "$SCRIPT_NAME source: warm them where there is network: $SCRIPT_NAME warm cache --with-source $artifact" >&2
           fi
         done
       fi

--- a/skills/jetpack/tests/test-jetpack-offline
+++ b/skills/jetpack/tests/test-jetpack-offline
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Tests for jetpack's offline mode (JETPACK_OFFLINE / AGENT_OFFLINE) and its
+# HTTP cache, per skills/coding-standards/references/caching.md.
+#
+# Hermetic and network-free by construction: every request is aimed at
+# http://127.0.0.1:1/, a privileged port with no listener, so the OS refuses
+# the connection immediately. A cached answer therefore proves the cache was
+# read, and a "could not reach" failure proves it was not — neither outcome
+# depends on the machine having (or lacking) internet access.
+
+set -u
+
+SCRIPT_DIR=$(dirname "$0")
+ROOT_DIR="$SCRIPT_DIR/.."
+BIN_JETPACK="$ROOT_DIR/scripts/jetpack"
+
+TEST_TMP=$(mktemp -d)
+export TMPDIR="$TEST_TMP"
+export JETPACK_CACHE_DIR="$TEST_TMP/cache"
+
+# The repo every case talks to, and where its cached responses live.
+REPO_URL="http://127.0.0.1:1/repo"
+ARTIFACT="androidx.wear.tiles:tiles"
+CACHED_DIR="$JETPACK_CACHE_DIR/http/127.0.0.1:1/repo/androidx/wear/tiles/tiles"
+
+TOTAL_TESTS=21
+TEST_NUM=0
+
+echo "1..$TOTAL_TESTS"
+
+cleanup() {
+  rm -rf "$TEST_TMP"
+}
+trap cleanup EXIT
+
+ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  echo "ok $TEST_NUM - $1"
+}
+
+not_ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  echo "not ok $TEST_NUM - $1"
+  shift
+  local line
+  for line in "$@"; do
+    echo "# $line"
+  done
+}
+
+assert_equals() {
+  local description="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected: $expected" "Actual:   $actual"
+  fi
+}
+
+assert_status() {
+  local description="$1" status="$2" expected="$3"
+  if [[ "$status" -eq "$expected" ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected exit $expected, got $status"
+  fi
+}
+
+assert_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected to contain: $needle" "Got: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected NOT to contain: $needle" "Got: $haystack"
+  fi
+}
+
+# Run jetpack, capturing stdout in $STDOUT, stderr in $STDERR, status in $STATUS.
+run_jetpack() {
+  local err_file
+  err_file=$(mktemp)
+  STDOUT=$("$BIN_JETPACK" "$@" 2>"$err_file")
+  STATUS=$?
+  STDERR=$(cat "$err_file")
+  rm -f "$err_file"
+}
+
+# --- Fixtures -----------------------------------------------------------
+#
+# Seed the cache the way a network-enabled `jetpack warm cache` run would have
+# left it. The layout mirrors the URL (host + path) precisely so that seeding
+# by hand is possible at all; that is the property being pinned here.
+
+warm_metadata() {
+  mkdir -p "$CACHED_DIR"
+  cat >"$CACHED_DIR/maven-metadata.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>androidx.wear.tiles</groupId>
+  <artifactId>tiles</artifactId>
+  <versioning>
+    <latest>1.5.0-alpha01</latest>
+    <release>1.4.0</release>
+    <versions>
+      <version>1.3.0</version>
+      <version>1.4.0</version>
+      <version>1.5.0-alpha01</version>
+    </versions>
+  </versioning>
+</metadata>
+EOF
+}
+
+warm_pom() {
+  mkdir -p "$CACHED_DIR/1.4.0"
+  cat >"$CACHED_DIR/1.4.0/tiles-1.4.0.pom" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>androidx.wear.tiles</groupId>
+  <artifactId>tiles</artifactId>
+  <version>1.4.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.8.0</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+}
+
+# A fresh, empty class index keeps the genuine-404 "did you mean" fallback from
+# reaching for the (large) GMaven index, exactly as the other jetpack tests do.
+mkdir -p "$JETPACK_CACHE_DIR"
+echo '{"Index": []}' >"$JETPACK_CACHE_DIR/androidx-index.json"
+
+# --- Cold cache, offline ------------------------------------------------
+
+AGENT_OFFLINE=1 run_jetpack version "$ARTIFACT" STABLE "$REPO_URL"
+assert_status "cold cache while offline exits non-zero" "$STATUS" 1
+assert_contains "cold-cache error names the missing URL" "$STDERR" \
+  "no cached copy of $REPO_URL/androidx/wear/tiles/tiles/maven-metadata.xml"
+assert_contains "cold-cache error names the variable in force" "$STDERR" "AGENT_OFFLINE=1"
+assert_contains "cold-cache error names the command that warms it" "$STDERR" \
+  "jetpack warm cache $ARTIFACT"
+assert_not_contains "a cold cache is never reported as a missing artifact" "$STDERR" "not found"
+
+# --- Warm cache, offline ------------------------------------------------
+
+warm_metadata
+
+AGENT_OFFLINE=1 run_jetpack version "$ARTIFACT" STABLE "$REPO_URL"
+assert_status "version succeeds offline from the cache" "$STATUS" 0
+assert_equals "version answers with the cached stable release" "$STDOUT" "1.4.0"
+assert_contains "the cache's age is reported on stderr" "$STDERR" "(cached just now)"
+assert_not_contains "the answer itself stays clean on stdout" "$STDOUT" "cached"
+
+AGENT_OFFLINE=1 run_jetpack list versions "$ARTIFACT" "$REPO_URL"
+assert_status "list versions succeeds offline" "$STATUS" 0
+assert_contains "list versions answers from the cached metadata" "$STDOUT" "1.5.0-alpha01"
+
+# Dependencies needs a second resource (the POM); the metadata being cached is
+# not enough, and the error must say which one is missing.
+AGENT_OFFLINE=1 run_jetpack list dependencies "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "a partially warmed cache fails rather than guessing" "$STATUS" 1
+assert_contains "the missing POM is named" "$STDERR" "tiles-1.4.0.pom"
+
+warm_pom
+
+AGENT_OFFLINE=1 run_jetpack list dependencies "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "list dependencies succeeds offline once the POM is cached" "$STATUS" 0
+assert_contains "dependencies come from the cached POM" "$STDOUT" \
+  "androidx.annotation:annotation:1.8.0 (compile)"
+
+# --- Precedence: per-tool variable wins over the workspace policy --------
+
+AGENT_OFFLINE=1 JETPACK_OFFLINE=0 run_jetpack version "$ARTIFACT" STABLE "$REPO_URL"
+assert_status "JETPACK_OFFLINE=0 opts back into the network" "$STATUS" 1
+assert_contains "opting out really does attempt the request" "$STDERR" "could not reach"
+assert_contains "the failure points at the cached copy it declined to use" "$STDERR" \
+  "re-run with JETPACK_OFFLINE=1 to use it"
+
+# --- Commands that need network refuse rather than half-run -------------
+
+AGENT_OFFLINE=1 run_jetpack warm cache "$ARTIFACT"
+assert_status "warm cache refuses to run offline" "$STATUS" 1
+
+AGENT_OFFLINE=1 run_jetpack search --force wear
+assert_status "search --force refuses to run offline" "$STATUS" 1
+if [[ -f "$JETPACK_CACHE_DIR/androidx-index.json" ]]; then
+  ok "search --force leaves the index it cannot rebuild in place"
+else
+  not_ok "search --force leaves the index it cannot rebuild in place" \
+    "The index was deleted with no way to download a replacement"
+fi

--- a/skills/jetpack/tests/test-jetpack-offline
+++ b/skills/jetpack/tests/test-jetpack-offline
@@ -24,7 +24,7 @@ REPO_URL="http://127.0.0.1:1/repo"
 ARTIFACT="androidx.wear.tiles:tiles"
 CACHED_DIR="$JETPACK_CACHE_DIR/http/127.0.0.1:1/repo/androidx/wear/tiles/tiles"
 
-TOTAL_TESTS=29
+TOTAL_TESTS=28
 TEST_NUM=0
 
 echo "1..$TOTAL_TESTS"
@@ -97,9 +97,11 @@ run_jetpack() {
 
 # --- Fixtures -----------------------------------------------------------
 #
-# Seed the cache the way a network-enabled `jetpack warm cache` run would have
-# left it. The layout mirrors the URL (host + path) precisely so that seeding
-# by hand is possible at all; that is the property being pinned here.
+# Seed the cache the way an online run of the same command would have left it:
+# the online path writes every response through, which is the whole reason no
+# separate warm command exists. The layout mirrors the URL (host + path)
+# precisely so that seeding by hand is possible at all; that is the property
+# being pinned here.
 
 warm_metadata() {
   mkdir -p "$CACHED_DIR"
@@ -160,8 +162,8 @@ assert_status "cold cache while offline exits non-zero" "$STATUS" 1
 assert_contains "cold-cache error names the missing URL" "$STDERR" \
   "no cached copy of $REPO_URL/androidx/wear/tiles/tiles/maven-metadata.xml"
 assert_contains "cold-cache error names the variable in force" "$STDERR" "AGENT_OFFLINE=1"
-assert_contains "cold-cache error names the command that warms it" "$STDERR" \
-  "jetpack warm cache $ARTIFACT"
+assert_contains "cold-cache error quotes the invocation to re-run online" "$STDERR" \
+  "jetpack version $ARTIFACT STABLE $REPO_URL"
 assert_not_contains "a cold cache is never reported as a missing artifact" "$STDERR" "not found"
 
 # --- Warm cache, offline ------------------------------------------------
@@ -201,9 +203,6 @@ assert_contains "the failure points at the cached copy it declined to use" "$STD
 
 # --- Commands that need network refuse rather than half-run -------------
 
-AGENT_OFFLINE=1 run_jetpack warm cache "$ARTIFACT"
-assert_status "warm cache refuses to run offline" "$STATUS" 1
-
 AGENT_OFFLINE=1 run_jetpack search --force wear
 assert_status "search --force refuses to run offline" "$STATUS" 1
 if [[ -f "$JETPACK_CACHE_DIR/androidx-index.json" ]]; then
@@ -234,8 +233,8 @@ AGENT_OFFLINE=1 run_jetpack source "$ARTIFACT" 1.4.0 "$REPO_URL"
 assert_status "source fails when the POM is missing from the cache" "$STATUS" 1
 assert_contains "the missing POM is named" "$STDERR" "tiles-1.4.0.pom"
 assert_contains "the consequence is spelled out" "$STDERR" "may be incomplete"
-assert_contains "the fix names --with-source" "$STDERR" \
-  "warm cache --with-source $ARTIFACT"
+assert_contains "the fix quotes the source invocation to re-run online" "$STDERR" \
+  "jetpack source $ARTIFACT 1.4.0 $REPO_URL"
 
 warm_pom
 

--- a/skills/jetpack/tests/test-jetpack-offline
+++ b/skills/jetpack/tests/test-jetpack-offline
@@ -24,7 +24,7 @@ REPO_URL="http://127.0.0.1:1/repo"
 ARTIFACT="androidx.wear.tiles:tiles"
 CACHED_DIR="$JETPACK_CACHE_DIR/http/127.0.0.1:1/repo/androidx/wear/tiles/tiles"
 
-TOTAL_TESTS=21
+TOTAL_TESTS=29
 TEST_NUM=0
 
 echo "1..$TOTAL_TESTS"
@@ -121,6 +121,13 @@ warm_metadata() {
 EOF
 }
 
+warm_sources_jar() {
+  mkdir -p "$CACHED_DIR/1.4.0" "$TEST_TMP/jarsrc/androidx/wear/tiles"
+  echo 'public class TileService {}' \
+    >"$TEST_TMP/jarsrc/androidx/wear/tiles/TileService.java"
+  (cd "$TEST_TMP/jarsrc" && jar cf "$CACHED_DIR/1.4.0/tiles-1.4.0-sources.jar" .)
+}
+
 warm_pom() {
   mkdir -p "$CACHED_DIR/1.4.0"
   cat >"$CACHED_DIR/1.4.0/tiles-1.4.0.pom" <<'EOF'
@@ -204,4 +211,39 @@ if [[ -f "$JETPACK_CACHE_DIR/androidx-index.json" ]]; then
 else
   not_ok "search --force leaves the index it cannot rebuild in place" \
     "The index was deleted with no way to download a replacement"
+fi
+
+# --- The index that search/resolve read must date itself too --------------
+
+AGENT_OFFLINE=1 run_jetpack search wear
+assert_status "search succeeds offline from the cached index" "$STATUS" 0
+assert_contains "the cached index reports its own age" "$STDERR" \
+  "using GMaven index cached"
+
+# --- A partially warmed cache must not yield incomplete sources -----------
+#
+# With the sources JAR cached but the POM missing, whether this artifact has
+# Kotlin Multiplatform platform sources cannot be determined. Returning the
+# base sources alone would look like success while quietly omitting every
+# platform target's classes, so it fails instead.
+
+rm -f "$CACHED_DIR/1.4.0/tiles-1.4.0.pom"
+warm_sources_jar
+
+AGENT_OFFLINE=1 run_jetpack source "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "source fails when the POM is missing from the cache" "$STATUS" 1
+assert_contains "the missing POM is named" "$STDERR" "tiles-1.4.0.pom"
+assert_contains "the consequence is spelled out" "$STDERR" "may be incomplete"
+assert_contains "the fix names --with-source" "$STDERR" \
+  "warm cache --with-source $ARTIFACT"
+
+warm_pom
+
+AGENT_OFFLINE=1 run_jetpack source "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "source succeeds offline once the POM is cached too" "$STATUS" 0
+if [[ -f "$STDOUT/androidx/wear/tiles/TileService.java" ]]; then
+  ok "the extracted sources come from the cached JAR"
+else
+  not_ok "the extracted sources come from the cached JAR" \
+    "Expected TileService.java under $STDOUT"
 fi

--- a/skills/workspace-config/SKILL.md
+++ b/skills/workspace-config/SKILL.md
@@ -88,6 +88,14 @@ human sets (what agents should do in this workspace); `SKILL_*` variables are
   `~/.gemini/jetski/skills` via the `05_local.py` plugin).
 - `SKILL_DEST_DIRS`: Colon-separated link destinations relative to the workspace
   root (default: `.claude/skills:.agents/skills`).
+- `SKILL_CACHE_DIR`: This tool's cache directory for remote skills and catalog
+  metadata (default: `${XDG_CACHE_HOME:-$HOME/.cache}/skill`).
+- `SKILL_OFFLINE` / `AGENT_OFFLINE`: Set to `1` to serve remote skills from that
+  cache instead of fetching them — what a CI job or a network-denied agent
+  sandbox needs, so `preflight` does not gate an agent launch on GitHub being
+  reachable. A skill that has never been fetched is a clear error rather than a
+  silent omission. Per-tool variable wins; see
+  [caching and offline mode](../coding-standards/references/caching.md).
 
 For the underlying model — what `apply` touches, the invariants `doctor` audits,
 and the one place `doctor` and `preflight` deliberately differ — see

--- a/skills/workspace-config/references/command-index.md
+++ b/skills/workspace-config/references/command-index.md
@@ -43,6 +43,16 @@ Commands:
 Options:
   --help             Display this help message and exit
   --plugin-template  Output a template/documentation for creating a Workspace plugin
+
+Environment:
+  SKILL_OFFLINE      Set to 1 to never fetch remote skills, serving whatever
+                     has already been downloaded (at any age) instead. A skill
+                     that has never been fetched is an error, not a guess.
+  AGENT_OFFLINE      Workspace-wide offline policy, used when SKILL_OFFLINE is
+                     unset. Set this in a CI job or agent sandbox with no
+                     egress.
+  SKILL_CACHE_DIR    Cache directory for remote skills and catalog metadata
+                     (default: ${XDG_CACHE_HOME:-$HOME/.cache}/skill)
 ```
 
 <!-- /generated -->
@@ -85,8 +95,7 @@ Agents:
 
 ## envrc
 
-The block below is `scripts/envrc --help`, kept in sync by
-`command-index-sync`.
+The block below is `scripts/envrc --help`, kept in sync by `command-index-sync`.
 
 <!-- generated: ../scripts/envrc --help -->
 

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -41,6 +41,25 @@ def clean_p(p):
     return s
 
 
+def age_human(path: Path) -> str:
+    """How long ago PATH was last written, for qualifying a cached answer."""
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return "unknown age"
+    for limit, unit, size in (
+        (3600, "minute", 60),
+        (86400, "hour", 3600),
+        (None, "day", 86400),
+    ):
+        if limit is None or age < limit:
+            n = int(age // size)
+            if n < 1 and unit == "minute":
+                return "just now"
+            return f"{n} {unit} ago" if n == 1 else f"{n} {unit}s ago"
+    return "unknown age"
+
+
 def prune_dirs(dest_dirs):
     for d in dest_dirs:
         try:
@@ -497,20 +516,39 @@ CATALOG_TTL = 7 * 24 * 3600  # 7 days
 PROVISION_TTL = 8 * 3600  # 8 hours
 
 
+def is_offline() -> bool:
+    """Whether remote fetches are forbidden in this environment.
+
+    Per skills/coding-standards/references/caching.md: the per-tool variable
+    wins when set (including when set to 0, to opt one tool out of a
+    workspace-wide policy), otherwise the AGENT_OFFLINE policy applies.
+    """
+    value = os.environ.get("SKILL_OFFLINE")
+    if value is None:
+        value = os.environ.get("AGENT_OFFLINE", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def offline_desc() -> str:
+    var = "SKILL_OFFLINE" if "SKILL_OFFLINE" in os.environ else "AGENT_OFFLINE"
+    return f"{var}={os.environ.get(var, '')}"
+
+
+def get_cache_dir() -> Path:
+    """This tool's cache directory (SKILL_CACHE_DIR names it outright)."""
+    override = os.environ.get("SKILL_CACHE_DIR")
+    if override:
+        return Path(override).expanduser()
+    base = Path(os.environ.get("XDG_CACHE_HOME") or "~/.cache").expanduser()
+    return base / "skill"
+
+
 def get_cache_base() -> Path:
-    return (
-        Path(
-            os.environ.get("SKILL_CACHE_DIR")
-            or os.environ.get("XDG_CACHE_HOME")
-            or "~/.cache"
-        ).expanduser()
-        / "skill"
-        / "remotes"
-    )
+    return get_cache_dir() / "remotes"
 
 
 def get_catalog_dir() -> Path:
-    return get_cache_base().parent / "catalog"
+    return get_cache_dir() / "catalog"
 
 
 def parse_github_url(url: str) -> tuple[str, str, str | None]:
@@ -542,6 +580,24 @@ def fetch_github(
         and (time.time() - meta_file.stat().st_mtime) < PROVISION_TTL
     ):
         return str(target_dir)
+
+    # Offline, a previously downloaded copy is the only copy obtainable: serve
+    # it at any age (and regardless of --force, which cannot be honoured
+    # without network), but say how old it is.
+    if is_offline():
+        if target_dir.is_dir():
+            stamp = meta_file if meta_file.is_file() else target_dir
+            print(
+                f"skill: offline ({offline_desc()}): using cached '{name}' "
+                f"(downloaded {age_human(stamp)})",
+                file=sys.stderr,
+            )
+            return str(target_dir)
+        die(
+            f"offline ({offline_desc()}) and remote skill '{name}' has never been "
+            f"downloaded to {clean_p(target_dir)}; fetch it from a "
+            f"network-enabled environment first with 'skill add {name}'"
+        )
 
     url = f"https://github.com/{repo}/archive/{ref}.tar.gz"
     print(f"skill: downloading remote skill '{name}' from GitHub...", file=sys.stderr)
@@ -610,6 +666,16 @@ def fetch_skill_md(
         and meta_file.is_file()
         and (time.time() - meta_file.stat().st_mtime) < CATALOG_TTL
     ):
+        return
+
+    # Catalog metadata is a nicety (descriptions in listings), so offline this
+    # degrades to whatever is on disk rather than failing the command.
+    if is_offline():
+        if not stub_md.is_file():
+            print(
+                f"skill: offline ({offline_desc()}): no cached metadata for '{name}'",
+                file=sys.stderr,
+            )
         return
 
     sub_part = f"/{subpath}" if subpath else ""
@@ -3264,7 +3330,17 @@ Commands:
 
 Options:
   --help             Display this help message and exit
-  --plugin-template  Output a template/documentation for creating a Workspace plugin"""
+  --plugin-template  Output a template/documentation for creating a Workspace plugin
+
+Environment:
+  SKILL_OFFLINE      Set to 1 to never fetch remote skills, serving whatever
+                     has already been downloaded (at any age) instead. A skill
+                     that has never been fetched is an error, not a guess.
+  AGENT_OFFLINE      Workspace-wide offline policy, used when SKILL_OFFLINE is
+                     unset. Set this in a CI job or agent sandbox with no
+                     egress.
+  SKILL_CACHE_DIR    Cache directory for remote skills and catalog metadata
+                     (default: ${XDG_CACHE_HOME:-$HOME/.cache}/skill)"""
     )
     sys.exit(0)
 

--- a/skills/workspace-config/scripts/skill
+++ b/skills/workspace-config/scripts/skill
@@ -573,14 +573,11 @@ def fetch_github(
     target_dir = dest_base / subpath if subpath else dest_base
     meta_file = get_catalog_dir() / ".meta" / name
 
-    if (
-        not force
-        and target_dir.is_dir()
-        and meta_file.is_file()
-        and (time.time() - meta_file.stat().st_mtime) < PROVISION_TTL
-    ):
-        return str(target_dir)
-
+    # Checked before the TTL shortcut below, not after: in the warm-then-freeze
+    # workflow the cache is usually younger than PROVISION_TTL, so testing this
+    # second would take the silent path in exactly the common case and skip the
+    # staleness signal every offline answer owes its caller.
+    #
     # Offline, a previously downloaded copy is the only copy obtainable: serve
     # it at any age (and regardless of --force, which cannot be honoured
     # without network), but say how old it is.
@@ -598,6 +595,14 @@ def fetch_github(
             f"downloaded to {clean_p(target_dir)}; fetch it from a "
             f"network-enabled environment first with 'skill add {name}'"
         )
+
+    if (
+        not force
+        and target_dir.is_dir()
+        and meta_file.is_file()
+        and (time.time() - meta_file.stat().st_mtime) < PROVISION_TTL
+    ):
+        return str(target_dir)
 
     url = f"https://github.com/{repo}/archive/{ref}.tar.gz"
     print(f"skill: downloading remote skill '{name}' from GitHub...", file=sys.stderr)

--- a/skills/workspace-config/tests/test-skill-plugins
+++ b/skills/workspace-config/tests/test-skill-plugins
@@ -15,7 +15,7 @@ set -euo pipefail
 source "$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 skill_test_init
 
-echo "1..15"
+echo "1..17"
 
 # Test 1: add bogus-skill-name reports unknown skill (non-zero exit).
 cd "$TMPDIR"
@@ -272,3 +272,35 @@ else
   echo "not ok 15 - [Remove] unresolvable remote spec remove failed unexpectedly"
 fi
 cd "$TMPDIR"
+
+# Test 16/17: offline mode serves an already-downloaded remote skill and says
+# how old it is, including when the cache is younger than PROVISION_TTL (the
+# usual state in the warm-then-freeze workflow), and refuses -- actionably --
+# when the skill was never downloaded at all.
+REMOTE_CACHE="${TMPDIR}/remote-cache"
+remote_fetch() {
+  AGENT_OFFLINE="$1" SKILL_CACHE_DIR="$REMOTE_CACHE" run_module "
+try:
+    print(m.fetch_github('pdf', 'owner/repo', 'main', 'sub'))
+except SystemExit as e:
+    print('exit', e.code)"
+}
+
+mkdir -p "${REMOTE_CACHE}/remotes/owner/repo/main/sub" "${REMOTE_CACHE}/catalog/.meta"
+date +%s >"${REMOTE_CACHE}/catalog/.meta/pdf"
+if out=$(remote_fetch 1 2>&1) &&
+  printf '%s\n' "$out" | grep -q "offline (AGENT_OFFLINE=1): using cached 'pdf' (downloaded" &&
+  printf '%s\n' "$out" | grep -q "remotes/owner/repo/main/sub"; then
+  echo "ok 16 - [Offline] fresh cached remote skill is served with its age"
+else
+  echo "not ok 16 - [Offline] unexpected output: ${out:-}"
+fi
+
+rm -rf "${REMOTE_CACHE}/remotes"
+if out=$(remote_fetch 1 2>&1) &&
+  printf '%s\n' "$out" | grep -q "has never been downloaded" &&
+  printf '%s\n' "$out" | grep -q "skill add pdf"; then
+  echo "ok 17 - [Offline] never-downloaded remote skill fails with a warm hint"
+else
+  echo "not ok 17 - [Offline] unexpected output: ${out:-}"
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,7 +83,34 @@ errors.
   hermeticity hide the host cache; share it by also exporting
   `UV_CACHE_DIR=~/.cache/uv`.
 
-### 2. Skipping External API Tests (`GEMINI_API_KEY=""`)
+### 2. Repository Tools' Offline Mode (`AGENT_OFFLINE=1`)
+
+`UV_OFFLINE` covers Python dependency resolution; it says nothing about the
+network calls the scripts themselves make. Scripts in this repository that cache
+what they fetch (`jetpack`, `skill`, `context`) honour a second switch:
+
+- **Solution**: Set `AGENT_OFFLINE=1` to make every such script answer from its
+  cache instead of the network, or `<TOOL>_OFFLINE` (`JETPACK_OFFLINE`,
+  `SKILL_OFFLINE`, `CONTEXT_OFFLINE`) to change one tool's behaviour — the
+  per-tool variable wins, including when set to `0` to opt back in.
+- **Usage**:
+  ```bash
+  UV_OFFLINE=1 AGENT_OFFLINE=1 prove tests/test-* skills/*/tests/test-*
+  ```
+- **Warming the cache**: same pattern as `uv` — run the tool once with real
+  network (e.g. `jetpack warm cache <artifact>`), then freeze. A cache miss
+  while offline is a clear error naming the warm command, never a silent stale
+  answer.
+- Tests that need a *specific* cache state should seed their own fixture rather
+  than depend on the host's, as `skills/jetpack/tests/test-jetpack-offline`
+  does: it points `JETPACK_CACHE_DIR` at a temp directory, writes the cached
+  responses by hand, and aims every request at an unroutable address so no case
+  can silently succeed over the network.
+
+The convention itself is documented in
+`skills/coding-standards/references/caching.md`.
+
+### 3. Skipping External API Tests (`GEMINI_API_KEY=""`)
 
 Some tests (like `test-pacioli` and `test-git-setup`) include integration tests
 that make actual network calls to the Gemini API. These can be slow, cost quota,
@@ -105,7 +132,7 @@ To run the entire test suite in a completely fast, local-only, offline, and
 deterministic mode:
 
 ```bash
-UV_OFFLINE=1 GEMINI_API_KEY="" prove tests/test-* skills/*/tests/test-*
+UV_OFFLINE=1 AGENT_OFFLINE=1 GEMINI_API_KEY="" prove tests/test-* skills/*/tests/test-*
 ```
 
 ## Writing Tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,9 +98,9 @@ what they fetch (`jetpack`, `skill`, `context`) honour a second switch:
   UV_OFFLINE=1 AGENT_OFFLINE=1 prove tests/test-* skills/*/tests/test-*
   ```
 - **Warming the cache**: same pattern as `uv` — run the tool once with real
-  network (e.g. `jetpack warm cache <artifact>`), then freeze. A cache miss
-  while offline is a clear error naming the warm command, never a silent stale
-  answer.
+  network, then freeze. These tools cache what they fetch, so the warm-up is
+  just the same command run online; a cache miss while offline is a clear error
+  quoting that command, never a silent stale answer.
 - Tests that need a *specific* cache state should seed their own fixture rather
   than depend on the host's, as `skills/jetpack/tests/test-jetpack-offline`
   does: it points `JETPACK_CACHE_DIR` at a temp directory, writes the cached


### PR DESCRIPTION
## Summary

Implements a cross-cutting caching and offline-mode convention for network-dependent scripts in the repository. This allows tools like `jetpack`, `skill`, and `context` to work in network-restricted environments (sandboxes, CI without egress) by serving cached responses with explicit age annotations.

## Key Changes

### Core Convention (`skills/coding-standards/references/caching.md`)
- Establishes unified cache location: `${<TOOL>_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/<tool>}`
- Defines offline mode via `<TOOL>_OFFLINE` (per-tool) and `AGENT_OFFLINE` (workspace-wide policy)
- Specifies behavior: no network calls when offline, serve stale data with age, fail loudly on cache misses
- Documents optional resources and write-through caching for online paths

### Jetpack (`skills/jetpack/scripts/jetpack`)
- Adds HTTP caching layer with `http_get()` and `http_get_body()` functions that:
  - Cache successful responses to `$JETPACK_CACHE_DIR/http/` mirroring URL structure
  - Serve cached copies when offline, annotating age on stderr
  - Fail with actionable errors (naming missing resource and warm command) on cache misses
- Implements offline mode detection (`is_offline()`) supporting both `JETPACK_OFFLINE` and `AGENT_OFFLINE`
- Adds `warm cache` subcommand to pre-populate cache for later offline use
- Adds `doctor` subcommand to report cache state and offline configuration
- Refactors existing `fetch_maven_metadata()` and `cmd_source()` to use new HTTP layer
- Updates help text and examples with offline workflow documentation
- Adds comprehensive test suite (`test-jetpack-offline`) covering cold/warm cache scenarios

### Workspace Config (`skills/workspace-config/scripts/skill`)
- Adds `is_offline()`, `offline_desc()`, and `get_cache_dir()` helpers
- Implements offline mode for remote skill fetching with cache age reporting
- Checks offline mode before TTL shortcuts to ensure warm-then-freeze workflow works correctly

### Agent Tools (`skills/agent-tools/scripts/context`)
- Adds `is_offline()`, `offline_desc()`, and `cache_age_human()` helpers
- Implements offline mode for GitHub URL fetching with proper error handling
- Respects `CONTEXT_CACHE_DIR` environment variable

### Documentation Updates
- Updates `skills/jetpack/SKILL.md` with offline mode guidance
- Updates `skills/jetpack/references/command-index.md` with new commands and environment variables
- Updates `skills/workspace-config/references/command-index.md` with offline mode documentation
- Updates `skills/coding-standards/references/shell.md` with caching best practices
- Updates `skills/coding-standards/references/cli-tools.md` with offline mode interface rules
- Updates `tests/README.md` with `AGENT_OFFLINE` documentation
- Updates Fish shell completions for jetpack

### Tests
- Adds `skills/jetpack/tests/test-jetpack-offline` with 29 test cases covering:
  - Cold cache offline failures with actionable errors
  - Warm cache offline success with age reporting
  - Partial cache handling (missing resources)
  - Cache age human-readable formatting
  - Offline mode variable precedence
- Updates `skills/agent-tools/tests/test-context` with offline mode tests
- Updates `skills/workspace-config/tests/test-skill-plugins` with offline mode tests

## Implementation Details

- **Cache layout mirrors URLs**: `http://host/path/to/resource` → `$CACHE_DIR/http/host/path/to/resource`, enabling manual inspection, seeding, and pruning
- **Best-effort caching**: Cache writes never fail the command; unwritable cache directories (read-only sandboxes) are tolerated
- **Age transparency**: Every cached answer includes `(cached X ago)` on stderr so stale data is never mistaken for current
- **Offline-first checks**: Offline mode is checked before TTL shortcuts,

https://claude.ai/code/session_01K3r5GFU7uuRoQk5HE4fCQM