### PR TITLE
Improve process group termination detection and cleanup

### DIFF
--- a/skills/agent-tools/scripts/benchmarker
+++ b/skills/agent-tools/scripts/benchmarker
@@ -262,30 +262,29 @@ async def teardown_process_group(
     pgid: int, proc: asyncio.subprocess.Process, grace_period: float = 1.5
 ) -> None:
     """Gracefully escalates process group termination from SIGTERM to SIGKILL."""
-    if proc.returncode is not None:
-        return
-
     try:
         os.killpg(pgid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         return
 
     async def _escalate_to_kill() -> None:
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=grace_period)
-        except (asyncio.TimeoutError, TimeoutError, asyncio.CancelledError):
-            if proc.returncode is None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(pgid, signal.SIGKILL)
+        deadline = asyncio.get_running_loop().time() + grace_period
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                os.killpg(pgid, 0)
+            except (ProcessLookupError, PermissionError):
+                return
+            await asyncio.sleep(0.05)
+
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
 
     with contextlib.suppress(asyncio.CancelledError):
         await asyncio.shield(_escalate_to_kill())
 
     if proc.returncode is None:
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
+        with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError):
+            await asyncio.wait_for(proc.wait(), timeout=0.5)
 
 
 def safe_int(val: Any) -> int | None:
@@ -910,7 +909,7 @@ async def async_main() -> int:
 
     for task in tasks:
         for comb in combinations:
-            param_dict = dict(zip(dim_names, comb))
+            param_dict = dict(zip(dim_names, comb, strict=True))
             if task:
                 param_dict["task"] = task.name
             for trial in range(1, args.trials + 1):

--- a/skills/agent-tools/scripts/benchmarker
+++ b/skills/agent-tools/scripts/benchmarker
@@ -258,6 +258,41 @@ async def drain_stream(stream: asyncio.StreamReader | None) -> bytes:
     return bytes(buf)
 
 
+def group_has_live_member(pgid: int) -> bool:
+    """Reports whether a process group still holds a member that has not yet exited.
+
+    ``killpg(pgid, 0)`` only proves the group still exists. An exited-but-unreaped
+    process (a zombie) stays a member of its group and cannot be signalled away, so
+    probing with signal 0 alone reads a group of corpses as live: the caller then
+    burns its whole grace period before escalating to a SIGKILL that can do nothing.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+
+    if not os.path.isdir("/proc"):
+        return True  # No procfs (e.g. macOS): group existence is all we can read.
+
+    saw_member = False
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat", encoding="utf-8") as fh:
+                # Skip the comm field: it is parenthesised and may contain spaces.
+                fields = fh.read().rsplit(")", 1)[1].split()
+            if int(fields[2]) != pgid:
+                continue
+            saw_member = True
+            if fields[0] != "Z":
+                return True
+        except (OSError, IndexError, ValueError):
+            continue
+
+    return not saw_member
+
+
 async def teardown_process_group(
     pgid: int, proc: asyncio.subprocess.Process, grace_period: float = 1.5
 ) -> None:
@@ -270,9 +305,7 @@ async def teardown_process_group(
     async def _escalate_to_kill() -> None:
         deadline = asyncio.get_running_loop().time() + grace_period
         while asyncio.get_running_loop().time() < deadline:
-            try:
-                os.killpg(pgid, 0)
-            except (ProcessLookupError, PermissionError):
+            if not group_has_live_member(pgid):
                 return
             await asyncio.sleep(0.05)
 
@@ -283,7 +316,7 @@ async def teardown_process_group(
         await asyncio.shield(_escalate_to_kill())
 
     if proc.returncode is None:
-        with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError):
+        with contextlib.suppress(asyncio.TimeoutError, TimeoutError):
             await asyncio.wait_for(proc.wait(), timeout=0.5)
 
 
@@ -390,9 +423,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                         stderr_bytes = (
                             b"[benchmarker] task setup timed out after 60s.\n"
                         )
-                        await teardown_process_group(
-                            setup_pgid, setup_proc, grace_period=1.0
-                        )
                     finally:
                         await teardown_process_group(
                             setup_pgid, setup_proc, grace_period=1.0
@@ -442,7 +472,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                             ):
                                 with contextlib.suppress(Exception):
                                     proc.stderr._transport.close()
-                            await teardown_process_group(pgid, proc, grace_period=1.5)
                         finally:
                             # Graceful escalation to ensure process group teardown
                             await teardown_process_group(pgid, proc, grace_period=1.5)
@@ -539,7 +568,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                     except (asyncio.TimeoutError, TimeoutError):
                         verify_passed = False
                         verify_output = "[benchmarker] verify hook timed out after 60s."
-                        await teardown_process_group(v_pgid, v_proc, grace_period=1.0)
                     finally:
                         await teardown_process_group(v_pgid, v_proc, grace_period=1.0)
 


### PR DESCRIPTION
## Summary

Refactors process group termination logic in the benchmarker to more reliably detect when a process group has truly exited, rather than relying solely on signal probing which can misidentify zombie processes as live members.

## Key Changes

- **New `group_has_live_member()` function**: Implements robust process group liveness detection by:
  - First attempting signal 0 probe (fast path for non-existent groups)
  - On systems with `/proc` filesystem, inspects individual process states to distinguish between live processes and zombies
  - Falls back to signal probe result on systems without `/proc` (e.g., macOS)
  - Returns `False` only when the group is truly empty or contains no non-zombie members

- **Simplified `teardown_process_group()` logic**:
  - Removes early return for already-exited processes, ensuring consistent cleanup
  - Replaces `proc.wait()` timeout with polling loop using `group_has_live_member()` for more accurate grace period handling
  - Eliminates redundant teardown calls in exception handlers (now handled by `finally` blocks)
  - Adds final short timeout on `proc.wait()` to ensure process object is reaped

- **Removed duplicate teardown calls**: Eliminates redundant `await teardown_process_group()` calls in exception handlers across three job execution phases (setup, main task, verify hook), relying instead on `finally` blocks for guaranteed cleanup

- **Added `strict=True` to `zip()` call**: Ensures dimension names and combinations have matching lengths, catching potential mismatches early

## Implementation Details

The new `group_has_live_member()` function addresses a critical issue where `killpg(pgid, 0)` reports success for process groups containing only zombies. By reading `/proc/{pid}/stat` files, it can distinguish process state (field 0 is 'Z' for zombies) and only returns `True` if at least one non-zombie member exists. This prevents the grace period from being wasted on groups that cannot be signalled.

https://claude.ai/code/session_01BwRr4XLQd6j8XvZuec9ybz