### PR TITLE
fix(git): format the index in the node pre-commit hook

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,202 @@
 # TODO
 
+## Make installed git hooks propagate fixes and uninstall cleanly (2026-08-09)
+
+**Problem:** Three unrelated mechanisms install hooks, all three copy the
+hook file, and nothing detects that a copy has gone stale.
+
+- `init.templatedir` (`home/.gitconfig:123`) copies
+  `etc/git/templates/global/hooks/post-checkout` at clone time.
+- `bin/git-hooks-node` runs `git init --template=`, which only applies at
+  `git init`. An existing repository can never be updated by it, so the
+  pre-commit index fix (686f52d, PR #146) reaches no checkout that already
+  exists.
+- `bin/git-hooks-agent` installs through `git-hooks-multiplexer install`,
+  which does reach existing repositories but leaves a frozen `cp` of the
+  source.
+
+`git-hooks-multiplexer doctor` then tests only `-x` on the sub-hook, so a
+copy that is years out of date reports `ok`. `~/workspace/ptracker` and
+`~/workspace/inkyframe` are the live instance: both carry a diverged
+pre-commit hook, and no command in this repository can say so.
+
+Removal is all-or-nothing in the other direction. `bin/git-hooks-none` is
+`rm -rf "$(git rev-parse --git-dir)/hooks"`, which also deletes third-party
+hooks (the Gerrit hook that `git-hooks-gerrit` installs, husky), every
+`<hook>.d/` directory, and the `00-legacy` hook the multiplexer carefully
+preserved on install — with no confirmation and no way to drop one hook.
+
+Three mechanics were measured against git 2.43.0 on 2026-08-09, since the
+choice between copy and symlink turns on them:
+
+- `git init --template=` preserves a symlink verbatim, so a symlink in a
+  template only survives if its target is absolute.
+- A dangling symlink at `.git/hooks/pre-commit` is *silently skipped*: the
+  commit succeeded and exited 0. Moving or renaming `~/.dotfiles` would
+  therefore disable every symlinked hook with no signal.
+- A stub whose `exec` target is missing fails loudly — `exec: not found`,
+  exit 1, commit aborted.
+
+**Goal:** An installed hook should track its source in this repository, so
+that fixing a hook here fixes it everywhere it is installed without a
+manual re-copy; a hook whose source has gone away should fail loudly rather
+than quietly stop running; and removing one hook should leave every other
+hook alone. Part of making the hook system trustworthy enough to keep
+putting policy in it — the pre-commit fix showed that a bug in a hook is
+both easy to ship and, once copied, impossible to recall.
+
+**Criteria:**
+
+- Editing a hook source under `etc/git/` changes the behaviour of an
+  already-set-up repository with no re-install step.
+- A drifted or orphaned installation is a `doctor` finding that exits
+  non-zero; today a stale copy reports `ok`.
+- The node pre-commit hook can be installed into an existing repository
+  without `git init`.
+- Removing one managed hook leaves other managed hooks, third-party
+  sub-hooks and `00-legacy` in place; when the last managed sub-hook goes,
+  `00-legacy` is restored as the plain hook.
+- `tests/test-git-hooks-multiplexer` and `tests/test-git-hooks-agent` cover
+  install → drift → remove → restore.
+
+**Sketch:** The decision the evidence above points to is a *trampoline*: the
+installed file is a generated stub whose body is
+`exec <absolute path into this repo> "$@"`. It keeps a symlink's
+propagation without a symlink's silent-skip failure, and unlike a real
+symlink it survives `git init --template=` without an absolute path baked
+into a tracked file. This is not a new pattern —
+`etc/git/templates/global/hooks/post-checkout` is already exactly this,
+execing `$HOME/.dotfiles/bin/git-setup` — so the work is mostly applying it
+consistently, resolving the absolute path at install time rather than
+hardcoding `~/.dotfiles`.
+
+The second-order benefit is what makes drift detectable at all: a stub's
+content is generated and never changes, so `doctor` can compare it
+byte-for-byte, where a copy of a hook can only be compared against a moving
+target.
+
+Other findings worth keeping:
+
+- `git-hooks-multiplexer` bakes `$hook_name` into the body it generates.
+  Deriving the name from `basename "$0"` instead would make one generic
+  file serve every hook name (git invokes the hook by its own path, so both
+  `dirname "$0"` and `basename "$0"` still resolve correctly through a
+  stub), and the multiplexer itself then becomes a trampoline too.
+- Removal wants the `add`/`remove` pair from `cli-tools.md`:
+  `remove <hook> <key>` with an `rm` alias, plus a `clean` that drops only
+  managed hooks the way `permission clean` does. `git-hooks-none` can stay
+  as the nuclear option if it enumerates what it will delete and requires
+  `--force`.
+- Moving the node pre-commit hook onto the multiplexer retires
+  `git init --template=` for content hooks, and is what would make
+  ptracker and inkyframe fixable in place. `init.templatedir` then keeps
+  exactly one job: the clone-time post-checkout trampoline.
+- Six commands cover this one domain today (`git-hooks-agent`,
+  `-node`, `-gerrit`, `-none`, `-multiplexer`, plus the deprecated
+  `git-updatehooks` stub, which prints "use 'git init' instead"). That is
+  the hyphenated-command shape `cli-tools.md` says to avoid; a single
+  `git-hooks <verb>` manager is the Appendix A shape, with the current
+  names kept as aliases since `bin/git-setup`, `home/.gitconfig` and the
+  docs all reference them. Whether that consolidation belongs inside this
+  item or after it is open.
+- A `--copy` escape hatch is worth keeping for a machine that has no
+  dotfiles tree to point at.
+
+**Constraints:** A hook must never silently stop running — where loud
+failure and silent skip trade off, take loud failure. `rm .git/hooks/<name>`
+by hand must keep working as the documented escape hatch, and the
+`00-legacy` preservation contract must survive. If this tooling ever moves
+under a skill, `clean` and the `git-hooks-none` equivalent need declaring
+in that skill's `permissions/unsafe`; as `bin/` scripts they are not
+pre-approved today. Out of scope: `core.hooksPath` as a delivery mechanism,
+adopting a hook framework (husky, lefthook, pre-commit), and the read-only
+`git-hooks list` surface — this item only owes `doctor` the ability to see
+drift.
+
+## Auto-fix mechanically fixable commit messages (2026-08-09)
+
+**Problem:** `etc/git/templates/agent/hooks/commit-msg` checks four things —
+a Conventional Commits subject, a subject of 50 characters or fewer, a blank
+second line, and body/footer lines of 72 characters or fewer (the 50 and 72
+come from `skills/coding-standards/references/git.md:70-78`). Every
+violation exits 1 with the full list of errors.
+
+Rejection is the right answer for two of those four and the wrong answer for
+the other two. An over-long or non-conventional *subject* cannot be fixed
+without changing what it says, and it is the kind of defect a writer can see
+by eye. Body wrapping at 72 is neither: it is a deterministic,
+meaning-preserving transform that a writer — an agent especially — cannot do
+reliably by eye, and getting it wrong costs a full round trip in which the
+whole message is re-emitted and can be re-broken somewhere else.
+
+The hook already rewrites the message in place: it strips `Co-Authored-By:`,
+`TAG=` and `CONV=` trailers before validating. So rewriting is established
+here; wrapping is the case it does not yet cover.
+
+**Goal:** A commit whose only defects are mechanically fixable should be
+fixed and committed rather than rejected, with rejection reserved for
+defects whose repair would change meaning. Part of cutting the deterministic
+back-and-forth between agents and this hook without loosening the standard
+the hook enforces.
+
+**Criteria:**
+
+- Body and footer lines over 72 characters are rewrapped and the commit
+  proceeds; a subject over 50 characters, or one that is not Conventional
+  Commits, still exits 1.
+- Wrapping is idempotent: `wrap(wrap(x)) == wrap(x)`.
+- Fenced code blocks, indented blocks, table rows and the trailer block come
+  through byte-identical; a single token longer than 72 (a URL) is left
+  over-length rather than broken; list items keep their marker and gain a
+  hanging indent.
+- No character the author typed is changed other than line breaks and the
+  whitespace around them.
+- The hook reports on stderr what it rewrote.
+- `tests/test-git-hooks-agent` has a case for each of the above.
+
+**Sketch:** Running the hook under `uv run --script` is fine — the startup
+objection does not survive measurement. On 2026-08-09, warm `uv` cache: a
+PEP 723 script with no dependencies took ~40 ms, one with an `mdformat`
+dependency ~30 ms, plain `python3 -c pass` ~18 ms, and the current `/bin/sh`
+hook (which already spawns awk, grep and sed) ~24 ms.
+
+`mdformat` was then evaluated as the wrapper and should not be used.
+`mdformat.text(..., options={"wrap": 72})` does handle paragraphs, bullet
+hanging indents and fenced code correctly, but it is a Markdown formatter
+and a commit message is not Markdown. On a fixture of realistic commit
+prose it escaped `5*3` to `5\*3` and `*.ts` to `\*.ts` — inserting
+backslashes that `git log` renders literally — rewrote an indented block as
+a fenced one, and joined a trailer block into a single paragraph.
+`mdformat --help` offers no escape-free mode; the escaping is part of its
+round-trip guarantee, so it cannot be configured away.
+
+The standard library covers it instead. A 57-line prototype that classifies
+each line (fence, verbatim, blank, trailer, bullet, prose), joins runs of
+prose, and calls `textwrap.wrap(..., break_long_words=False,
+break_on_hyphens=False)` with `initial_indent`/`subsequent_indent` for
+bullets produced correct output on both the commit-message and hazard
+fixtures, and was idempotent on both. Being dependency-free also shrinks the
+cold-start risk noted in Constraints.
+
+Whatever does the wrapping, the trailer block has to be excluded from it —
+that was mdformat's worst failure and a hand-rolled wrapper can make it just
+as easily. `git interpret-trailers --parse` is the authoritative splitter and
+the hook is already in the business of manipulating trailers.
+
+An opt-out belongs on `git config hooks.commitMsgWrap`, matching the
+`hooks.preCommitRegexp` precedent already sitting in `home/.gitconfig:117`.
+
+**Constraints:** Any rewrite must be announced on stderr; silently rewriting
+the author's text is precisely the failure PR #146 removed from the
+pre-commit hook, and it would be worse here because the author never sees
+the file again. Keep the dependency list empty: a commit hook that resolves
+dependencies cannot commit on a cold `uv` cache with no network, and
+`caching.md` already records that `uv run --script` resolves before the
+script can check `AGENT_OFFLINE` — even a stdlib-only script may make `uv`
+fetch an interpreter, so decide what the hook does when `uv` itself fails.
+Do not share library code with `bin/markdown-format`. The 50 and 72 numbers
+are `git.md`'s to change, not this item's.
+
 ## Fix the node pre-commit hook's staged-file handling (2026-08-05) — done
 
 The third sketched approach won: `etc/git/templates/node/hooks/pre-commit` now

--- a/TODO.md
+++ b/TODO.md
@@ -1,76 +1,69 @@
 # TODO
 
-## Fix the node pre-commit hook's staged-file handling (2026-08-05)
+## Fix the node pre-commit hook's staged-file handling (2026-08-05) — done
 
-**Problem:** `etc/git/templates/node/hooks/pre-commit` formats staged `.ts` and
-`.md` files with `prettier --write`, then runs `git add` on the same paths.
-`git add` re-stages each file from the working tree, so what lands in the index
-is whatever the working tree holds — not the staged content the hook just
-formatted. Those agree only when the file has no unstaged changes.
+The third sketched approach won: `etc/git/templates/node/hooks/pre-commit` now
+formats the *index* and never re-adds from the working tree. For each staged
+`.ts`/`.md` path it reads the staged blob (`git ls-files --stage` for the mode
+and sha, `git cat-file blob` for the content), pipes it through
+`prettier --stdin-filepath "$path"`, and stages the result with
+`git hash-object -w` plus `git update-index --cacheinfo`. The working tree is
+never read to decide what to commit, which is what the three reproductions all
+came down to.
 
-Three reproductions, run 2026-08-05 against throwaway repositories with the hook
-installed:
+The cheaper "skip partially staged files" option was rejected because it cannot
+meet the second criterion: a staged edit to a file deleted from the working tree
+*is* a partially staged file, and skipping it either commits it unformatted or
+refuses, where the criterion asks for the edit to be committed. It also answers
+`git add -p` — the workflow the bug targets — with a refusal rather than with a
+formatted commit, which is the whole point of having the hook.
 
-- A partially staged file commits its unstaged changes too. With
-  `export const a = 2;` staged and `export const SECRET = "unstaged work";` left
-  unstaged, the commit contained both lines, with nothing printed.
-- A staged edit becomes a deletion when the file is missing from the working
-  tree. Staging a change and then removing the file produced
-  `1 file changed, 1 deletion(-)` and `delete mode 100644 g.ts` rather than the
-  staged edit.
-- A path containing a space aborts the commit. `xargs` splits `my notes.md` into
-  two arguments, `git add` exits non-zero with
-  `fatal: pathspec 'my' did not match any files`, and the hook's non-zero status
-  stops the commit.
+Formatting happens in two passes: pass one formats every blob into a temp
+directory, pass two stages the results. Nothing reaches the index unless every
+file formatted successfully, so a missing or failing formatter aborts the commit
+with the index exactly as the author staged it. `prettier` is resolved as
+`npx --no-install prettier` first and a global `prettier` second — the template
+now matches what the two installed copies actually do — and the commit fails
+outright when neither exists, rather than the old behaviour of silently
+re-staging without ever formatting.
 
-The `git add` also runs whether or not prettier did. In the test repository
-`prettier` was not on `PATH`, `xargs` reported
-`prettier: No such file or directory`, and the commit still proceeded and still
-absorbed the unstaged line. The template invokes bare `prettier`, so on a
-machine with no global install it re-stages without ever formatting; the two
-installed copies invoke `npx --no-install prettier` and do format.
+The working tree still gets the formatting, but only where it is safe to give
+it: when `git diff --quiet` says the file matches what was staged, the hook runs
+`git checkout-index -f` after updating the index, so smudge filters apply and
+the tree stays consistent. Where the tree carries unstaged work (or the file is
+gone), it is left untouched and the hook says so on stderr. That closes the
+"working tree still holds the unformatted text" cost the sketch attached to this
+approach for every case except the one where the alternative is destroying
+someone's edits.
 
-**Goal:** A commit should contain what was staged. The hook may add formatting
-of that content, but it must not enrol changes the author did not stage, and it
-must not turn an edit into a deletion. `git add -p` is the workflow this breaks,
-and it breaks it silently, which is what makes the result easy to push before
-anyone notices.
+Four smaller things fell out along the way. Paths are read `-z` from
+`git diff --cached --name-only` into a bash array and never passed through
+`xargs`, so a space is just a character. Pathspecs are `:(literal)` (git 1.9+):
+without it, staging both `a1.ts` and `a[1].ts` makes the bracketed path's
+pathspec match its sibling, and the sibling's content gets staged under the
+wrong name — a corruption worse than the one being fixed, and now test 9.
+Symlinks (120000) and gitlinks (160000) are skipped, since running a symlink's
+target text through a markdown formatter is not formatting. And empty formatter
+output for non-empty input is treated as a failure, so a `.prettierignore`d path
+cannot blank a file. Unmerged paths never arrive: `--diff-filter=ACMR` excludes
+them.
 
-**Criteria:** With the hook installed: a repository with one hunk staged and
-another left unstaged commits only the staged hunk; a staged edit to a file
-deleted from the working tree commits the edit; a staged path containing a space
-commits without aborting. A formatter that is absent or fails leaves the index
-untouched and fails the commit rather than passing it through.
+`tests/test-git-hooks-node` covers all of it in 10 hermetic cases — the three
+reproductions, the four failure modes, and the three edge cases above. The hook
+runs with `PATH` pointing at a directory holding symlinks to the handful of
+commands it needs plus a stub formatter (quotes normalised, trailing whitespace
+stripped, so "formatted" is observable), which means no case can reach a real
+prettier or the network, and the absent-formatter case is genuinely absent
+rather than stubbed to fail. Separately verified by hand against real prettier
+3.8.1: the partially staged commit contains only the staged hunk, the deleted
+file's staged edit commits as an edit, and `my notes.md` commits.
 
-**Sketch:** Four approaches, in rough order of cost:
-
-- Skip files that are partially staged — intersect
-  `git diff --cached --name-only` with `git diff --name-only` and warn instead
-  of formatting for files in both. For every other file the current re-add is
-  already safe, since index and working tree agree. About six lines and no new
-  machinery; pairing it with `prettier --check` on the skipped files keeps those
-  from being committed unformatted.
-- Check without fixing — run `prettier --check` over the staged content and
-  abort with instructions. Cannot corrupt the index at all, at the cost of a
-  manual format-and-restage round trip.
-- Format the index rather than the working tree — `git show :path` into the
-  formatter, `git hash-object -w`, `git update-index --cacheinfo`. Correct and
-  leaves the working tree alone, at the price of plumbing and a working tree
-  that still holds the unformatted text.
-- Stash the unstaged remainder around the format step, as lint-staged does. Also
-  correct, but a `stash pop` can conflict when formatting touches lines being
-  edited, and an interrupted hook strands work in a stash. This is most of why
-  lint-staged is as large as it is.
-
-Independent of that choice: pass the path list with `-z` and `xargs -0`, and
-make the hook fail when the formatter fails.
-
-**Constraints:** Hooks here are copied, not linked — `init.templatedir` points
-at `templates/global`, which carries only `post-checkout`, so this one was
-installed by hand. `~/workspace/ptracker` and `~/workspace/inkyframe` hold
-diverged copies (both the `npx --no-install` variant), and fixing the template
-updates neither. Prefer a fix small enough to stay readable inside a hook;
-adopting lint-staged is out of scope.
+Not done: `~/workspace/ptracker` and `~/workspace/inkyframe` still hold the old
+copies. Hooks here are copied rather than linked, so both need a manual re-copy;
+nothing in this repository can detect or fix that. Bash 3.2 was not verified
+against a real 3.2 build (none available in the sandbox this ran in) — the hook
+uses no 4.x feature, and the one 3.2 parser trap on record, a here-document
+inside a command substitution, does not appear in it.
 
 ## Measure and extend the Jetpack source-history evals (2026-08-04)
 

--- a/etc/git/templates/node/hooks/pre-commit
+++ b/etc/git/templates/node/hooks/pre-commit
@@ -1,10 +1,102 @@
 #!/bin/bash
 
-# Format staged files before commit
+# Tests: tests/test-git-hooks-node
 
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|md)$')
+# Format the staged content of .ts and .md files with prettier.
+#
+# The formatter reads each file's staged blob and the result is written back
+# into the index directly, so a commit contains exactly what was staged plus
+# formatting. Re-adding from the working tree (the obvious implementation)
+# would instead enrol unstaged edits, or turn a staged edit into a deletion
+# when the file is gone from the working tree.
 
