### PR TITLE
Fix `jetpack` offline temporary file handling and add evals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -183,67 +183,60 @@ flags.
 - Determine whether a common helper or consistent error-trapped probing pattern
   should be applied across all completion entries.
 
-## Continue evaluating jetpack with skill-eval-harness (2026-07-27)
+## Continue evaluating jetpack with skill-eval-harness (2026-07-27) — done
 
-**Problem:** `skills/jetpack/evals/shared-benchmark.json` (12 cases: 6
-`library-lookup`, 6 `trigger`) exists but has barely been exercised. This
-session ran exactly one case (`pos-version-stable`) through
-`skill-benchmark prepare`/`run-codex`/`benchmark`, repeatedly, to shake out
-tooling problems rather than to actually evaluate the skill — and it still found
-two real, distinct issues on the way: `scripts/jetpack` required bash 4.0 for
-one `mapfile` call (fixed, commit `050b3eb`), and `run-codex` hardcodes
-`--sandbox read-only`, which blocks `mktemp`/network entirely and made an
-already-correct script look broken (worked around per-invocation with
-`--codex-cmd "codex exec --json --sandbox workspace-write -c sandbox_workspace_write.network_access=true"`,
-not yet a permanent fix). Only after both were understood did
-`pos-version-stable` show a clean lift (`with_skill` 1.0 vs `without_skill` 0.5,
-`case_flags` empty). The other 5 `library-lookup` cases and all 6 `trigger`
-cases (which need `skill-trigger-matrix`, not `benchmark`) haven't been run at
-all.
+All 6 `library-lookup` tune cases and all 6 `trigger` cases have been run, and
+the harness earned its keep: three fixes landed as a direct result.
 
-**Goal:** Reach one of two explicit end states, not just "ran it a few more
-times": either (a) `jetpack` has been iterated on, using whatever the harness
-surfaces, until there's confidence the skill is solid across its case set — or
-(b) a written verdict that `skill-eval-harness` isn't worth continuing to invest
-in for this skill. This is a continuation of the smoke-testing already underway,
-not a restart; it depends on known jetpack bugs being fixed as they're found (as
-`050b3eb` already was), not on some separate fixed-up prerequisite state.
+`skill-benchmark` over the 6 `pos-*` cases (Codex, workspace-write + network,
+one run per variant) gives `with_skill` 1.0 against `without_skill` 0.42,
+`case_flags` empty, sign-flip p=0.031. The lift is entirely *process*: with the
+network open, the baseline arm answers most of these correctly by curling
+`developer.android.com` or `android.googlesource.com` by hand, so the outcome
+assertions are base-saturated and only the `command_ran` assertions
+discriminate. That is worth knowing before reading any future outcome delta on
+this manifest as a capability claim.
 
-**Criteria:**
+What the harness caught, in the order it caught it:
 
-- All 6 `library-lookup` tune cases have been run (`with_skill`/`without_skill`,
-  Codex, workspace-write + network) and graded; each case's `case_flags` is
-  either clean or has a recorded, justified reason (e.g. base-saturated — not a
-  real regression).
-- The 6 `trigger` cases have been run through `skill-trigger-matrix`, or their
-  deferral is explicitly noted with why.
-- Either one or more jetpack fixes have landed as a direct result (each its own
-  commit, as with `050b3eb`), or this item (or a follow-up) records a
-  one-paragraph verdict on whether the harness earned its keep here — citing
-  what it did and didn't catch, not just a feeling.
+- **A real jetpack bug** (`c5b6d0b3`). Running under `run-codex`'s default
+  sandbox — read-only, which is what a warmed cache is supposed to make
+  survivable — `jetpack version` exited 1 with an xmllint parser error while the
+  answer sat in the cache. `mktemp` had failed, `tmp=$(mktemp)` swallowed it,
+  and the empty path reached `cp "$cache_file" ""`, which BSD cp resolves to
+  `./<basename>`: a stray `maven-metadata.xml` in the caller's working
+  directory. `version`, `list versions`, `list dependencies`, `resolve`, and
+  `search` now read the cache where it lies and need no writable filesystem;
+  `source`/`inspect` still need somewhere to extract a JAR and now say so,
+  naming `--output`.
+- **A leaky assertion in this repo's own manifest** (`bf7c4f9f`).
+  `pos-inspect-implementation` asserted /`TileService\.(kt|java)`/ meaning "read
+  the real source". The arm that downloaded and read the published source failed
+  it (a good answer quotes signatures, not filenames) while the arm that did not
+  passed on a citation URL ending in `TileService.java` — the oracle scored the
+  two arms backwards.
+- **A trigger false positive** (`997d6efc`). `skill-trigger-matrix` (claude,
+  sonnet+opus, 3 runs per query) fired the skill on "teach me the basics of
+  composables and state hoisting" in 5 of 6 runs, because the description ended
+  in a bare keyword list and "jetpack" matches any mention of Jetpack Compose.
+  Rewriting it around the class of question cut that to 2 of 6 and moved the
+  matrix 27/36 → 29/36.
 
-**Sketch:**
+Two things the harness did *not* catch, both oracle-side.
+`pos-resolve-coordinate` scored `without_skill` 0.0 on an answer that was
+correct: the model emitted a zero-width space inside the coordinate and the
+regex missed it, so that case's outcome delta is spurious. And a `--workers 3`
+trigger run had 29 of 36 invocations fail outright (exit 1,
+`observation_complete: false`); the summary table scored those as trigger
+failures rather than excluding them, reporting a catastrophic 0/18 regression
+that was nothing but a failed run. Check `observation_complete` before believing
+any trigger number.
 
-- Pick up where this session left off:
-  `skill-benchmark prepare skills/jetpack/evals/shared-benchmark.json --split tune --runs-per-variant 1 --out tasks.jsonl`
-  emits only the 6 `pos-*` rows (the `trig-*` cases are for
-  `skill-trigger-matrix`, a separate tool, not `prepare`/`benchmark`).
-- Keep using the `--codex-cmd` override above until sandbox permissions are
-  addressed some other way — `run-codex`'s own default makes a correct script
-  fail, which is easy to misdiagnose as a jetpack bug (it already was, once,
-  this session).
-- Once single-run signal looks stable per case, raise `--runs-per-variant` to
-  catch flakiness — the harness's pass@k/pass^k reliability plumbing exists for
-  exactly this and hasn't been exercised yet.
-- No case declares `files`, so no fixture directory work is needed alongside
-  this.
-- Worth revisiting now: "Make jetpack work offline with a pre-warmed cache"
-  below is done, so `version`/`resolve`/`list dependencies`/`source` all answer
-  from `$JETPACK_CACHE_DIR` under `AGENT_OFFLINE=1`. A run that warms the cache
-  first (network-enabled, outside the sandbox) should be evaluable under
-  `run-codex`'s default `read-only` sandbox — except that sandbox also blocks
-  `mktemp`, which several jetpack paths still need, so check that before
-  assuming the `--codex-cmd` override can be dropped.
+Left deliberately undone: `--runs-per-variant` stayed at 1 for the benchmark
+side, so the pass@k/pass^k reliability plumbing is still unexercised; the
+holdout and holdback splits are still empty; and Sonnet's recall on
+`trig-pos-coordinate-request` (1/3 before the description change, 0/3 after) is
+a real gap that three runs cannot resolve either way.
 
 ## Make jetpack work offline with a pre-warmed cache (2026-07-27) — done
 

--- a/skills/jetpack/SKILL.md
+++ b/skills/jetpack/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: jetpack
 description: >
-  Resolves AndroidX/Jetpack library information including version lookup,
-  package-to-Maven-coordinate conversion, and source code downloading. Provides
-  tools for inspecting Jetpack library implementations. Use when working with
-  androidx libraries, resolving Maven coordinates, downloading Jetpack source
-  code, checking library versions (alpha/beta/stable/snapshot), or inspecting
-  AndroidX class implementations. Triggers: androidx, jetpack, maven coordinate,
-  jetpack source, library version, snapshot, alpha, beta.
+  Looks up AndroidX/Jetpack library facts that change between releases and are
+  therefore wrong from memory: the current version of an artifact
+  (alpha/beta/rc/stable/snapshot, or a pinned build ID), the Maven coordinate a
+  package or class belongs to, an artifact's direct dependencies, and the real
+  published source of an AndroidX class. Use whenever the answer would
+  otherwise be a remembered version number, coordinate, or API signature —
+  including phrasings that name a library without saying "androidx", such as
+  "the latest release of Compose Material 3". Not for teaching Jetpack Compose
+  or Android APIs in general, where no lookup is needed, and not for the
+  literal rocket-pack sense of the word.
 compatibility: >-
   Requires curl, xmllint (libxml2-utils), jar (JDK), jq, perl. Needs network
   access to dl.google.com, androidx.dev, and cs.android.com, or a cache left by

