### PR TITLE
fix(caxton): block case aliases of git metadata

### DIFF
--- a/skills/agent-tools/scripts/caxton
+++ b/skills/agent-tools/scripts/caxton
@@ -673,7 +673,12 @@ def in_repository_metadata(rel: str) -> bool:
     command. Nesting matters as much as the root, since 'sub/.git' is another
     repository's metadata.
     """
-    return ".git" in (rel.split("/") if rel else [])
+    # APFS commonly uses a case-insensitive view of the worktree.  On such a
+    # filesystem, `.GIT/config` and `.git/config` name the same file even
+    # though realpath is not required to normalize the spelling supplied by
+    # the caller.  Match case-insensitively so an alternate spelling cannot
+    # bypass the metadata boundary on supported macOS systems.
+    return any(part.casefold() == ".git" for part in rel.split("/"))
 
 
 def unrestorable_creations(root: Path, created: list[str]) -> list[str]:

--- a/skills/agent-tools/tests/test-caxton
+++ b/skills/agent-tools/tests/test-caxton
@@ -1243,7 +1243,9 @@ exec(compile(stripped, "caxton", "exec"), cx)
 blocks = cx["in_repository_metadata"]
 cases = {
     ".git/hooks/pre-commit": True,
+    ".GIT/config": True,
     ".git": True,
+    "sub/.Git/hooks/post-checkout": True,
     "sub/.git/config": True,
     ".github/ci.yml": False,
     ".gitignore": False,


### PR DESCRIPTION
### Motivation

- On case-insensitive filesystems (e.g. APFS on macOS) an alternate spelling like `.GIT/config` could refer to the same file as `.git/config`, allowing a metadata-boundary bypass. 
- The repository metadata boundary must be robust to such aliases so Caxton never treats git internals as project content or creation roots.

### Description

- Make `in_repository_metadata` check repository metadata case-insensitively by testing `part.casefold() == ".git"` for every path component, preventing mixed-case aliases from bypassing the rule (change in `skills/agent-tools/scripts/caxton`).
- Add regression coverage for uppercase and mixed-case metadata paths to `skills/agent-tools/tests/test-caxton` so `.GIT/config` and `sub/.Git/...` variants are asserted as metadata.
- Changes are limited to the metadata detection and tests that validate it.

### Testing

- Ran the caxton skill test script for the agent-tools skill (`skills/agent-tools/tests/test-caxton`) and verified the metadata-guard assertions for `.git`, `.GIT`, and mixed-case nested metadata passed in the exercised checks. 
- Ran linters and checks: `ruff check` and `ruff format --check` completed with no failures. 
- Verified bytecode compilation with `python3 -m py_compile skills/agent-tools/scripts/caxton` and ran `bin/command-index-sync --check --all` and `git diff --check`, all of which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85bf4552448321abf17fa0e2236df9)