-if [ -n "$STAGED_FILES" ]; then
-  echo "$STAGED_FILES" | xargs prettier --write --log-level warn
-  echo "$STAGED_FILES" | xargs git add
+set -euo pipefail
+
+hook=$(basename "$0")
+
+die() {
+  echo "$hook: $*" >&2
+  exit 1
+}
+
+# NUL-delimited: paths may contain spaces.
+paths=()
+while IFS= read -r -d '' path; do
+  case $path in
+    *.ts | *.md) paths+=("$path") ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ ${#paths[@]} -eq 0 ]; then
+  exit 0
 fi
+
+# Prefer the project's own prettier over a global install.
+if npx --no-install prettier --version >/dev/null 2>&1; then
+  prettier=(npx --no-install prettier)
+elif command -v prettier >/dev/null 2>&1; then
+  prettier=(prettier)
+else
+  die "prettier not found (tried 'npx --no-install prettier' and 'prettier' on PATH)"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+# Pass 1: format every staged blob into $tmpdir. Nothing is written back until
+# all of them succeed, so a formatter that is missing or fails leaves the index
+# as the author staged it.
+formatted_paths=()
+modes=()
+blobs=()
+for path in "${paths[@]}"; do
+  # :(literal) so a path containing glob characters resolves to itself.
+  entry=$(git ls-files --stage -- ":(literal)$path")
+  read -r mode blob _ <<<"$entry"
+
+  # Symlinks (120000) and submodules (160000) hold no source to format.
+  case $mode in
+    100644 | 100755) ;;
+    *) continue ;;
+  esac
+
+  i=${#formatted_paths[@]}
+  if ! git cat-file blob "$blob" |
+    "${prettier[@]}" --stdin-filepath "$path" --log-level warn >"$tmpdir/$i"; then
+    die "prettier failed on $path; index left unchanged"
+  fi
+  # A .prettierignore'd path or an unknown parser must not blank the file.
+  if [ ! -s "$tmpdir/$i" ] && [ -n "$(git cat-file blob "$blob")" ]; then
+    die "prettier produced no output for $path; index left unchanged"
+  fi
+
+  formatted_paths[i]=$path
+  modes[i]=$mode
+  blobs[i]=$blob
+done
+
+if [ ${#formatted_paths[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# Pass 2: stage the formatted content.
+i=0
+for path in "${formatted_paths[@]}"; do
+  formatted=$(git hash-object -w -- "$tmpdir/$i")
+  if [ "$formatted" != "${blobs[i]}" ]; then
+    # Mirror the formatting into the working tree only where it still holds
+    # exactly what was staged; anywhere else it carries edits of the author's.
+    sync_worktree=no
+    if git diff --quiet -- ":(literal)$path"; then
+      sync_worktree=yes
+    fi
+
+    git update-index --cacheinfo "${modes[i]},$formatted,$path"
+    if [ "$sync_worktree" = yes ]; then
+      git checkout-index -f -- "$path"
+    else
+      echo "$hook: formatted the staged content of $path (working tree left alone)" >&2
+    fi
+  fi
+  i=$((i + 1))
+done

--- a/tests/test-git-hooks-node
+++ b/tests/test-git-hooks-node
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+# Tests: tests/test-git-hooks-node
+
+set -u
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+HOOK="$DIR/../etc/git/templates/node/hooks/pre-commit"
+
+# Isolate from the user's/system git config (signing, hooks, templates).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+WORK=$(mktemp -d "/tmp/git-hooks-node-test.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# The hook runs with PATH pointing at this directory alone, so it can only ever
+# reach the prettier stub a test installs — never a real prettier on the host.
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+for cmd in git bash sh sed cat rm mktemp basename dirname grep; do
+  ln -s "$(command -v "$cmd")" "$BIN/$cmd"
+done
+
+# Stand-in for prettier: normalises quotes and strips trailing whitespace, so
+# "formatted" is observable without depending on a real prettier being present.
+stub_prettier() {
+  printf '%s\n' '#!/bin/sh' "$@" >"$BIN/prettier"
+  chmod +x "$BIN/prettier"
+}
+
+formatter_ok() { stub_prettier 'exec sed -e "s/'\''/\"/g" -e "s/[[:space:]]*\$//"'; }
+formatter_fails() { stub_prettier 'cat >/dev/null' 'exit 2'; }
+formatter_silent() { stub_prettier 'exec cat >/dev/null'; }
+formatter_absent() { rm -f "$BIN/prettier"; }
+
+new_repo() {
+  local repo="$WORK/$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" config commit.gpgsign false
+  cp "$HOOK" "$repo/.git/hooks/pre-commit"
+  chmod +x "$repo/.git/hooks/pre-commit"
+  printf '%s\n' "$repo"
+}
+
+commit() { # commit REPO MESSAGE -- runs with the restricted PATH
+  local repo=$1 msg=$2
+  PATH="$BIN" git -C "$repo" commit -q -m "$msg"
+}
+
+echo "1..10"
+
+# Test 1: a fully staged file is formatted in both the commit and the tree
+formatter_ok
+REPO=$(new_repo format)
+printf "export const a = 'x';   \n" >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+if commit "$REPO" add >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show HEAD:a.ts)" = 'export const a = "x";' ] &&
+  [ "$(cat "$REPO/a.ts")" = 'export const a = "x";' ]; then
+  echo "ok 1 - staged file is formatted in the commit and the working tree"
+else
+  echo "not ok 1 - formatting did not reach the commit or the working tree"
+fi
+
+# Test 2: a partially staged file commits only the staged hunk
+formatter_ok
+REPO=$(new_repo partial)
+printf 'export const a = 1;\n' >"$REPO/f.ts"
+git -C "$REPO" add f.ts
+commit "$REPO" initial >/dev/null 2>&1
+printf "export const a = 2;   \n" >"$REPO/f.ts"
+git -C "$REPO" add f.ts
+printf "export const a = 2;\nexport const SECRET = 'unstaged work';\n" >"$REPO/f.ts"
+if commit "$REPO" staged-only >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show HEAD:f.ts)" = 'export const a = 2;' ] &&
+  grep -q 'SECRET' "$REPO/f.ts"; then
+  echo "ok 2 - only the staged hunk is committed, unstaged work stays in the tree"
+else
+  echo "not ok 2 - unstaged work leaked into the commit or was destroyed"
+fi
+
+# Test 3: a staged edit survives the file being deleted from the working tree
+formatter_ok
+REPO=$(new_repo deleted)
+printf 'export const g = 1;\n' >"$REPO/g.ts"
+git -C "$REPO" add g.ts
+commit "$REPO" initial >/dev/null 2>&1
+printf "export const g = 2;   \n" >"$REPO/g.ts"
+git -C "$REPO" add g.ts
+rm "$REPO/g.ts"
+if commit "$REPO" edit >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show HEAD:g.ts)" = 'export const g = 2;' ]; then
+  echo "ok 3 - staged edit is committed even when the file is gone from the tree"
+else
+  echo "not ok 3 - staged edit was turned into a deletion or lost"
+fi
+
+# Test 4: a path containing a space does not abort the commit
+formatter_ok
+REPO=$(new_repo spaces)
+printf '# Title   \n' >"$REPO/my notes.md"
+git -C "$REPO" add "my notes.md"
+if commit "$REPO" spaced >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show "HEAD:my notes.md")" = '# Title' ]; then
+  echo "ok 4 - a staged path containing a space is formatted and committed"
+else
+  echo "not ok 4 - a path containing a space aborted the commit"
+fi
+
+# Test 5: a missing formatter fails the commit and leaves the index alone
+formatter_ok
+REPO=$(new_repo missing)
+printf 'export const a = 1;\n' >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+commit "$REPO" initial >/dev/null 2>&1
+formatter_absent
+HEAD_BEFORE=$(git -C "$REPO" rev-parse HEAD)
+printf "export const a = 'x';   \n" >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+if ! commit "$REPO" nope >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" rev-parse HEAD)" = "$HEAD_BEFORE" ] &&
+  [ "$(git -C "$REPO" show :a.ts)" = "export const a = 'x';   " ]; then
+  echo "ok 5 - a missing formatter fails the commit with the index untouched"
+else
+  echo "not ok 5 - a missing formatter did not stop the commit cleanly"
+fi
+
+# Test 6: a failing formatter fails the commit and leaves the index alone
+formatter_fails
+REPO=$(new_repo failing)
+printf 'export const a = 1;\n' >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+formatter_ok
+commit "$REPO" initial >/dev/null 2>&1
+formatter_fails
+HEAD_BEFORE=$(git -C "$REPO" rev-parse HEAD)
+printf "export const a = 'x';   \n" >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+if ! commit "$REPO" nope >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" rev-parse HEAD)" = "$HEAD_BEFORE" ] &&
+  [ "$(git -C "$REPO" show :a.ts)" = "export const a = 'x';   " ]; then
+  echo "ok 6 - a failing formatter fails the commit with the index untouched"
+else
+  echo "not ok 6 - a failing formatter did not stop the commit cleanly"
+fi
+
+# Test 7: a formatter that emits nothing must not blank the staged file
+formatter_silent
+REPO=$(new_repo silent)
+printf "export const a = 'x';\n" >"$REPO/a.ts"
+git -C "$REPO" add a.ts
+if ! commit "$REPO" empty >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show :a.ts)" = "export const a = 'x';" ]; then
+  echo "ok 7 - empty formatter output fails the commit instead of blanking the file"
+else
+  echo "not ok 7 - empty formatter output reached the index"
+fi
+
+# Test 8: files the hook does not format are committed untouched
+formatter_ok
+REPO=$(new_repo other)
+printf "notes = 'x';   \n" >"$REPO/a.txt"
+git -C "$REPO" add a.txt
+if commit "$REPO" other >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show HEAD:a.txt)" = "notes = 'x';   " ]; then
+  echo "ok 8 - non-ts/md files are committed without formatting"
+else
+  echo "not ok 8 - a file outside the hook's scope was altered"
+fi
+
+# Test 9: a path containing glob characters resolves to itself, not to the
+# sibling its wildcards would match
+formatter_ok
+REPO=$(new_repo globby)
+printf "export const bracketed = 'x';   \n" >"$REPO/a[1].ts"
+printf "export const plain = 'y';   \n" >"$REPO/a1.ts"
+git -C "$REPO" add "a[1].ts" a1.ts
+if commit "$REPO" globby >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show "HEAD:a[1].ts")" = 'export const bracketed = "x";' ] &&
+  [ "$(git -C "$REPO" show HEAD:a1.ts)" = 'export const plain = "y";' ]; then
+  echo "ok 9 - a staged path containing glob characters keeps its own content"
+else
+  echo "not ok 9 - a glob-matching sibling's content was staged under the wrong path"
+fi
+
+# Test 10: a staged symlink keeps its target instead of being formatted
+formatter_ok
+REPO=$(new_repo symlink)
+printf '# Real   \n' >"$REPO/real.md"
+ln -s "real.md" "$REPO/link.md"
+git -C "$REPO" add real.md link.md
+if commit "$REPO" symlink >/dev/null 2>&1 &&
+  [ "$(git -C "$REPO" show HEAD:link.md)" = 'real.md' ] &&
+  [ "$(git -C "$REPO" ls-tree HEAD link.md | cut -d' ' -f1)" = '120000' ] &&
+  [ "$(git -C "$REPO" show HEAD:real.md)" = '# Real' ]; then
+  echo "ok 10 - a staged symlink is left alone while its neighbour is formatted"
+else
+  echo "not ok 10 - a symlink's target text was run through the formatter"
+fi


