### PR TITLE
ci(lint): cap job runtime with timeout-minutes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
     # (which do not trigger push here) need the pull_request run.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -43,6 +44,7 @@ jobs:
     # (which do not trigger push here) need the pull_request run.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -63,6 +65,7 @@ jobs:
     # (which do not trigger push here) need the pull_request run.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -90,6 +93,7 @@ jobs:
     # (which do not trigger push here) need the pull_request run.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Run 31909157955's shellcheck-shfmt job hung on "sudo apt-get install -y
shfmt" (a transient apt/dpkg-lock stall) for the full 6-hour default job
timeout before GitHub force-cancelled it. Bound every lint job to 10
minutes so a future hang fails fast instead of burning hours of runner
time.