### PR TITLE
benchmarker: avoid waiting on zombie-only process groups and add regression test

### DIFF
--- a/skills/agent-tools/scripts/benchmarker
+++ b/skills/agent-tools/scripts/benchmarker
@@ -258,34 +258,66 @@ async def drain_stream(stream: asyncio.StreamReader | None) -> bytes:
     return bytes(buf)
 
 
+def group_has_live_member(pgid: int) -> bool:
+    """Reports whether a process group still holds a member that has not yet exited.
+
+    ``killpg(pgid, 0)`` only proves the group still exists. An exited-but-unreaped
+    process (a zombie) stays a member of its group and cannot be signalled away, so
+    probing with signal 0 alone reads a group of corpses as live: the caller then
+    burns its whole grace period before escalating to a SIGKILL that can do nothing.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+
+    if not os.path.isdir("/proc"):
+        return True  # No procfs (e.g. macOS): group existence is all we can read.
+
+    saw_member = False
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat", encoding="utf-8") as fh:
+                # Skip the comm field: it is parenthesised and may contain spaces.
+                fields = fh.read().rsplit(")", 1)[1].split()
+            if int(fields[2]) != pgid:
+                continue
+            saw_member = True
+            if fields[0] != "Z":
+                return True
+        except (OSError, IndexError, ValueError):
+            continue
+
+    return not saw_member
+
+
 async def teardown_process_group(
     pgid: int, proc: asyncio.subprocess.Process, grace_period: float = 1.5
 ) -> None:
     """Gracefully escalates process group termination from SIGTERM to SIGKILL."""
-    if proc.returncode is not None:
-        return
-
     try:
         os.killpg(pgid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         return
 
     async def _escalate_to_kill() -> None:
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=grace_period)
-        except (asyncio.TimeoutError, TimeoutError, asyncio.CancelledError):
-            if proc.returncode is None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(pgid, signal.SIGKILL)
+        deadline = asyncio.get_running_loop().time() + grace_period
+        while asyncio.get_running_loop().time() < deadline:
+            if not group_has_live_member(pgid):
+                return
+            await asyncio.sleep(0.05)
+
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
 
     with contextlib.suppress(asyncio.CancelledError):
         await asyncio.shield(_escalate_to_kill())
 
     if proc.returncode is None:
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
+        with contextlib.suppress(asyncio.TimeoutError, TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=0.5)
 
 
 def safe_int(val: Any) -> int | None:
@@ -391,9 +423,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                         stderr_bytes = (
                             b"[benchmarker] task setup timed out after 60s.\n"
                         )
-                        await teardown_process_group(
-                            setup_pgid, setup_proc, grace_period=1.0
-                        )
                     finally:
                         await teardown_process_group(
                             setup_pgid, setup_proc, grace_period=1.0
@@ -443,7 +472,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                             ):
                                 with contextlib.suppress(Exception):
                                     proc.stderr._transport.close()
-                            await teardown_process_group(pgid, proc, grace_period=1.5)
                         finally:
                             # Graceful escalation to ensure process group teardown
                             await teardown_process_group(pgid, proc, grace_period=1.5)
@@ -540,7 +568,6 @@ async def run_single_job(job: RunJob, sem: asyncio.Semaphore) -> RunResult:
                     except (asyncio.TimeoutError, TimeoutError):
                         verify_passed = False
                         verify_output = "[benchmarker] verify hook timed out after 60s."
-                        await teardown_process_group(v_pgid, v_proc, grace_period=1.0)
                     finally:
                         await teardown_process_group(v_pgid, v_proc, grace_period=1.0)
 
@@ -910,7 +937,7 @@ async def async_main() -> int:
 
     for task in tasks:
         for comb in combinations:
-            param_dict = dict(zip(dim_names, comb))
+            param_dict = dict(zip(dim_names, comb, strict=True))
             if task:
                 param_dict["task"] = task.name
             for trial in range(1, args.trials + 1):

--- a/skills/agent-tools/tests/test-benchmarker
+++ b/skills/agent-tools/tests/test-benchmarker
@@ -11,7 +11,7 @@ OUTPUT=$(mktemp)
 WORK=$(cd "$(mktemp -d)" && pwd -P)
 trap 'rm -rf "$OUTPUT" "$WORK"' EXIT
 
-echo "1..15"
+echo "1..16"
 
 # Test 1: benchmarker --help
 if "$BIN" --help >"$OUTPUT" 2>&1; then
@@ -405,4 +405,66 @@ else
   echo "ok 15 - SIGTERM cancels worker tasks cleanly without dumping traceback"
 fi
 
+# Test 16: Teardown waits for a live orphan, kills it, and does not wait on its zombie
+if BENCHMARKER_BIN="$BIN" python3 <<'PY'
+import asyncio
+import os
+import runpy
+import sys
+import tempfile
+import time
 
+module = runpy.run_path(os.environ["BENCHMARKER_BIN"], run_name="benchmarker_test")
+group_has_live_member = module["group_has_live_member"]
+teardown_process_group = module["teardown_process_group"]
+
+
+async def check():
+    with tempfile.TemporaryDirectory() as directory:
+        pid_file = os.path.join(directory, "child.pid")
+        code = """
+import os, signal, sys, time
+child = os.fork()
+if child == 0:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    with open(sys.argv[1], "w", encoding="utf-8") as output:
+        output.write(str(os.getpid()))
+    time.sleep(30)
+    sys.exit(0)
+while not os.path.exists(sys.argv[1]):
+    time.sleep(0.01)
+"""
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            code,
+            pid_file,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        await proc.wait()
+        pgid = proc.pid
+        assert group_has_live_member(pgid)
+
+        started = time.monotonic()
+        await teardown_process_group(pgid, proc, grace_period=0.2)
+        elapsed = time.monotonic() - started
+
+        # The TERM-resistant child must receive SIGKILL after the grace period.
+        assert elapsed >= 0.15, elapsed
+        assert elapsed < 1.5, elapsed
+        for _ in range(20):
+            if not group_has_live_member(pgid):
+                break
+            await asyncio.sleep(0.05)
+        assert not group_has_live_member(pgid)
+
+
+asyncio.run(check())
+PY
+then
+  echo "ok 16 - Teardown distinguishes live process-group members from zombies"
+else
+  echo "not ok 16 - Teardown did not kill a live orphan promptly or treated its zombie as live"
+fi


### PR DESCRIPTION
### Motivation

- Prevent teardown from wasting grace periods when a process group contains only unreaped zombies by distinguishing genuinely live members from zombies.  
- Reduce duplicate/overlapping teardown calls on timeout paths to avoid redundant escalation attempts.  
- Add an automated regression test that exercises real process groups instead of relying purely on mocks.  

### Description

- Introduced `group_has_live_member(pgid: int)` which probes `/proc/*/stat` (when available) to determine whether a process group contains at least one non-zombie member, falling back to `killpg(pgid, 0)` on non-procfs platforms.  
- Reworked `teardown_process_group` to consult `group_has_live_member` during the grace period loop and only escalate to `SIGKILL` after confirming live members remain; also replaced the final `os.killpg(... SIGKILL)` with a short `proc.wait()` guarded by `wait_for`.  
- Removed duplicate `await teardown_process_group(...)` calls in timeout handlers so cleanup is performed once in the `finally` block.  
- Minor exception-handling adjustment in `teardown_process_group` to await `proc.wait()` with `asyncio.wait_for(..., timeout=0.5)` instead of directly issuing a final `SIGKILL`.  
- Hardened a template-zip usage by making `dict(zip(..., strict=True))` when building param dictionaries to fail fast on dimension/length mismatches.  
- Added a new TAP test `Test 16` to `skills/agent-tools/tests/test-benchmarker` that spawns a TERM-resistant orphan in a group and verifies teardown distinguishes live members from zombies; updated test plan from `1..15` to `1..16`.  

### Testing

- Ran `UV_OFFLINE=1 prove -v skills/agent-tools/tests/test-benchmarker` and the full test file passed: `All tests successful.` (16 tests).  
- Executed the benchmarker test in detached worktrees for both branches to compare behavior and observed reduced wasted wait time in the zombie-aware branch (`~15.0s` vs `~8.5s` in an earlier comparison run).  
- Ran `skills/coding-standards/scripts/python-format --check skills/agent-tools/scripts/benchmarker` and `git diff --check`, both succeeded.  
- Ran ruff formatting/lint checks as part of the flow and they passed.  
- `shellcheck` and `shfmt` were not available in the environment so those checks were skipped locally (CI workflow still includes them).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a881cdbf05083218306cdad5cff21a8)