### PR DESCRIPTION
Fixes the TODO item "Fix the node pre-commit hook's staged-file handling
(2026-08-05)", which is rewritten in `TODO.md` as a `— done` entry.

## The bug

`etc/git/templates/node/hooks/pre-commit` ran `prettier --write` on the
staged paths and then `git add` on the same paths. `git add` re-stages from
the **working tree**, so a commit contained whatever the tree held rather
than what was staged. The two agree only when a file has no unstaged
changes, which produced three failures:

- a partially staged file committed its unstaged hunks too, silently —
  `git add -p` is the workflow this breaks;
- a staged edit to a file deleted from the working tree committed as a
  deletion;
- a path containing a space aborted the commit, because `xargs` split
  `my notes.md` into two arguments.

The `git add` also ran whether or not prettier did, so on a machine with no
global `prettier` the hook re-staged without ever formatting.

## The fix

Format the index instead of the working tree: `git cat-file blob` into
`prettier --stdin-filepath`, then `git hash-object -w` and
`git update-index --cacheinfo`. The working tree is never consulted to
decide what to commit.

The cheaper "skip partially staged files" option was rejected because it
cannot meet the second criterion — a staged edit to a file deleted from the
tree *is* a partially staged file, so skipping it either commits it
unformatted or refuses, where the criterion asks for the edit to be
committed. It also answers `git add -p` with a refusal rather than a
formatted commit.