--- a/skills/jetpack/SKILL.md
+++ b/skills/jetpack/SKILL.md
@@ -214,9 +214,17 @@ AGENT_OFFLINE=1 scripts/jetpack inspect androidx.wear.tiles.TileService
 ```
 
 A miss quotes the command to re-run, so the fix is always the invocation that
-just failed. See
-[caching and offline mode](../coding-standards/references/caching.md) for the
-repo-wide convention.
+just failed.
+
+The sandbox that denies egress usually denies writes too, so the lookups read
+straight from the cache and need no writable filesystem at all: `version`,
+`list versions`, `list dependencies`, `resolve`, and `search` all answer with
+nowhere to write. `source` and `inspect` are the exception — they extract a JAR,
+so they need somewhere to put it; pass `--output DIR` naming a writable
+directory when the default temp location is not one.
+
+See [caching and offline mode](../coding-standards/references/caching.md) for
+the repo-wide convention.
 
 ## Safety Notes
 

--- a/skills/jetpack/SKILL.md
+++ b/skills/jetpack/SKILL.md
@@ -21,16 +21,28 @@ compatibility: >-
 
 ## Important: Use Script First
 
-**ALWAYS use `scripts/jetpack` over raw `curl` and `xmllint` commands.** The
-script is located in the `scripts/` subdirectory of this skill's folder.
-References to `scripts/...` in this skill are relative to this skill directory.
-It provides features that raw commands do not:
+**ALWAYS use `scripts/jetpack` to answer these questions — never a raw command
+against a Maven URL or against the cache.** The script is located in the
+`scripts/` subdirectory of this skill's folder. References to `scripts/...` in
+this skill are relative to this skill directory. It provides features that raw
+commands do not:
 
 - Package-to-coordinate resolution with exceptions table
 - Code search integration for finding artifacts by class name
 - Version type handling (ALPHA, BETA, STABLE, SNAPSHOT)
 - Kotlin Multiplatform platform-specific source detection
 - Build ID resolution for pinned snapshots
+
+**The cache is the script's storage, not an interface.** `curl` and `xmllint`
+against `dl.google.com` are the obvious way to bypass the script, but reaching
+into `$JETPACK_CACHE_DIR` with `jq`, `unzip`, `jar`, `find`, or `grep` bypasses
+it just as completely — and offline, where the script is answering from that
+same cache, it looks like the shortest path. It is not: the index and the cached
+responses are raw upstream data, so reading them by hand skips the version-type
+filtering, the exceptions table, and the platform-source detection listed above,
+and returns something plausible with no sign that those steps were missed. Ask
+the script the question, offline or not; browse the cache only to diagnose the
+script itself.
 
 **When to read the script source:** If the script doesn't do exactly what you
 need, or fails due to missing dependencies, read the script source. It encodes

--- a/skills/jetpack/evals/README.md
+++ b/skills/jetpack/evals/README.md
@@ -4,6 +4,17 @@ Measurements of whether the `jetpack` skill actually helps, and whether it loads
 when it should. Run with
 [skill-eval-harness](https://github.com/adewale/skill-eval-harness).
 
+> **Temporary:** install the harness from the
+> [`agy-adapter` branch of this fork](https://github.com/ithinkihaveacat/skill-eval-harness/tree/agy-adapter),
+> not from upstream. It carries the Google Antigravity backend these evals use,
+> which is not yet released upstream. Once it lands, use upstream and delete
+> this note.
+>
+> ```bash
+> git clone -b agy-adapter https://github.com/ithinkihaveacat/skill-eval-harness.git
+> cd skill-eval-harness && uv tool install --editable .
+> ```
+
 ## What is here
 
 | Path                                 | What it is                                                                                                 |
@@ -105,9 +116,8 @@ Every one of these cost real time to find.
   entry, so trigger runs mount to `.agents/skills/SKILL.md/`. Cosmetic —
   detection uses the frontmatter `name:` — but confusing in a trace.
 
-- **`--agent agy` needs an unreleased harness.** The Antigravity adapter was
-  written for this work and is not in 0.6.0. Until it lands upstream, install
-  the harness from a checkout that has it.
+- **`--agent agy` needs the forked harness** linked at the top. The other
+  backends (`claude`, `codex`, `vibe`) work against upstream 0.6.0.
 
 ## Versions this was last run against
 

--- a/skills/jetpack/evals/README.md
+++ b/skills/jetpack/evals/README.md
@@ -1,0 +1,166 @@
+# jetpack evals
+
+Measurements of whether the `jetpack` skill actually helps, and whether it loads
+when it should. Run with
+[skill-eval-harness](https://github.com/adewale/skill-eval-harness).
+
+## What is here
+
+| Path                                 | What it is                                                                                                 |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `shared-benchmark.json`              | The manifest: 13 tune cases (7 `library-lookup`, 6 `trigger`) plus 2 declared ablations                    |
+| `oracles/answer-names-added-symbols` | A grade-time oracle that recomputes a real source diff and checks the answer names every added declaration |
+
+Two different tools read this one manifest, and they do not overlap:
+
+- **`skill-benchmark`** runs the 7 `library-lookup` cases. Each is graded on two
+  channels — a *process* assertion (did the model run `scripts/jetpack`?) and an
+  *outcome* assertion (is the answer right?). Every case runs twice, once
+  `with_skill` and once `without_skill`, and the score is the paired lift.
+- **`skill-trigger-matrix`** runs the 6 `trigger` cases. These have no
+  assertions: the tool mounts the skill where an agent discovers skills on its
+  own, asks a raw question, and measures whether the skill loaded. Three are
+  positive (should fire), three negative (should not).
+
+`skill-benchmark prepare` silently emits only the `pos-*` rows. If you expect 13
+tasks and get 7, nothing is broken.
+
+## Running the answer cases
+
+```bash
+cd ~/.dotfiles
+
+skill-benchmark prepare skills/jetpack/evals/shared-benchmark.json \
+  --split tune --runs-per-variant 1 --out /tmp/tasks.jsonl
+
+# Codex. The sandbox override is required — see Gotchas.
+skill-benchmark run-codex --tasks /tmp/tasks.jsonl --runs /tmp/runs --timeout 600 \
+  --codex-cmd "codex exec --json --sandbox workspace-write -c sandbox_workspace_write.network_access=true"
+
+# Or any registered native backend: claude, codex, vibe, agy
+skill-benchmark run-agent --agent agy --model gemini-3.1-pro-high \
+  --tasks /tmp/tasks.jsonl --runs /tmp/runs --timeout 600
+
+skill-benchmark benchmark skills/jetpack/evals/shared-benchmark.json \
+  --runs /tmp/runs --split tune --allow-scripts --out /tmp/benchmark.json
+```
+
+Read the result with:
+
+```bash
+jq -r '.results[] | [.case_id, .variant, (.objective_pass_rate|tostring)] | @tsv' /tmp/benchmark.json
+jq '.summary.with_skill.mean_objective_pass_rate, .paired_summary' /tmp/benchmark.json
+```
+
+## Running the trigger cases
+
+```bash
+skill-trigger-matrix skills/jetpack/evals/shared-benchmark.json --split tune \
+  --agent claude --model sonnet --model opus \
+  --runs-per-query 3 --workers 1 --out /tmp/trigger.json
+```
+
+`--agent stub` runs the whole pipeline offline with no model, which is enough to
+check that the manifest and mounting work before spending tokens.
+
+## Gotchas
+
+Every one of these cost real time to find.
+
+- **Check `observation_complete` before believing any trigger number.** A failed
+  invocation is scored as "did not trigger", not excluded, so a broken run is
+  indistinguishable from a real activation collapse in the summary table. A
+  `--workers 3` run here had 29 of 36 invocations fail and reported a
+  catastrophic 0/18 that was pure noise. Use `--workers 1` and verify:
+
+  ```bash
+  jq '[.results[] | select(.observation_complete == false)] | length' /tmp/trigger.json
+  ```
+
+- **`run-codex` needs the sandbox override** for any case that writes or
+  fetches. It inherits `codex exec`'s read-only default, which blocks `mktemp`
+  and the network, so `source`/`inspect` cases fail in a way that looks like a
+  jetpack bug. (`CodexBackend` hardcodes `sandbox="read-only"` upstream.)
+
+- **`--allow-scripts` is required** or the `script` assertion on
+  `pos-version-diff` fails closed with "script assertion skipped". It is opt-in
+  because script assertions execute repo-owned commands.
+
+- **The oracle needs network or a warm cache.** It downloads two versions of an
+  artifact to recompute the diff. Warming beforehand makes grading fast and
+  offline-safe:
+
+  ```bash
+  skills/jetpack/scripts/jetpack source androidx.compose.remote:remote-tooling-preview 1.0.0-alpha08 --output /tmp/warm08
+  skills/jetpack/scripts/jetpack source androidx.compose.remote:remote-tooling-preview 1.0.0-alpha09 --output /tmp/warm09
+  ```
+
+- **Assertions are shape checks unless stated otherwise.** `returns-a-version`
+  is `\b\d+\.\d+\.\d+\b` — a confidently stale answer passes exactly as well as
+  a correct one. Only `pos-version-diff` holds an answer against live ground
+  truth. Do not read a high outcome score as "the answer was right".
+
+- **The mounted skill directory is named `SKILL.md`.** The manifest declares
+  `skill_paths: ["SKILL.md"]` and the harness names the mounted root after that
+  entry, so trigger runs mount to `.agents/skills/SKILL.md/`. Cosmetic —
+  detection uses the frontmatter `name:` — but confusing in a trace.
+
+- **`--agent agy` needs an unreleased harness.** The Antigravity adapter was
+  written for this work and is not in 0.6.0. Until it lands upstream, install
+  the harness from a checkout that has it.
+
+## Versions this was last run against
+
+| Tool               | Version                                     |
+| ------------------ | ------------------------------------------- |
+| skill-eval-harness | 0.6.0 (`uv tool install --editable .`)      |
+| uv                 | 0.11.33                                     |
+| codex-cli          | 0.145.0                                     |
+| agy (Antigravity)  | 1.1.8 — `stream-json` output needs >= 1.1.8 |
+| Claude Code        | 2.1.220                                     |
+
+If `uv` refuses to install the harness's own `[test]` extra, it is the
+`UV_EXCLUDE_NEWER` cutoff, not a broken dependency: a pinned tool version
+published after the cutoff is filtered out. `UV_EXCLUDE_NEWER="1 day"` gets past
+it.
+
+## Last run: 2026-07-29
+
+One run per variant. `pos-version-diff` was added partway through, so Codex's
+aggregate covers the 6 cases that predate it and that case was run separately;
+Antigravity's covers all 7.
+
+| Runner                              | Cases | with_skill | without_skill | Notes                                       |
+| ----------------------------------- | ----: | ---------: | ------------: | ------------------------------------------- |
+| Codex (CLI default model)           |     6 |       1.00 |          0.42 | Δ +0.58, sign-flip p = 0.031, no case flags |
+| Antigravity (`gemini-3.1-pro-high`) |     7 |       1.00 |          0.43 | Δ +0.57, p = 0.016, no case flags           |
+
+One run per variant is enough to see a lift this size but not to settle per-case
+differences; raise `--runs-per-variant` before reading anything finer.
+
+Two findings worth carrying forward:
+
+**The lift is process, not capability.** With the network open, the
+`without_skill` arm answers most of these correctly by curling
+`developer.android.com` by hand. The outcome assertions are base-saturated; only
+the `command_ran` assertions discriminate. Checked after the fact against live
+resolution — the baseline was genuinely correct every time.
+
+**Except on `pos-version-diff`, and there the runners disagree.** That case asks
+what changed between two alpha versions of an obscure artifact; the answer is
+one `@RestrictTo` class and cannot be recalled.
+
+| Runner      | with_skill | without_skill | How the baseline behaved                                       |
+| ----------- | ---------: | ------------: | -------------------------------------------------------------- |
+| Codex       |       1.00 |          0.50 | Hand-rolled `curl`+`unzip`+`diff`; right answer, 2× the tokens |
+| Antigravity |       1.00 |      **0.00** | Ran **zero commands** and fabricated the answer                |
+
+Antigravity's baseline had egress (verified: the same `curl` returns `200` under
+the eval's own flags), so not looking was a choice. Same question, two agents,
+two different failure modes — the skill shows up as *cost* against a diligent
+agent and as *correctness* against one that guesses. Do not generalise a
+token-efficiency conclusion from a single runner.
+
+Trigger matrix, Claude sonnet + opus, 3 runs per query: 29/36 overall. Opus is
+9/9 on positives; the residual failure is a false positive on generic "teach me
+Jetpack Compose" questions.

--- a/skills/jetpack/evals/oracles/answer-names-added-symbols
+++ b/skills/jetpack/evals/oracles/answer-names-added-symbols
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Grade-time oracle for skill-eval-harness `script` assertions.
+#
+# Tests: ../../tests/test-jetpack-eval-oracles
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") ANSWER ARTIFACT OLD_VERSION NEW_VERSION
+
+Check that an agent's answer names every public declaration a Maven artifact
+gained between two versions.
+
+Downloads both versions' source JARs, diffs them, and collects the public
+Kotlin/Java declarations that appear only in NEW_VERSION. The answer passes
+only if it names all of them, which an answer written from memory or from
+release notes cannot reliably do.
+
+Arguments:
+  ANSWER        Path to the file holding the agent's answer
+  ARTIFACT      Maven coordinate (GROUP_ID:ARTIFACT_ID)
+  OLD_VERSION   The earlier version
+  NEW_VERSION   The later version
+
+Options:
+  --help, -h    Display this help message and exit
+
+Exit status:
+  0  the answer names every added declaration
+  1  the answer misses at least one, or no declarations were added
+  2  the diff could not be computed (download failed)
+
+Examples:
+  $(basename "$0") run/output.md androidx.compose.remote:remote-tooling-preview \\
+    1.0.0-alpha08 1.0.0-alpha09
+
+  # As a manifest assertion, with {output_path} substituted by the harness:
+  #   {"type": "script", "command": ["oracles/$(basename "$0")",
+  #    "{output_path}", "androidx.compose.remote:remote-tooling-preview",
+  #    "1.0.0-alpha08", "1.0.0-alpha09"]}
+
+Honours JETPACK_OFFLINE/AGENT_OFFLINE, so a warmed cache grades without
+network. Published versions are immutable, so a pinned pair always yields the
+same expected set.
+EOF
+  exit 0
+}
+
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+fi
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo >&2 "$SCRIPT_NAME: $1 not found"
+    exit 127
+  }
+}
+
+if [[ $# -lt 4 ]]; then
+  echo "$SCRIPT_NAME: need an answer file, an artifact, and two versions" >&2
+  echo "  $SCRIPT_NAME run/output.md androidx.compose.remote:remote-tooling-preview 1.0.0-alpha08 1.0.0-alpha09" >&2
+  echo "Run '$SCRIPT_NAME --help' for usage" >&2
+  exit 1
+fi
+
+ANSWER=$1
+ARTIFACT=$2
+OLD=$3
+NEW=$4
+
+require diff
+require grep
+
+JETPACK=${JETPACK_BIN:-$(cd "$(dirname "$0")/../../scripts" && pwd)/jetpack}
+if [[ ! -x $JETPACK ]]; then
+  echo "$SCRIPT_NAME: jetpack not executable at $JETPACK" >&2
+  exit 2
+fi
+
+if [[ ! -f $ANSWER ]]; then
+  echo "$SCRIPT_NAME: no answer file at $ANSWER" >&2
+  exit 2
+fi
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/jetpack-oracle.XXXXXXXX") || {
+  echo "$SCRIPT_NAME: could not create a working directory in ${TMPDIR:-/tmp}" >&2
+  exit 2
+}
+trap 'rm -rf -- "$WORK"' EXIT
+
+for version in "$OLD" "$NEW"; do
+  if ! "$JETPACK" source "$ARTIFACT" "$version" --output "$WORK/$version" >/dev/null 2>"$WORK/err"; then
+    echo "$SCRIPT_NAME: could not download $ARTIFACT $version" >&2
+    sed 's/^/  /' "$WORK/err" >&2
+    exit 2
+  fi
+done
+
+# Declarations visible only in the newer tree. Public API is what an answer can
+# reasonably be held to; a private helper moving is not a "change" a caller sees.
+decls() {
+  find "$1" -type f \( -name '*.kt' -o -name '*.java' \) -print0 2>/dev/null |
+    xargs -0 grep -hoE '(public|internal)?[[:space:]]*(class|interface|object|enum class|annotation class)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' 2>/dev/null |
+    grep -oE '[A-Za-z_][A-Za-z0-9_]*$' |
+    sort -u
+}
+
+decls "$WORK/$OLD" >"$WORK/old.txt"
+decls "$WORK/$NEW" >"$WORK/new.txt"
+ADDED=$(comm -13 "$WORK/old.txt" "$WORK/new.txt")
+
+if [[ -z $ADDED ]]; then
+  echo "$SCRIPT_NAME: $ARTIFACT gained no public declarations between $OLD and $NEW" >&2
+  echo "$SCRIPT_NAME: this pair cannot discriminate; pin a pair that does" >&2
+  exit 1
+fi
+
+MISSING=""
+FOUND=""
+while IFS= read -r symbol; do
+  [[ -z $symbol ]] && continue
+  if grep -qF -- "$symbol" "$ANSWER"; then
+    FOUND="$FOUND $symbol"
+  else
+    MISSING="$MISSING $symbol"
+  fi
+done <<<"$ADDED"
+
+if [[ -n $MISSING ]]; then
+  echo "$SCRIPT_NAME: answer does not name:$MISSING" >&2
+  echo "$SCRIPT_NAME: added between $OLD and $NEW:$(echo " $ADDED" | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+echo "answer names every declaration added between $OLD and $NEW:$FOUND"
+exit 0

--- a/skills/jetpack/evals/shared-benchmark.json
+++ b/skills/jetpack/evals/shared-benchmark.json
@@ -6,8 +6,13 @@
     "url": "https://github.com/adewale/skill-eval-harness",
     "version": ">=0.6.0"
   },
-  "skill_paths": ["SKILL.md"],
-  "variants": ["with_skill", "without_skill"],
+  "skill_paths": [
+    "SKILL.md"
+  ],
+  "variants": [
+    "with_skill",
+    "without_skill"
+  ],
   "split_policy": {
     "tune": "Visible cases used while iterating on the skill.",
     "holdout": "Hidden cases scored only at end-of-round.",
@@ -23,10 +28,21 @@
         "Uses scripts/jetpack version to resolve the STABLE version instead of guessing from training data, which is likely stale."
       ],
       "assertions": [
-        {"name": "used-version-script", "type": "command_ran", "pattern": "jetpack\\s+version\\s+androidx\\.work"},
-        {"name": "returns-a-version", "type": "regex", "pattern": "\\b\\d+\\.\\d+\\.\\d+\\b"}
+        {
+          "name": "used-version-script",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+version\\s+androidx\\.work"
+        },
+        {
+          "name": "returns-a-version",
+          "type": "regex",
+          "pattern": "\\b\\d+\\.\\d+\\.\\d+\\b"
+        }
       ],
-      "tags": ["version", "stable"]
+      "tags": [
+        "version",
+        "stable"
+      ]
     },
     {
       "id": "pos-resolve-coordinate",
@@ -37,10 +53,21 @@
         "Uses scripts/jetpack resolve rather than guessing the coordinate from the package name heuristically."
       ],
       "assertions": [
-        {"name": "used-resolve-script", "type": "command_ran", "pattern": "jetpack\\s+resolve"},
-        {"name": "returns-a-coordinate", "type": "regex", "pattern": "androidx\\.[\\w.]+:[\\w-]+"}
+        {
+          "name": "used-resolve-script",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+resolve"
+        },
+        {
+          "name": "returns-a-coordinate",
+          "type": "regex",
+          "pattern": "androidx\\.[\\w.]+:[\\w-]+"
+        }
       ],
-      "tags": ["resolve", "maven-coordinate"]
+      "tags": [
+        "resolve",
+        "maven-coordinate"
+      ]
     },
     {
       "id": "pos-search-artifact",
@@ -51,10 +78,20 @@
         "Uses scripts/jetpack search (or code-search fallback) to find the artifact rather than guessing."
       ],
       "assertions": [
-        {"name": "used-search-script", "type": "command_ran", "pattern": "jetpack\\s+search"},
-        {"name": "returns-a-coordinate", "type": "regex", "pattern": "androidx\\.[\\w.]+:[\\w-]+"}
+        {
+          "name": "used-search-script",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+search"
+        },
+        {
+          "name": "returns-a-coordinate",
+          "type": "regex",
+          "pattern": "androidx\\.[\\w.]+:[\\w-]+"
+        }
       ],
-      "tags": ["search"]
+      "tags": [
+        "search"
+      ]
     },
     {
       "id": "pos-inspect-implementation",
@@ -65,10 +102,21 @@
         "Uses scripts/jetpack inspect (search+resolve+source) to fetch and read the real source instead of describing from memory."
       ],
       "assertions": [
-        {"name": "used-inspect-or-source", "type": "command_ran", "pattern": "jetpack\\s+(inspect|source)"},
-        {"name": "names-the-abstract-method", "type": "contains", "value": "onTileRequest"}
+        {
+          "name": "used-inspect-or-source",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+(inspect|source)"
+        },
+        {
+          "name": "names-the-abstract-method",
+          "type": "contains",
+          "value": "onTileRequest"
+        }
       ],
-      "tags": ["inspect", "source"]
+      "tags": [
+        "inspect",
+        "source"
+      ]
     },
     {
       "id": "pos-list-dependencies",
@@ -79,10 +127,20 @@
         "Uses scripts/jetpack list dependencies to get the real dependency list."
       ],
       "assertions": [
-        {"name": "used-list-dependencies", "type": "command_ran", "pattern": "jetpack\\s+list\\s+dependencies"},
-        {"name": "returns-a-coordinate", "type": "regex", "pattern": "androidx\\.[\\w.]+:[\\w-]+"}
+        {
+          "name": "used-list-dependencies",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+list\\s+dependencies"
+        },
+        {
+          "name": "returns-a-coordinate",
+          "type": "regex",
+          "pattern": "androidx\\.[\\w.]+:[\\w-]+"
+        }
       ],
-      "tags": ["dependencies"]
+      "tags": [
+        "dependencies"
+      ]
     },
     {
       "id": "pos-snapshot-build",
@@ -93,10 +151,64 @@
         "Uses scripts/jetpack version ... SNAPSHOT to resolve a real, current build id from androidx.dev rather than inventing one."
       ],
       "assertions": [
-        {"name": "used-snapshot-lookup", "type": "command_ran", "pattern": "jetpack\\s+version.*SNAPSHOT"},
-        {"name": "mentions-build-id", "type": "regex", "pattern": "\\b\\d{6,}\\b"}
+        {
+          "name": "used-snapshot-lookup",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+version.*SNAPSHOT"
+        },
+        {
+          "name": "mentions-build-id",
+          "type": "regex",
+          "pattern": "\\b\\d{6,}\\b"
+        }
       ],
-      "tags": ["snapshot", "build-id"]
+      "tags": [
+        "snapshot",
+        "build-id"
+      ]
+    },
+    {
+      "id": "pos-version-diff",
+      "split": "tune",
+      "kind": "library-lookup",
+      "prompt": "What changed in androidx.compose.remote:remote-tooling-preview between 1.0.0-alpha08 and 1.0.0-alpha09?",
+      "expected_behavior": [
+        "Downloads both versions' sources with scripts/jetpack source and compares them. Unlike the other cases here, this one has no memorisable answer: the artifact is an alpha of a new library and the delta is a single @RestrictTo class, so an answer not derived from the two source trees cannot name it."
+      ],
+      "assertions": [
+        {
+          "name": "fetched-the-older-version",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+source.*alpha08"
+        },
+        {
+          "name": "fetched-the-newer-version",
+          "type": "command_ran",
+          "pattern": "jetpack\\s+source.*alpha09"
+        },
+        {
+          "name": "names-the-added-class",
+          "type": "contains",
+          "value": "RemotePreviewWrapper"
+        },
+        {
+          "name": "names-every-added-declaration",
+          "type": "script",
+          "command": [
+            "oracles/answer-names-added-symbols",
+            "{output_path}",
+            "androidx.compose.remote:remote-tooling-preview",
+            "1.0.0-alpha08",
+            "1.0.0-alpha09"
+          ],
+          "timeout_s": 300
+        }
+      ],
+      "tags": [
+        "diff",
+        "source",
+        "unmemorisable"
+      ]
     },
     {
       "id": "trig-pos-keyword-version",
@@ -106,7 +218,10 @@
       "expected_behavior": [
         "The jetpack skill loads autonomously since this is a direct library-version question."
       ],
-      "tags": ["trigger", "positive"]
+      "tags": [
+        "trigger",
+        "positive"
+      ]
     },
     {
       "id": "trig-pos-natural-phrasing",
@@ -116,7 +231,11 @@
       "expected_behavior": [
         "The jetpack skill loads even without the literal keywords 'androidx' or 'maven coordinate' appearing in the prompt."
       ],
-      "tags": ["trigger", "positive", "generalization"]
+      "tags": [
+        "trigger",
+        "positive",
+        "generalization"
+      ]
     },
     {
       "id": "trig-pos-coordinate-request",
@@ -126,7 +245,10 @@
       "expected_behavior": [
         "The jetpack skill loads to resolve the coordinate rather than the model guessing from memory."
       ],
-      "tags": ["trigger", "positive"]
+      "tags": [
+        "trigger",
+        "positive"
+      ]
     },
     {
       "id": "trig-neg-literal-jetpack",
@@ -136,7 +258,11 @@
       "expected_behavior": [
         "The jetpack skill should not trigger on the literal rocket-pack meaning of the word."
       ],
-      "tags": ["trigger", "negative", "false-friend"]
+      "tags": [
+        "trigger",
+        "negative",
+        "false-friend"
+      ]
     },
     {
       "id": "trig-neg-generic-compose",
@@ -146,7 +272,11 @@
       "expected_behavior": [
         "The jetpack skill should not trigger just because Jetpack Compose is mentioned generically, with no version/coordinate/source lookup needed."
       ],
-      "tags": ["trigger", "negative", "false-friend"]
+      "tags": [
+        "trigger",
+        "negative",
+        "false-friend"
+      ]
     },
     {
       "id": "trig-neg-unrelated-android",
@@ -156,7 +286,10 @@
       "expected_behavior": [
         "The jetpack skill should not trigger on generic Android UI questions unrelated to AndroidX library resolution."
       ],
-      "tags": ["trigger", "negative"]
+      "tags": [
+        "trigger",
+        "negative"
+      ]
     }
   ],
   "ablations": [

--- a/skills/jetpack/evals/shared-benchmark.json
+++ b/skills/jetpack/evals/shared-benchmark.json
@@ -66,7 +66,7 @@
       ],
       "assertions": [
         {"name": "used-inspect-or-source", "type": "command_ran", "pattern": "jetpack\\s+(inspect|source)"},
-        {"name": "shows-a-real-source-file", "type": "regex", "pattern": "TileService\\.(kt|java)"}
+        {"name": "names-the-abstract-method", "type": "contains", "value": "onTileRequest"}
       ],
       "tags": ["inspect", "source"]
     },

--- a/skills/jetpack/scripts/jetpack
+++ b/skills/jetpack/scripts/jetpack
@@ -40,6 +40,21 @@ require() {
   }
 }
 
+# mktemp that reports its own failure. A bare `tmp=$(mktemp)` yields an empty
+# path when no temp directory is writable, and BSD cp resolves an empty
+# destination to ./<basename> -- so the body lands as a stray file in the
+# caller's working directory and the parse of the (absent) temp file fails with
+# an xmllint error that names nothing useful. Every call site pairs this with
+# `|| return`/`|| exit` so the failure stops there instead.
+make_temp() {
+  local path
+  path=$(mktemp "$@" 2>/dev/null) && [[ -n "$path" ]] || {
+    echo "$SCRIPT_NAME: could not create a temporary file in ${TMPDIR:-/tmp} (not writable?)" >&2
+    return 1
+  }
+  printf '%s\n' "$path"
+}
+
 # =============================================================================
 # OFFLINE MODE AND HTTP CACHE
 # =============================================================================
@@ -153,6 +168,24 @@ cache_store() {
   return 0
 }
 
+# offline_body_file URL -- print the path of an already-cached body, if this is
+# an offline run and the cache has one, without writing anything at all.
+#
+# Callers that only need to *read* a body (metadata and POM XML, as opposed to
+# the source JARs that have to land in a build directory) use this before
+# reaching for http_get. Copying a cache hit into a temp file needs a writable
+# filesystem, and offline mode's whole reason to exist is the sandbox that
+# denies egress -- which is usually the same sandbox that denies writes. Note
+# the age exactly as http_get does; a cached answer is dated either way.
+offline_body_file() {
+  local url="$1" cache_file
+  is_offline || return 1
+  cache_file=$(cache_path_for_url "$url" 2>/dev/null) || return 1
+  [[ -f "$cache_file" ]] || return 1
+  echo "$SCRIPT_NAME: offline: using cached $url (cached $(file_age_human "$cache_file"))" >&2
+  printf '%s\n' "$cache_file"
+}
+
 # http_get URL OUTFILE
 #
 # Writes the response body to OUTFILE and sets, for the caller's error message:
@@ -234,8 +267,20 @@ http_get() {
 # http_get_body URL -- print the response body on stdout. Same exit codes and
 # HTTP_STATUS/HTTP_ERROR contract as http_get, for callers that want a string.
 http_get_body() {
-  local url="$1" tmp status=0
-  tmp=$(mktemp)
+  local url="$1" tmp status=0 cached
+  if cached=$(offline_body_file "$url"); then
+    HTTP_STATUS="200"
+    HTTP_ERROR=""
+    HTTP_HINT=""
+    cat "$cached"
+    return 0
+  fi
+  tmp=$(make_temp) || {
+    HTTP_STATUS=""
+    HTTP_ERROR="no writable temporary directory for the body of $url"
+    HTTP_HINT=""
+    return 2
+  }
   http_get "$url" "$tmp" || status=$?
   if [[ $status -eq 0 ]]; then
     cat "$tmp"
@@ -290,10 +335,25 @@ fetch_maven_metadata() {
 
   local metadata_url="$repo_url/$group_id_path/$artifact_id/maven-metadata.xml"
 
-  local tmp_body status
-  tmp_body=$(mktemp)
+  # Offline, the cached metadata is readable where it already lies; only the
+  # online path needs somewhere to put the response.
+  local tmp_body status body_file
   status=0
-  http_get "$metadata_url" "$tmp_body" || status=$?
+  if body_file=$(offline_body_file "$metadata_url"); then
+    tmp_body=""
+    HTTP_STATUS="200"
+    HTTP_ERROR=""
+    HTTP_HINT=""
+  else
+    tmp_body=$(make_temp) || {
+      HTTP_ERROR="no writable temporary directory for $metadata_url"
+      status=2
+    }
+    body_file="$tmp_body"
+    if [[ $status -eq 0 ]]; then
+      http_get "$metadata_url" "$tmp_body" || status=$?
+    fi
+  fi
 
   if [[ $status -eq 2 ]]; then
     # Neither a missing network nor an unwarmed cache is evidence the artifact
@@ -331,8 +391,11 @@ fetch_maven_metadata() {
     return 1
   fi
 
-  cat "$tmp_body"
-  rm -f "$tmp_body"
+  cat "$body_file"
+  if [[ -n "$tmp_body" ]]; then
+    rm -f "$tmp_body"
+  fi
+  return 0
 }
 
 extract_versions_from_xml() {
@@ -531,7 +594,7 @@ update_index() {
 
   (
     local tmp_gz tmp_json
-    tmp_gz=$(mktemp)
+    tmp_gz=$(make_temp) || exit 1
     tmp_json="${tmp_gz}.json"
     trap 'rm -f "$tmp_gz" "$tmp_json"' EXIT
 
@@ -1290,8 +1353,7 @@ cmd_source() {
   fi
 
   # Validate all artifacts before creating directories
-  local group_id artifact_id group_id_path metadata_url tmp_metadata
-  tmp_metadata=$(mktemp)
+  local group_id artifact_id group_id_path metadata_url tmp_metadata=""
   for artifact in "${artifacts[@]}"; do
     validate_artifact_format "$artifact"
 
@@ -1300,6 +1362,14 @@ cmd_source() {
     group_id_path=$(echo "$group_id" | sed 's/\./\//g')
     metadata_url="${repo_url}/${group_id_path}/${artifact_id}/maven-metadata.xml"
 
+    # This body is only ever tested for existence, so a cache hit needs no copy.
+    if offline_body_file "$metadata_url" >/dev/null; then
+      continue
+    fi
+
+    if [[ -z "$tmp_metadata" ]]; then
+      tmp_metadata=$(make_temp) || exit 1
+    fi
     if ! http_get "$metadata_url" "$tmp_metadata"; then
       rm -f "$tmp_metadata"
       echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
@@ -1310,7 +1380,9 @@ cmd_source() {
       exit 1
     fi
   done
-  rm -f "$tmp_metadata"
+  if [[ -n "$tmp_metadata" ]]; then
+    rm -f "$tmp_metadata"
+  fi
 
   # Create output directory
   local build_dir
@@ -1318,7 +1390,12 @@ cmd_source() {
     build_dir="$output_dir"
     mkdir -p "$build_dir"
   else
-    build_dir=$(mktemp -d "${TMPDIR:-/tmp}/jetpack.XXXXXXXXXX")
+    # Extracted sources have to land somewhere writable; --output names that
+    # directory when the default temp location is not one.
+    build_dir=$(make_temp -d "${TMPDIR:-/tmp}/jetpack.XXXXXXXXXX") || {
+      echo "$SCRIPT_NAME source: pass --output DIR to extract somewhere writable" >&2
+      exit 1
+    }
   fi
 
   # Download and extract each package
@@ -1388,19 +1465,24 @@ cmd_source() {
     # this whole mode exists to prevent — so it is fatal and says how to fix it.
     pom_url="${repo_url}/${group_id_path}/${artifact_id}/${version}/${artifact_id}-${jar_version}.pom"
     pom_status=0
-    pom_file=$(mktemp)
-    http_get "${pom_url}" "$pom_file" || pom_status=$?
     pom_content=""
-    if [[ $pom_status -eq 0 ]]; then
+    if pom_file=$(offline_body_file "$pom_url"); then
       pom_content=$(cat "$pom_file")
-    elif [[ $pom_status -eq 2 ]] && is_offline; then
+    else
+      pom_file=$(make_temp) || exit 1
+      http_get "${pom_url}" "$pom_file" || pom_status=$?
+      if [[ $pom_status -eq 0 ]]; then
+        pom_content=$(cat "$pom_file")
+      fi
       rm -f "$pom_file"
+    fi
+
+    if [[ $pom_status -eq 2 ]] && is_offline; then
       echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
       echo "$SCRIPT_NAME source: without it, whether $artifact has Kotlin Multiplatform sources cannot be determined, and the extracted sources may be incomplete" >&2
       warm_hint
       exit 1
     fi
-    rm -f "$pom_file"
 
     if [[ -n "$pom_content" ]]; then
       # sort -u because a platform artifact listed both as a compile and a
@@ -1710,19 +1792,23 @@ cmd_dependencies() {
   # Fetch into a file rather than a command substitution: HTTP_ERROR is set by
   # http_get in the shell that runs it, and a $(...) subshell would take it
   # (and the reason this failed) with it.
-  local pom_content pom_file
-  pom_file=$(mktemp)
-  if ! http_get "${pom_url}" "$pom_file"; then
-    rm -f "$pom_file"
-    echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
-    http_print_hint
-    if is_offline; then
-      warm_hint
+  local pom_content pom_file cached_pom
+  if cached_pom=$(offline_body_file "$pom_url"); then
+    pom_content=$(cat "$cached_pom")
+  else
+    pom_file=$(make_temp) || exit 1
+    if ! http_get "${pom_url}" "$pom_file"; then
+      rm -f "$pom_file"
+      echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
+      http_print_hint
+      if is_offline; then
+        warm_hint
+      fi
+      exit 1
     fi
-    exit 1
+    pom_content=$(cat "$pom_file")
+    rm -f "$pom_file"
   fi
-  pom_content=$(cat "$pom_file")
-  rm -f "$pom_file"
 
   local deps
   deps=$(echo "$pom_content" | perl -0777 -ne '

--- a/skills/jetpack/scripts/jetpack
+++ b/skills/jetpack/scripts/jetpack
@@ -40,18 +40,36 @@ require() {
   }
 }
 
+# make_temp [-d] [DIR] -- create a temporary file (or directory, with -d) under
+# DIR, defaulting to $TMPDIR.
+#
 # mktemp that reports its own failure. A bare `tmp=$(mktemp)` yields an empty
 # path when no temp directory is writable, and BSD cp resolves an empty
 # destination to ./<basename> -- so the body lands as a stray file in the
 # caller's working directory and the parse of the (absent) temp file fails with
 # an xmllint error that names nothing useful. Every call site pairs this with
 # `|| return`/`|| exit` so the failure stops there instead.
+#
+# The template is always explicit: BSD mktemp given no template writes to
+# Darwin's per-user temp directory and ignores TMPDIR entirely, so a caller who
+# pointed TMPDIR at a writable fallback would still fail -- and be told the
+# fallback was unwritable, naming a directory mktemp never tried. Both BSD and
+# GNU mktemp honour an explicit template.
 make_temp() {
-  local path
-  path=$(mktemp "$@" 2>/dev/null) && [[ -n "$path" ]] || {
-    echo "$SCRIPT_NAME: could not create a temporary file in ${TMPDIR:-/tmp} (not writable?)" >&2
+  local dir path
+  if [[ "${1:-}" == "-d" ]]; then
+    shift
+    dir="${1:-${TMPDIR:-/tmp}}"
+    path=$(mktemp -d "$dir/jetpack.XXXXXXXXXX" 2>/dev/null) || path=""
+  else
+    dir="${1:-${TMPDIR:-/tmp}}"
+    path=$(mktemp "$dir/jetpack.XXXXXXXXXX" 2>/dev/null) || path=""
+  fi
+
+  if [[ -z "$path" ]]; then
+    echo "$SCRIPT_NAME: could not create a temporary file in $dir (not writable?)" >&2
     return 1
-  }
+  fi
   printf '%s\n' "$path"
 }
 
@@ -186,6 +204,20 @@ offline_body_file() {
   printf '%s\n' "$cache_file"
 }
 
+# offline_miss URL -- set the http_get result variables for a cache miss that
+# offline mode has already decided.
+#
+# Once offline_body_file has come up empty there is nothing left to find: no
+# network to ask and no cached copy to read. Callers use this instead of running
+# http_get against a temporary file, so the cold-cache diagnostic (and the
+# command that would warm it) still reaches the user where there is nowhere to
+# write a body that was never going to arrive.
+offline_miss() {
+  HTTP_STATUS=""
+  HTTP_ERROR="offline ($(offline_desc)) and no cached copy of $1"
+  HTTP_HINT=""
+}
+
 # http_get URL OUTFILE
 #
 # Writes the response body to OUTFILE and sets, for the caller's error message:
@@ -213,7 +245,7 @@ http_get() {
       HTTP_STATUS="200"
       return 0
     fi
-    HTTP_ERROR="offline ($(offline_desc)) and no cached copy of $url"
+    offline_miss "$url"
     return 2
   fi
 
@@ -275,6 +307,10 @@ http_get_body() {
     cat "$cached"
     return 0
   fi
+  if is_offline; then
+    offline_miss "$url"
+    return 2
+  fi
   tmp=$(make_temp) || {
     HTTP_STATUS=""
     HTTP_ERROR="no writable temporary directory for the body of $url"
@@ -335,8 +371,8 @@ fetch_maven_metadata() {
 
   local metadata_url="$repo_url/$group_id_path/$artifact_id/maven-metadata.xml"
 
-  # Offline, the cached metadata is readable where it already lies; only the
-  # online path needs somewhere to put the response.
+  # Offline, the cached metadata is readable where it already lies and a miss is
+  # already decided; only the online path needs somewhere to put a response.
   local tmp_body status body_file
   status=0
   if body_file=$(offline_body_file "$metadata_url"); then
@@ -344,6 +380,10 @@ fetch_maven_metadata() {
     HTTP_STATUS="200"
     HTTP_ERROR=""
     HTTP_HINT=""
+  elif is_offline; then
+    tmp_body=""
+    offline_miss "$metadata_url"
+    status=2
   else
     tmp_body=$(make_temp) || {
       HTTP_ERROR="no writable temporary directory for $metadata_url"
@@ -1352,50 +1392,64 @@ cmd_source() {
     echo "info: Using AndroidX snapshot repository (latest)" >&2
   fi
 
-  # Validate all artifacts before creating directories
-  local group_id artifact_id group_id_path metadata_url tmp_metadata=""
+  # Validate every artifact before touching the filesystem or the network, so a
+  # typo cannot leave a half-built output directory behind.
+  local group_id artifact_id group_id_path metadata_url
   for artifact in "${artifacts[@]}"; do
     validate_artifact_format "$artifact"
+  done
 
+  # Create the output directory next, before anything needs a temporary file:
+  # --output is the documented recovery when the default temp directory is not
+  # writable, so it has to be the place the bodies fetched along the way land
+  # too. Otherwise an online `source --output /writable` would still die on the
+  # first metadata allocation, having been told to pass the flag it just passed.
+  local build_dir temp_dir="${TMPDIR:-/tmp}"
+  if [[ -n "$output_dir" ]]; then
+    build_dir="$output_dir"
+    mkdir -p "$build_dir"
+    temp_dir="$build_dir"
+  else
+    # Extracted sources have to land somewhere writable; --output names that
+    # directory when the default temp location is not one.
+    build_dir=$(make_temp -d) || {
+      echo "$SCRIPT_NAME source: pass --output DIR to extract somewhere writable" >&2
+      exit 1
+    }
+    temp_dir="$build_dir"
+  fi
+
+  local tmp_metadata=""
+  for artifact in "${artifacts[@]}"; do
     group_id=$(echo "$artifact" | cut -d: -f1)
     artifact_id=$(echo "$artifact" | cut -d: -f2)
     group_id_path=$(echo "$group_id" | sed 's/\./\//g')
     metadata_url="${repo_url}/${group_id_path}/${artifact_id}/maven-metadata.xml"
 
-    # This body is only ever tested for existence, so a cache hit needs no copy.
+    # This body is only ever tested for existence, so a cache hit needs no copy
+    # and, offline, a miss needs no temporary file to report itself.
     if offline_body_file "$metadata_url" >/dev/null; then
       continue
     fi
+    if is_offline; then
+      offline_miss "$metadata_url"
+      echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
+      warm_hint
+      exit 1
+    fi
 
     if [[ -z "$tmp_metadata" ]]; then
-      tmp_metadata=$(make_temp) || exit 1
+      tmp_metadata=$(make_temp "$temp_dir") || exit 1
     fi
     if ! http_get "$metadata_url" "$tmp_metadata"; then
       rm -f "$tmp_metadata"
       echo "$SCRIPT_NAME source: $HTTP_ERROR" >&2
       http_print_hint
-      if is_offline; then
-        warm_hint
-      fi
       exit 1
     fi
   done
   if [[ -n "$tmp_metadata" ]]; then
     rm -f "$tmp_metadata"
-  fi
-
-  # Create output directory
-  local build_dir
-  if [[ -n "$output_dir" ]]; then
-    build_dir="$output_dir"
-    mkdir -p "$build_dir"
-  else
-    # Extracted sources have to land somewhere writable; --output names that
-    # directory when the default temp location is not one.
-    build_dir=$(make_temp -d "${TMPDIR:-/tmp}/jetpack.XXXXXXXXXX") || {
-      echo "$SCRIPT_NAME source: pass --output DIR to extract somewhere writable" >&2
-      exit 1
-    }
   fi
 
   # Download and extract each package
@@ -1468,8 +1522,11 @@ cmd_source() {
     pom_content=""
     if pom_file=$(offline_body_file "$pom_url"); then
       pom_content=$(cat "$pom_file")
+    elif is_offline; then
+      offline_miss "$pom_url"
+      pom_status=2
     else
-      pom_file=$(make_temp) || exit 1
+      pom_file=$(make_temp "$temp_dir") || exit 1
       http_get "${pom_url}" "$pom_file" || pom_status=$?
       if [[ $pom_status -eq 0 ]]; then
         pom_content=$(cat "$pom_file")
@@ -1792,22 +1849,31 @@ cmd_dependencies() {
   # Fetch into a file rather than a command substitution: HTTP_ERROR is set by
   # http_get in the shell that runs it, and a $(...) subshell would take it
   # (and the reason this failed) with it.
-  local pom_content pom_file cached_pom
+  local pom_content pom_file cached_pom fetch_failed=0
   if cached_pom=$(offline_body_file "$pom_url"); then
     pom_content=$(cat "$cached_pom")
+  elif is_offline; then
+    # A cold cache with no network is decided already, and reporting that must
+    # not depend on having somewhere to write the body that will never arrive.
+    offline_miss "$pom_url"
+    fetch_failed=1
   else
     pom_file=$(make_temp) || exit 1
-    if ! http_get "${pom_url}" "$pom_file"; then
-      rm -f "$pom_file"
-      echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
-      http_print_hint
-      if is_offline; then
-        warm_hint
-      fi
-      exit 1
+    if http_get "${pom_url}" "$pom_file"; then
+      pom_content=$(cat "$pom_file")
+    else
+      fetch_failed=1
     fi
-    pom_content=$(cat "$pom_file")
     rm -f "$pom_file"
+  fi
+
+  if [[ $fetch_failed -eq 1 ]]; then
+    echo "$SCRIPT_NAME dependencies: failed to download $pom_url: $HTTP_ERROR" >&2
+    http_print_hint
+    if is_offline; then
+      warm_hint
+    fi
+    exit 1
   fi
 
   local deps

--- a/skills/jetpack/tests/test-jetpack-eval-oracles
+++ b/skills/jetpack/tests/test-jetpack-eval-oracles
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Tests for the grade-time oracles under evals/oracles/.
+#
+# The argument and usage surface is exercised without network. The verdict
+# paths need two source JARs, which the oracle downloads through jetpack; they
+# run offline against a warmed cache and are skipped when it is cold, so a
+# clean checkout does not fail here for want of a download.
+
+set -u
+
+SCRIPT_DIR=$(dirname "$0")
+ROOT_DIR="$SCRIPT_DIR/.."
+ORACLE="$ROOT_DIR/evals/oracles/answer-names-added-symbols"
+
+ARTIFACT="androidx.compose.remote:remote-tooling-preview"
+OLD="1.0.0-alpha08"
+NEW="1.0.0-alpha09"
+ADDED="RemotePreviewWrapper"
+
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+TOTAL_TESTS=9
+TEST_NUM=0
+echo "1..$TOTAL_TESTS"
+
+ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  echo "ok $TEST_NUM - $1"
+}
+
+not_ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  echo "not ok $TEST_NUM - $1"
+  shift
+  local line
+  for line in "$@"; do
+    echo "# $line"
+  done
+}
+
+skip() {
+  TEST_NUM=$((TEST_NUM + 1))
+  echo "ok $TEST_NUM - $1 # SKIP $2"
+}
+
+assert_status() {
+  local description="$1" status="$2" expected="$3"
+  if [[ "$status" -eq "$expected" ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected exit $expected, got $status"
+  fi
+}
+
+assert_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    ok "$description"
+  else
+    not_ok "$description" "Expected to contain: $needle" "Got: $haystack"
+  fi
+}
+
+run_oracle() {
+  local err_file
+  err_file=$(mktemp)
+  STDOUT=$("$ORACLE" "$@" 2>"$err_file")
+  STATUS=$?
+  STDERR=$(cat "$err_file")
+  rm -f "$err_file"
+}
+
+# --- Usage surface (no network) -------------------------------------------
+
+run_oracle --help
+assert_status "--help exits 0" "$STATUS" 0
+assert_contains "help names the arguments" "$STDOUT" "ANSWER        Path to the file"
+
+run_oracle -h
+assert_status "-h is a help alias" "$STATUS" 0
+
+run_oracle
+assert_status "no arguments is a usage error" "$STATUS" 1
+assert_contains "the usage error points at --help" "$STDERR" "--help"
+
+printf 'irrelevant\n' >"$TEST_TMP/answer.md"
+
+run_oracle "$TEST_TMP/nonexistent.md" "$ARTIFACT" "$OLD" "$NEW"
+assert_status "a missing answer file exits 2, not 1" "$STATUS" 2
+assert_contains "the missing answer file is named" "$STDERR" "no answer file at"
+
+# --- Verdicts (offline, against a warmed cache) ---------------------------
+#
+# Exit 2 means the download failed, which here means the cache is cold rather
+# than that the oracle is wrong; report that as a skip.
+
+printf 'alpha09 adds %s, a PreviewWrapperProvider.\n' "$ADDED" >"$TEST_TMP/good.md"
+printf 'Various bug fixes and performance improvements.\n' >"$TEST_TMP/vague.md"
+
+AGENT_OFFLINE=1 run_oracle "$TEST_TMP/good.md" "$ARTIFACT" "$OLD" "$NEW"
+if [[ "$STATUS" -eq 2 ]]; then
+  skip "an answer naming the added class passes" "cache not warmed for $ARTIFACT"
+  skip "a vague answer fails and names what it missed" "cache not warmed for $ARTIFACT"
+else
+  assert_status "an answer naming the added class passes" "$STATUS" 0
+
+  AGENT_OFFLINE=1 run_oracle "$TEST_TMP/vague.md" "$ARTIFACT" "$OLD" "$NEW"
+  if [[ "$STATUS" -eq 1 && "$STDERR" == *"$ADDED"* ]]; then
+    ok "a vague answer fails and names what it missed"
+  else
+    not_ok "a vague answer fails and names what it missed" \
+      "Expected exit 1 mentioning $ADDED, got $STATUS: $STDERR"
+  fi
+fi

--- a/skills/jetpack/tests/test-jetpack-offline
+++ b/skills/jetpack/tests/test-jetpack-offline
@@ -24,7 +24,7 @@ REPO_URL="http://127.0.0.1:1/repo"
 ARTIFACT="androidx.wear.tiles:tiles"
 CACHED_DIR="$JETPACK_CACHE_DIR/http/127.0.0.1:1/repo/androidx/wear/tiles/tiles"
 
-TOTAL_TESTS=31
+TOTAL_TESTS=41
 TEST_NUM=0
 
 echo "1..$TOTAL_TESTS"
@@ -287,3 +287,70 @@ if [[ "$STDERR" == *"could not reach"* ]]; then
 else
   ok "a received 404 is not reported as an unreachable host"
 fi
+
+# --- No writable temporary directory --------------------------------------
+#
+# The sandbox that denies egress usually denies writes too, so offline mode is
+# worth little if reading a cached answer still needs somewhere to copy it.
+# Reading the cache file where it already lies keeps version and list
+# dependencies working; source, which has to extract a JAR, still needs
+# --output and must say so.
+#
+# Regression: a bare `tmp=$(mktemp)` left an empty path, and BSD cp resolves an
+# empty destination to ./<basename> -- so the body landed as a stray
+# maven-metadata.xml in the caller's working directory and the run ended in an
+# xmllint parser error naming nothing useful.
+
+NOMKTEMP_DIR="$TEST_TMP/nomktemp"
+mkdir -p "$NOMKTEMP_DIR"
+cat >"$NOMKTEMP_DIR/mktemp" <<'SHIM'
+#!/bin/sh
+echo "mktemp: mkstemp failed: Operation not permitted" >&2
+exit 1
+SHIM
+chmod +x "$NOMKTEMP_DIR/mktemp"
+
+# The test's own bookkeeping still needs a real mktemp, so shim only the child.
+run_jetpack_no_mktemp() {
+  local err_file
+  err_file=$(mktemp)
+  STDOUT=$(cd "$WORKDIR" && PATH="$NOMKTEMP_DIR:$PATH" "$ABS_JETPACK" "$@" 2>"$err_file")
+  STATUS=$?
+  STDERR=$(cat "$err_file")
+  rm -f "$err_file"
+}
+
+WORKDIR="$TEST_TMP/work"
+mkdir -p "$WORKDIR"
+# Absolute, because the runner above invokes jetpack from inside WORKDIR.
+ABS_JETPACK=$(cd "$(dirname "$BIN_JETPACK")" && pwd)/$(basename "$BIN_JETPACK")
+
+AGENT_OFFLINE=1 run_jetpack_no_mktemp version "$ARTIFACT" STABLE "$REPO_URL"
+assert_status "version succeeds offline with no writable temp dir" "$STATUS" 0
+assert_equals "it still answers from the cache" "$STDOUT" "1.4.0"
+
+if [[ -z "$(ls -A "$WORKDIR")" ]]; then
+  ok "nothing is written into the working directory"
+else
+  not_ok "nothing is written into the working directory" \
+    "Stray files: $(ls -A "$WORKDIR")"
+fi
+
+AGENT_OFFLINE=1 run_jetpack_no_mktemp list dependencies "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "list dependencies succeeds offline with no writable temp dir" "$STATUS" 0
+assert_contains "dependencies still come from the cached POM" "$STDOUT" \
+  "androidx.annotation:annotation:1.8.0 (compile)"
+
+# Without the cache to fall back on there is nowhere to put a response, and the
+# failure must name that rather than surfacing as a parse error further down.
+AGENT_OFFLINE=1 run_jetpack_no_mktemp version "$ARTIFACT" STABLE "$REPO_URL/missing"
+assert_status "an uncached URL with no temp dir fails" "$STATUS" 1
+assert_contains "the failure names the temporary directory" "$STDERR" \
+  "could not create a temporary file"
+assert_not_contains "no parser error leaks out instead" "$STDERR" "parser error"
+
+# source has to extract a JAR somewhere, so it cannot answer from the cache
+# alone -- but it must point at the switch that gives it a writable directory.
+AGENT_OFFLINE=1 run_jetpack_no_mktemp source "$ARTIFACT" 1.4.0 "$REPO_URL"
+assert_status "source fails with no writable temp dir" "$STATUS" 1
+assert_contains "source names --output as the way out" "$STDERR" "--output"

--- a/skills/jetpack/tests/test-jetpack-offline
+++ b/skills/jetpack/tests/test-jetpack-offline
@@ -24,7 +24,7 @@ REPO_URL="http://127.0.0.1:1/repo"
 ARTIFACT="androidx.wear.tiles:tiles"
 CACHED_DIR="$JETPACK_CACHE_DIR/http/127.0.0.1:1/repo/androidx/wear/tiles/tiles"
 
-TOTAL_TESTS=41
+TOTAL_TESTS=49
 TEST_NUM=0
 
 echo "1..$TOTAL_TESTS"
@@ -301,20 +301,22 @@ fi
 # maven-metadata.xml in the caller's working directory and the run ended in an
 # xmllint parser error naming nothing useful.
 
-NOMKTEMP_DIR="$TEST_TMP/nomktemp"
-mkdir -p "$NOMKTEMP_DIR"
-cat >"$NOMKTEMP_DIR/mktemp" <<'SHIM'
-#!/bin/sh
-echo "mktemp: mkstemp failed: Operation not permitted" >&2
-exit 1
-SHIM
-chmod +x "$NOMKTEMP_DIR/mktemp"
+# A real unwritable directory rather than a stubbed mktemp: the stub would fail
+# every allocation alike, and could not tell "the default temp directory is
+# unwritable" (which --output is supposed to rescue) from "no temporary is
+# obtainable anywhere". It also pins the reason make_temp passes an explicit
+# template -- BSD mktemp given none ignores TMPDIR and would quietly succeed in
+# Darwin's per-user temp directory, testing nothing.
+RO_TMPDIR="$TEST_TMP/readonly"
+mkdir -p "$RO_TMPDIR"
+chmod 500 "$RO_TMPDIR"
 
-# The test's own bookkeeping still needs a real mktemp, so shim only the child.
+# The test's own bookkeeping still needs a writable TMPDIR, so redirect only the
+# child's.
 run_jetpack_no_mktemp() {
   local err_file
   err_file=$(mktemp)
-  STDOUT=$(cd "$WORKDIR" && PATH="$NOMKTEMP_DIR:$PATH" "$ABS_JETPACK" "$@" 2>"$err_file")
+  STDOUT=$(cd "$WORKDIR" && TMPDIR="$RO_TMPDIR" "$ABS_JETPACK" "$@" 2>"$err_file")
   STATUS=$?
   STDERR=$(cat "$err_file")
   rm -f "$err_file"
@@ -341,10 +343,23 @@ assert_status "list dependencies succeeds offline with no writable temp dir" "$S
 assert_contains "dependencies still come from the cached POM" "$STDOUT" \
   "androidx.annotation:annotation:1.8.0 (compile)"
 
-# Without the cache to fall back on there is nowhere to put a response, and the
-# failure must name that rather than surfacing as a parse error further down.
+# An offline miss is decided before any body could arrive, so it must still
+# produce the cold-cache diagnostic and the command that warms it. Reporting a
+# missing temp directory instead would send the reader to fix the wrong thing.
 AGENT_OFFLINE=1 run_jetpack_no_mktemp version "$ARTIFACT" STABLE "$REPO_URL/missing"
 assert_status "an uncached URL with no temp dir fails" "$STATUS" 1
+assert_contains "the cold-cache error survives having nowhere to write" "$STDERR" \
+  "no cached copy of $REPO_URL/missing/androidx/wear/tiles/tiles/maven-metadata.xml"
+assert_contains "it still quotes the invocation to re-run online" "$STDERR" \
+  "jetpack version $ARTIFACT STABLE $REPO_URL/missing"
+assert_not_contains "the temp directory is not blamed for a decided miss" "$STDERR" \
+  "could not create a temporary file"
+assert_not_contains "no parser error leaks out instead" "$STDERR" "parser error"
+
+# Online, there really is nowhere to put the response, and that is what the
+# failure must name -- rather than surfacing as a parse error further down.
+run_jetpack_no_mktemp version "$ARTIFACT" STABLE "$REPO_URL"
+assert_status "an online fetch with no temp dir fails" "$STATUS" 1
 assert_contains "the failure names the temporary directory" "$STDERR" \
   "could not create a temporary file"
 assert_not_contains "no parser error leaks out instead" "$STDERR" "parser error"
@@ -354,3 +369,13 @@ assert_not_contains "no parser error leaks out instead" "$STDERR" "parser error"
 AGENT_OFFLINE=1 run_jetpack_no_mktemp source "$ARTIFACT" 1.4.0 "$REPO_URL"
 assert_status "source fails with no writable temp dir" "$STATUS" 1
 assert_contains "source names --output as the way out" "$STDERR" "--output"
+
+# ...and taking that advice has to work. --output is a writable directory even
+# when the default temp location is not, so the metadata fetched on the way
+# there must land in it rather than dying on the flag the caller just passed.
+run_jetpack_no_mktemp source "$ARTIFACT" 1.4.0 "$REPO_URL" --output "$TEST_TMP/out"
+assert_status "source with --output gets past temp allocation" "$STATUS" 1
+assert_not_contains "--output is honoured before any temporary is needed" "$STDERR" \
+  "could not create a temporary file"
+assert_contains "it fails on the network instead, having got that far" "$STDERR" \
+  "could not reach"


### PR DESCRIPTION
**Description:**
This PR improves the robustness of the `jetpack` script and introduces formal evaluation criteria. 

**Key Changes:**
- **Robust Offline Execution:** Fixes a bug where offline reads would fail if the system's default temporary directory (`/tmp`) wasn't writable. Caches are now read directly without unnecessary file allocations, and it properly falls back to the `--output` directory when temporary space is required.
- **Offline Tests:** Adds `test-jetpack-offline` regression tests to ensure the caching and temporary file logic remains stable.
- **Skill Evaluations:** Adds standard benchmarks, assertions, and grading oracles (`answer-names-added-symbols`) for the `jetpack` skill so it can be rigorously evaluated against `skill-eval-harness`.
- **Documentation:** Updates `TODO.md` and `SKILL.md` (refining trigger descriptions). Also adds `evals/README.md` with explicit instructions to temporarily use the `agy-adapter` fork of the harness until the Antigravity backend lands upstream.

***