### PR TITLE
agent-tools: stabilize benchmarker teardown and fix ruff B905

### DIFF
--- a/skills/agent-tools/scripts/benchmarker
+++ b/skills/agent-tools/scripts/benchmarker
@@ -262,30 +262,29 @@ async def teardown_process_group(
     pgid: int, proc: asyncio.subprocess.Process, grace_period: float = 1.5
 ) -> None:
     """Gracefully escalates process group termination from SIGTERM to SIGKILL."""
-    if proc.returncode is not None:
-        return
-
     try:
         os.killpg(pgid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         return
 
     async def _escalate_to_kill() -> None:
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=grace_period)
-        except (asyncio.TimeoutError, TimeoutError, asyncio.CancelledError):
-            if proc.returncode is None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(pgid, signal.SIGKILL)
+        deadline = asyncio.get_running_loop().time() + grace_period
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                os.killpg(pgid, 0)
+            except (ProcessLookupError, PermissionError):
+                return
+            await asyncio.sleep(0.05)
+
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
 
     with contextlib.suppress(asyncio.CancelledError):
         await asyncio.shield(_escalate_to_kill())
 
     if proc.returncode is None:
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
+        with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError):
+            await asyncio.wait_for(proc.wait(), timeout=0.5)
 
 
 def safe_int(val: Any) -> int | None:
@@ -910,7 +909,7 @@ async def async_main() -> int:
 
     for task in tasks:
         for comb in combinations:
-            param_dict = dict(zip(dim_names, comb))
+            param_dict = dict(zip(dim_names, comb, strict=True))
             if task:
                 param_dict["task"] = task.name
             for trial in range(1, args.trials + 1):


### PR DESCRIPTION
### Motivation
- Recent CI runs failed because ruff reported `B905` for a `zip()` call without an explicit `strict=` and the benchmarker tests intermittently lost telemetry on timeouts due to process-group teardown not waiting for child cleanup handlers.
- The goal is to make benchmarker tests deterministic and compliant with lint rules so the lint/test workflow reliably passes.

### Description
- Add `strict=True` to the Cartesian-product pairing call to satisfy ruff's `B905` (`param_dict = dict(zip(dim_names, comb, strict=True))`).
- Improve `teardown_process_group` to monitor the entire process group during the grace period, poll for group liveness, send `SIGKILL` only after the grace window, and wait briefly for the subprocess to be reaped to ensure child cleanup handlers can flush telemetry.
- Change teardown to avoid prematurely returning and to use `asyncio.shield`/`wait_for` patterns so telemetry persistence is hit reliably on timeout.
- Keep existing behavior for safe telemetry parsing and index writing while ensuring the new teardown flow preserves telemetry files written by child cleanup handlers.

### Testing
- Ran lint/format checks with `skills/coding-standards/scripts/python-format --check` which passed for the modified file.
- Ran the benchmarker TAP suite with `prove -v skills/agent-tools/tests/test-benchmarker` and it passed all tests (15/15).
- Ran the repo lint/test workflow commands locally (`shellcheck`, `shfmt`, `prove -j $(nproc) tests/test-* skills/*/tests/test-*`); linters and the repaired benchmarker suite passed, while the full test run exposed unrelated, pre-existing failures in `jetpack` and `skill-plugin` test suites which are out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87c6f4885483218bf72da9a8c3ebbb)