Formatting still reaches the working tree where that is safe: when
`git diff --quiet` says the file matches what was staged, the hook runs
`git checkout-index -f` after updating the index, so smudge filters apply.
Where the tree carries unstaged work (or the file is gone) it is left
untouched and the hook says so on stderr.

Other changes in the same rewrite:

- Two passes — nothing reaches the index until every file has formatted, so
  a formatter that is missing or fails aborts the commit with the index
  exactly as the author staged it, rather than passing the commit through.
- `prettier` resolves as `npx --no-install prettier` first and a global
  `prettier` second, matching what the installed copies of this hook
  already do; the commit fails outright when neither exists.
- Paths come from `git diff --cached --name-only -z` into a bash array, with
  no `xargs`.
- Pathspecs are `:(literal)`. Without it, staging both `a1.ts` and
  `a[1].ts` makes the bracketed path's pathspec match its sibling and the
  sibling's content gets staged under the wrong name.
- Symlinks (120000) and gitlinks (160000) are skipped — a symlink's target
  text is not source to format.
- Empty formatter output for non-empty input is a failure, so a
  `.prettierignore`d path cannot blank a file.

## Testing

New `tests/test-git-hooks-node`: 10 hermetic TAP cases covering the three
reproductions, the four failure modes, and the three edge cases above. The
hook runs with `PATH` pointing at a directory holding symlinks to the few
commands it needs plus a stub formatter, so no case can reach a real
prettier or the network, and the absent-formatter case is genuinely absent
rather than stubbed to fail. Tests 9 and 10 were each confirmed to fail
against the un-hardened version.

Also verified by hand against real prettier 3.8.1: the partially staged
commit contains only the staged hunk, the deleted file's staged edit
commits as an edit, and `my notes.md` commits.

`tests/test-git-hooks-agent` and `tests/test-git-hooks-multiplexer` still
pass. CI's `test` job runs `prove tests/test-*`, so the new suite is
covered there and is green on this commit. CI's lint globs are a different
matter — `shellcheck-shfmt` covers `bin/`, `skills/*/scripts/`,
`etc/macos/apply-defaults` and `install.sh`, so neither `etc/git/templates/`
nor `tests/` is linted; both new files were checked locally against the
same versions CI uses (`shellcheck` 0.11.0, `shfmt -d -i 2 -ci`) and are
clean.

## Not covered

`~/workspace/ptracker` and `~/workspace/inkyframe` still hold diverged
copies of this hook. Hooks here are copied rather than linked
(`bin/git-hooks-node` works via `git init --template=`, which only applies
at `git init`), so both need a manual re-copy; nothing in this repository
can detect or fix that. Bash 3.2 was not verified against a real 3.2 build
— the hook uses no 4.x feature, and the one 3.2 parser trap on record, a
here-document inside a command substitution, does not appear in it.

## Also in this PR (`1c66dec`, `TODO.md` only)

Two new TODO items came out of studying the hook system after the fix
above, and are docs-only:

- **Make installed git hooks propagate fixes and uninstall cleanly** — all
  three install paths copy the hook file and no `doctor` can see a stale
  copy, which is why ptracker and inkyframe are stuck. Records the
  measurements behind preferring a generated trampoline to a symlink (a
  dangling symlink hook is silently skipped and the commit succeeds; a stub
  with a missing `exec` target aborts it) and the case for granular removal
  next to today's `rm -rf` of the whole hooks directory.
- **Auto-fix mechanically fixable commit messages** — rewrap over-long body
  lines rather than rejecting the commit, keeping rejection for subject
  defects that cannot be repaired without changing meaning. Records that
  `uv run --script` startup is ~30–40 ms warm (comparable to the current sh
  hook) and that `mdformat` is unsuitable for commit messages despite being
  the house Markdown formatter, since it escapes literal `*` into prose,
  re-fences indented blocks and joins trailer blocks.

Happy to split these onto their own branch if you'd rather keep this PR to
the hook fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKno3k4zYPQpwMf3jDHDiy