### PR TITLE
feat(taskgo): let callers name task files with --slug

### DIFF
--- a/fish/completions/taskgo.fish
+++ b/fish/completions/taskgo.fish
@@ -51,6 +51,7 @@ complete -f -c taskgo -n '__fish_seen_subcommand_from create list status sync do
 complete -f -c taskgo -n '__fish_seen_subcommand_from history checkpoint' -a '(__fish_taskgo_tasks)' -d 'Task ID'
 
 # create options
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l slug -x -d 'Filename mnemonic (max 32 chars)'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l status -x -a 'todo in-progress blocked done cancelled' -d 'Initial state'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l no-commit -d 'Create task and sync without committing'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l dry-run -d 'Preview task path without creating files'

--- a/fish/completions/taskgo.fish
+++ b/fish/completions/taskgo.fish
@@ -31,6 +31,7 @@ end
 complete -f -c taskgo -n __fish_use_subcommand -a id -d 'Allocate a unique task ID'
 complete -f -c taskgo -n __fish_use_subcommand -a root -d 'Print the active control repository root'
 complete -f -c taskgo -n __fish_use_subcommand -a create -d 'Create a new task'
+complete -f -c taskgo -n __fish_use_subcommand -a update -d 'Update task fields, status, or headings'
 complete -f -c taskgo -n __fish_use_subcommand -a list -d 'List tasks'
 complete -f -c taskgo -n __fish_use_subcommand -a status -d 'Show project status'
 complete -f -c taskgo -n __fish_use_subcommand -a sync -d 'Update STATUS.md snapshot'
@@ -47,31 +48,57 @@ complete -c taskgo -f -s h -l help -d 'Display help message and exit'
 # Subcommand arguments (Projects)
 complete -f -c taskgo -n '__fish_seen_subcommand_from create list status sync doctor fix' -a '(__fish_taskgo_projects)' -d Project
 
-# Subcommand arguments (Task IDs for history / checkpoint)
-complete -f -c taskgo -n '__fish_seen_subcommand_from history checkpoint' -a '(__fish_taskgo_tasks)' -d 'Task ID'
+# Subcommand arguments (Task IDs for update / history / checkpoint)
+complete -f -c taskgo -n '__fish_seen_subcommand_from update history checkpoint' -a '(__fish_taskgo_tasks)' -d 'Task ID'
 
 # create options
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l slug -x -d 'Filename mnemonic (max 32 chars)'
-complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l status -x -a 'todo in-progress blocked done cancelled' -d 'Initial state'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -s s -l status -x -a 'todo in-progress blocked done cancelled' -d 'Initial state'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -s p -l problem -x -d 'Problem description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -s g -l goal -x -d 'Goal description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -s c -l criteria -x -d 'Observable end condition'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l sketch -x -d 'Implementation sketch'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l constraints -x -d Constraints
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l outcome -x -d 'Outcome description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l findings -x -d Findings
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l next -x -d 'Next steps'
+complete -f -c taskgo -n '__fish_seen_subcommand_from create' -s C -l conv -l conversation -x -d 'Active conversation or session ID'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l no-commit -d 'Create task and sync without committing'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l dry-run -d 'Preview task path without creating files'
 
+# update options
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s s -l status -x -a 'todo in-progress blocked done cancelled' -d 'New task state'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s t -l title -x -d 'New task title'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l slug -x -d 'Rename the task file slug (max 32 chars)'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s p -l problem -x -d 'Problem description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s g -l goal -x -d 'Goal description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s c -l criteria -x -d 'Observable end condition'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l sketch -x -d 'Implementation sketch'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l constraints -x -d Constraints
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l outcome -x -d 'Outcome description'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l findings -x -d Findings
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -l next -x -d 'Next steps'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update' -s C -l conv -l conversation -x -d 'Active conversation or session ID'
+
 # list options
-complete -f -c taskgo -n '__fish_seen_subcommand_from list' -l state -x -a 'todo in-progress blocked done cancelled' -d 'Filter by state'
-complete -f -c taskgo -n '__fish_seen_subcommand_from list' -l json -d 'Emit JSON output'
+complete -f -c taskgo -n '__fish_seen_subcommand_from list' -s s -l state -l status -x -a 'todo in-progress blocked done cancelled' -d 'Filter by state'
+complete -f -c taskgo -n '__fish_seen_subcommand_from list' -s j -l json -d 'Emit JSON output'
 
 # status options
-complete -f -c taskgo -n '__fish_seen_subcommand_from status' -l json -d 'Emit JSON output'
+complete -f -c taskgo -n '__fish_seen_subcommand_from status' -s j -l json -d 'Emit JSON output'
 
 # fix options
 complete -f -c taskgo -n '__fish_seen_subcommand_from fix' -l dry-run -d 'Preview repairs without modifying files'
 complete -f -c taskgo -n '__fish_seen_subcommand_from fix' -l no-commit -d 'Apply repairs without committing'
 
 # checkpoint options
-complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -l path -r -d 'Include additional modified project file'
-complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -l body -x -d 'Commit body'
-complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -l ref -x -d 'External reference URL/ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -s a -l all -d 'Stage all modified/untracked project files'
+complete -c taskgo -n '__fish_seen_subcommand_from checkpoint' -s p -l path -r -d 'Include additional modified project file'
+complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -s b -l body -x -d 'Commit body'
+complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -s r -l ref -x -d 'External reference URL/ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from checkpoint' -s C -l conv -l conversation -x -d 'Active conversation or session ID'
 
 # commit options
-complete -f -c taskgo -n '__fish_seen_subcommand_from commit' -l body -x -d 'Commit body'
-complete -f -c taskgo -n '__fish_seen_subcommand_from commit' -l ref -x -d 'External reference URL/ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from commit' -s b -l body -x -d 'Commit body'
+complete -f -c taskgo -n '__fish_seen_subcommand_from commit' -s r -l ref -x -d 'External reference URL/ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from commit' -s C -l conv -l conversation -x -d 'Active conversation or session ID'

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -119,8 +119,19 @@ repo. Use random IDs, not a counter:
 
 ```bash
 <skill-dir>/scripts/taskgo id
-<skill-dir>/scripts/taskgo create PROJECT "Diagnose intermittent disconnects"
+<skill-dir>/scripts/taskgo create PROJECT "Diagnose intermittent disconnects" --slug disconnects
 ```
+
+Task files are named `TASK-XXXXX-<slug>.md`. The slug is a filename mnemonic,
+not the title: `create` derives one from `TITLE` when `--slug` is omitted, but a
+derived slug keeps the *leading* words of the title, which are rarely the
+distinguishing ones ("Generate readable task filename slugs with clean length
+limits" derives `generate-readable-task-filename`, where `filename-slugs` is
+wanted). Pass `--slug` (at most 32 characters after normalization) whenever the
+title runs longer than a few words; `create` warns when it had to shorten a
+derived slug. Nothing resolves tasks by filename — IDs and titles carry that —
+so slugs exist purely for humans reading `tasks/`, `git log`, and fuzzy finders.
+Rename an existing task file with `update --slug`.
 
 Preferred states: `todo`, `in-progress`, `blocked`, `done`, `cancelled`.
 Unknown/missing values remain readable but should be reported.
@@ -308,8 +319,8 @@ working directory. In the command list below, `taskgo` refers to either the
 ```text
 taskgo id
 taskgo root
-taskgo create PROJECT TITLE [--conv ID] [--status STATE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--no-commit] [--dry-run]
-taskgo update TASK_ID [--conv ID] [--status STATE] [--title TITLE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--outcome TEXT] [--findings TEXT] [--next TEXT]
+taskgo create PROJECT TITLE [--slug SLUG] [--conv ID] [--status STATE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--no-commit] [--dry-run]
+taskgo update TASK_ID [--slug SLUG] [--conv ID] [--status STATE] [--title TITLE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--outcome TEXT] [--findings TEXT] [--next TEXT]
 taskgo list [PROJECT] [--state STATE] [--json]
 taskgo status [PROJECT] [--json]
 taskgo sync [PROJECT]
@@ -323,8 +334,13 @@ taskgo commit SUBJECT [--conv ID] [--body TEXT] [--ref REF]...
 `create` is the atomic task creation command: it allocates a unique ID, writes
 the initial task record, synchronizes `STATUS.md`, and when the
 `taskgo:allow-local-commits` marker is present, commits the transition
-automatically. Use `--no-commit` to keep the created task uncommitted in the
-working tree, or `--dry-run` to preview the task path without creating files.
+automatically. Use `--slug` to name the task file (see "Tasks" above),
+`--no-commit` to keep the created task uncommitted in the working tree, or
+`--dry-run` to preview the task path without creating files.
+
+`update --slug` renames the task file in place, keeping its ID prefix. The
+rename is left uncommitted (as with every other `update` edit); commit it with
+`checkpoint --all`, which stages both the old and new paths.
 
 `history` compares a frontmatter field (default `status`) across historical
 blobs. `doctor` performs strictly read-only mechanical checks and prints a

--- a/skills/taskgo/references/model.md
+++ b/skills/taskgo/references/model.md
@@ -86,8 +86,10 @@ Commands follow the fixed `tool [verb] [noun]` structure with clean,
 unhyphenated verbs:
 
 - `taskgo id`: Allocate unique `TASK-XXXXX` identifier.
-- `taskgo create PROJECT TITLE [--status STATE] [--no-commit] [--dry-run]`:
-  Create a structured task record.
+- `taskgo create PROJECT TITLE [--slug SLUG] [--status STATE] [--no-commit] [--dry-run]`:
+  Create a structured task record. `--slug` names the file
+  (`TASK-XXXXX-<slug>.md`); when omitted, the slug is derived from `TITLE` and
+  shortened at word boundaries to 32 characters, with a warning.
 - `taskgo list [PROJECT] [--state STATE] [--json]`: List tasks in tabular or
   JSON format.
 - `taskgo status [PROJECT] [--json]`: Display operational status or

--- a/skills/taskgo/scripts/taskgo
+++ b/skills/taskgo/scripts/taskgo
@@ -35,6 +35,7 @@ CANONICAL_URL = "https://github.com/ithinkihaveacat/dotfiles/tree/master/skills/
 COMMIT_AUTH = "<!-- taskgo:allow-local-commits -->"
 ID_PATTERN = re.compile(r"^TASK-[0-9A-F]{5}$")
 WRAP_WIDTH = 80
+SLUG_MAX_LEN = 32
 
 
 class TaskStatus(StrEnum):
@@ -426,12 +427,39 @@ def extract_title(content: str) -> str:
     return ""
 
 
-def slugify(title: str) -> str:
-    s = title.lower()
+def normalize_slug(value: str) -> str:
+    """Normalizes VALUE into slug form (lowercase, hyphen-separated, no truncation)."""
+    s = value.lower()
     s = re.sub(r"[^a-z0-9]+", "-", s)
-    s = s.strip("-")
     s = re.sub(r"-+", "-", s)
-    return s[:48]
+    return s.strip("-")
+
+
+def slugify(title: str, max_len: int = SLUG_MAX_LEN) -> str:
+    """Derives a filename slug from TITLE, truncated at word boundaries."""
+    s = normalize_slug(title)
+    if len(s) <= max_len:
+        return s
+    words = s.split("-")
+    kept: list[str] = []
+    length = 0
+    for word in words:
+        extra = len(word) if not kept else len(word) + 1
+        if length + extra > max_len:
+            break
+        kept.append(word)
+        length += extra
+    if not kept:
+        # A single leading word exceeds the budget; hard-cut it rather than
+        # return nothing.
+        return words[0][:max_len]
+    return "-".join(kept)
+
+
+def filename_slug(name: str) -> str:
+    """Extracts the slug of an already taskgo-named file (empty when not one)."""
+    m = re.match(r"^TASK-[0-9A-F]{5}-(.+)$", name.removesuffix(".md"))
+    return normalize_slug(m.group(1)) if m else ""
 
 
 def normalize_status(raw_status: str) -> str:
@@ -895,7 +923,15 @@ def audit_workspace(root: Path, target_project: str | None = None) -> list[Findi
                             except Exception:
                                 pass
                             atomic_write(target_tf, new_content)
-                            slug = slugify(t_title) or "task"
+                            # Preserve a caller-chosen slug when the file is
+                            # already taskgo-named: only its ID prefix is
+                            # being repaired. Files adopted from other names
+                            # still get a slug derived from their title.
+                            slug = (
+                                filename_slug(target_tf.name)
+                                or slugify(t_title)
+                                or "task"
+                            )
                             new_name = f"{t_id}-{slug}.md"
                             new_path = p_tasks / new_name
                             if target_tf.name != new_name:
@@ -1199,6 +1235,7 @@ def render_task_file(
 def cmd_create(
     project_name: str,
     title: str,
+    slug: str | None = None,
     status: str = "todo",
     problem: str | None = None,
     goal: str | None = None,
@@ -1224,6 +1261,32 @@ def cmd_create(
             f"invalid project name (must be a top-level directory and cannot start with a dot): {project_name}"
         )
 
+    if slug is not None:
+        task_slug = normalize_slug(slug)
+        if not task_slug:
+            die_scoped(f"--slug contains no usable characters: {slug}")
+        if len(task_slug) > SLUG_MAX_LEN:
+            die_scoped(
+                f"--slug too long ({len(task_slug)} > {SLUG_MAX_LEN} chars): {task_slug}"
+            )
+    else:
+        full_slug = normalize_slug(title)
+        task_slug = slugify(title) or "task"
+        if not full_slug or len(full_slug) > SLUG_MAX_LEN:
+            reason = (
+                "Title yields no usable filename slug"
+                if not full_slug
+                else "Title too long for a filename"
+            )
+            print(
+                f"[WARN]  {reason}; using '{task_slug}'.",
+                file=sys.stderr,
+            )
+            print(
+                f"[WARN]    Pass --slug SLUG (<= {SLUG_MAX_LEN} chars) to choose a better filename.",
+                file=sys.stderr,
+            )
+
     status = normalize_status(status)
     conv_id = get_active_conversation_id(conv)
     root = get_repo_root()
@@ -1234,8 +1297,7 @@ def cmd_create(
         )
 
     task_id = generate_task_id(root)
-    slug = slugify(title) or "task"
-    filename = f"{task_id}-{slug}.md"
+    filename = f"{task_id}-{task_slug}.md"
     rel_task_path = f"{project_name}/tasks/{filename}"
     is_new_project = not is_project_dir(proj_dir)
 
@@ -1355,6 +1417,7 @@ def cmd_update(
     query: str,
     status: str | None = None,
     title: str | None = None,
+    slug: str | None = None,
     problem: str | None = None,
     goal: str | None = None,
     criteria: str | None = None,
@@ -1366,6 +1429,16 @@ def cmd_update(
     conv: str | None = None,
 ) -> None:
     """Update task fields, status, or headings."""
+    new_slug: str | None = None
+    if slug is not None:
+        new_slug = normalize_slug(slug)
+        if not new_slug:
+            die_scoped(f"--slug contains no usable characters: {slug}")
+        if len(new_slug) > SLUG_MAX_LEN:
+            die_scoped(
+                f"--slug too long ({len(new_slug)} > {SLUG_MAX_LEN} chars): {new_slug}"
+            )
+
     root = get_repo_root()
     target_path = resolve_target(root, query)
     rel_path = str(target_path.relative_to(root))
@@ -1471,10 +1544,25 @@ def cmd_update(
         pass
     atomic_write(target_path, new_content)
 
-    sync_status(root, project_name)
     task_id_val = next(
         (str(v) for k, v in data.items() if str(k).lower() == "id"), query
     )
+
+    if new_slug is not None:
+        prefix = task_id_val if ID_PATTERN.match(task_id_val) else ""
+        new_name = f"{prefix}-{new_slug}.md" if prefix else f"{new_slug}.md"
+        new_path = target_path.with_name(new_name)
+        if new_path != target_path:
+            if new_path.exists():
+                die_scoped(f"cannot rename {rel_path}: {new_name} already exists")
+            target_path.rename(new_path)
+            print(
+                f"[INFO]  Renamed {rel_path} -> {new_path.relative_to(root)}",
+                file=sys.stderr,
+            )
+            rel_path = str(new_path.relative_to(root))
+
+    sync_status(root, project_name)
     print(f"[INFO]  Updated {task_id_val} in {rel_path}", file=sys.stderr)
 
 
@@ -2047,7 +2135,7 @@ Maintain a private Git-backed personal project/task control repo.
 Commands:
   id                               Allocate a unique task ID
   root                             Print the active control repository root
-  create PROJECT TITLE [OPTIONS]   Create a new task (--problem, --goal, etc.)
+  create PROJECT TITLE [OPTIONS]   Create a new task (--slug, --problem, etc.)
   update TASK_ID [OPTIONS]         Update task fields, status, or headings
   list [PROJECT] [OPTIONS]         List tasks
   status [PROJECT] [--json]        Show project status
@@ -2070,8 +2158,8 @@ Environment:
 
 Examples:
   taskgo id
-  taskgo create my-project "Diagnose intermittent disconnects"
-  taskgo create my-project "Add cache layer" --problem "High latency" --goal "Sub-10ms"
+  taskgo create my-project "Diagnose intermittent disconnects" --slug disconnects
+  taskgo create my-project "Add cache layer" --slug cache-layer --problem "High latency"
   taskgo update TASK-3A91F --status in-progress --sketch "Use in-memory dict"
   taskgo sync my-project
   taskgo fix my-project
@@ -2130,12 +2218,24 @@ def create_parser() -> argparse.ArgumentParser:
         description="Create a new task in PROJECT.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""Examples:
-  taskgo create my-project "Diagnose intermittent disconnects"
-  taskgo create my-project "Add cache layer" --problem "High latency" --goal "Sub-10ms"
-  taskgo create --status in-progress my-project "Initial implementation" """,
+  taskgo create my-project "Diagnose intermittent disconnects" --slug disconnects
+  taskgo create my-project "Add a read-through cache layer in front of the resolver" \\
+    --slug cache-layer --problem "High latency" --goal "Sub-10ms"
+  taskgo create --status in-progress my-project "Initial implementation" --slug initial-impl
+
+TITLE is prose for humans (it becomes the H1 and appears in STATUS.md); SLUG is
+the filename mnemonic. A slug derived from a long TITLE keeps the leading words,
+which are rarely the distinguishing ones, so pass --slug whenever TITLE is longer
+than a few words.""",
     )
     p_create.add_argument("project_name", metavar="PROJECT", help="Project identifier")
     p_create.add_argument("title", metavar="TITLE", help="Task title")
+    p_create.add_argument(
+        "--slug",
+        default=None,
+        metavar="SLUG",
+        help=f"Filename mnemonic, max {SLUG_MAX_LEN} chars (default: derived from TITLE)",
+    )
     p_create.add_argument(
         "--status",
         "-s",
@@ -2182,6 +2282,12 @@ def create_parser() -> argparse.ArgumentParser:
     p_update.add_argument("query", metavar="TASK_ID", help="Task ID or relative path")
     p_update.add_argument("--status", "-s", default=None, help="New task state")
     p_update.add_argument("--title", "-t", default=None, help="New task title")
+    p_update.add_argument(
+        "--slug",
+        default=None,
+        metavar="SLUG",
+        help=f"Rename the task file's slug, max {SLUG_MAX_LEN} chars",
+    )
     p_update.add_argument("--problem", "-p", default=None, help="Problem description")
     p_update.add_argument("--goal", "-g", default=None, help="Goal description")
     p_update.add_argument(
@@ -2423,6 +2529,7 @@ def main(argv: list[str] | None = None) -> None:
         cmd_create(
             project_name=args.project_name,
             title=args.title,
+            slug=args.slug,
             status=args.status,
             problem=args.problem,
             goal=args.goal,
@@ -2441,6 +2548,7 @@ def main(argv: list[str] | None = None) -> None:
             query=args.query,
             status=args.status,
             title=args.title,
+            slug=args.slug,
             problem=args.problem,
             goal=args.goal,
             criteria=args.criteria,

--- a/skills/taskgo/tests/test-taskgo
+++ b/skills/taskgo/tests/test-taskgo
@@ -34,7 +34,7 @@ printf '%s\n' \
   '# Confirm generated status formatting' \
   >"$REPO/example/tasks/TASK-A1B2C-confirm-status.md"
 
-echo '1..72'
+echo '1..79'
 
 if ("$BIN" --root "$REPO" sync example) &&
   "$MARKDOWN_FORMAT" --check "$REPO/example/STATUS.md" >/dev/null; then
@@ -1428,4 +1428,112 @@ if [[ "$HELP_TILDE" == *"Root: ~/taskgo-tilde-test"* ]]; then
   echo "ok 72 - help renders home-anchored roots with a ~ prefix"
 else
   echo "not ok 72 - help renders home-anchored roots with a ~ prefix"
+fi
+
+# 73: create derives a word-boundary slug and warns when it shortens the title
+LONG_TITLE='Generate readable task filename slugs with clean length limits'
+SLUG_OUT="$("$BIN" --root "$README_REPO" create proj1 "$LONG_TITLE" 2>"$TEST_ROOT/slug-warn.txt")"
+SLUG_PATH="$(printf '%s' "$SLUG_OUT" | cut -f2)"
+SLUG_WARN="$(cat "$TEST_ROOT/slug-warn.txt")"
+SLUG_NAME="$(basename "$SLUG_PATH")"
+if [[ "$SLUG_NAME" == "$(printf '%s' "$SLUG_OUT" | cut -f1)-generate-readable-task-filename.md" ]] &&
+  [[ -f "$README_REPO/$SLUG_PATH" ]] &&
+  [[ "$SLUG_WARN" == *"[WARN]"*"Title too long for a filename"* ]] &&
+  [[ "$SLUG_WARN" == *"--slug SLUG (<= 32 chars)"* ]]; then
+  echo 'ok 73 - create truncates slugs at word boundaries and warns'
+else
+  echo 'not ok 73 - create truncates slugs at word boundaries and warns'
+  echo "# name=$SLUG_NAME warn=$SLUG_WARN"
+fi
+
+# 74: --slug overrides the derived slug, is normalized, and suppresses the warning
+EXPLICIT_OUT="$("$BIN" --root "$README_REPO" create proj1 "$LONG_TITLE" --slug 'Filename Slugs!' 2>"$TEST_ROOT/slug-quiet.txt")"
+EXPLICIT_ID="$(printf '%s' "$EXPLICIT_OUT" | cut -f1)"
+EXPLICIT_PATH="$(printf '%s' "$EXPLICIT_OUT" | cut -f2)"
+if [[ "$(basename "$EXPLICIT_PATH")" == "$EXPLICIT_ID-filename-slugs.md" ]] &&
+  [[ -f "$README_REPO/$EXPLICIT_PATH" ]] &&
+  ! grep -q '\[WARN\]' "$TEST_ROOT/slug-quiet.txt"; then
+  echo 'ok 74 - create honours and normalizes an explicit --slug'
+else
+  echo 'not ok 74 - create honours and normalizes an explicit --slug'
+  echo "# path=$EXPLICIT_PATH warn=$(cat "$TEST_ROOT/slug-quiet.txt")"
+fi
+
+# 75: short titles produce untruncated slugs without a warning
+SHORT_OUT="$("$BIN" --root "$README_REPO" create proj1 'Fix cache eviction' 2>"$TEST_ROOT/slug-short.txt")"
+SHORT_ID="$(printf '%s' "$SHORT_OUT" | cut -f1)"
+if [[ "$(basename "$(printf '%s' "$SHORT_OUT" | cut -f2)")" == "$SHORT_ID-fix-cache-eviction.md" ]] &&
+  ! grep -q '\[WARN\]' "$TEST_ROOT/slug-short.txt"; then
+  echo 'ok 75 - create leaves short titles unshortened and unwarned'
+else
+  echo 'not ok 75 - create leaves short titles unshortened and unwarned'
+fi
+
+# 76: over-long and unusable --slug values are rejected with actionable errors
+LONG_SLUG_ERR="$("$BIN" --root "$README_REPO" create proj1 'Rejected' --slug 'aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd' 2>&1 || true)"
+LONG_SLUG_CODE=0
+"$BIN" --root "$README_REPO" create proj1 'Rejected' --slug 'aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd' >/dev/null 2>&1 || LONG_SLUG_CODE=$?
+EMPTY_SLUG_ERR="$("$BIN" --root "$README_REPO" create proj1 'Rejected' --slug '###' 2>&1 || true)"
+if [[ "$LONG_SLUG_CODE" -eq 1 ]] &&
+  [[ "$LONG_SLUG_ERR" == *"taskgo create: --slug too long (43 > 32 chars)"* ]] &&
+  [[ "$EMPTY_SLUG_ERR" == *"taskgo create: --slug contains no usable characters"* ]] &&
+  [[ "$LONG_SLUG_ERR" != *"Traceback"* ]] &&
+  [[ "$(find "$README_REPO/proj1/tasks" -name '*rejected*' | wc -l)" -eq 0 ]]; then
+  echo 'ok 76 - create rejects unusable --slug values without creating files'
+else
+  echo 'not ok 76 - create rejects unusable --slug values without creating files'
+  echo "# code=$LONG_SLUG_CODE err=$LONG_SLUG_ERR"
+fi
+
+# 77: titles with no slug-able characters fall back to a warned default
+UNICODE_OUT="$("$BIN" --root "$README_REPO" create proj1 '日本語のタイトル' 2>"$TEST_ROOT/slug-unicode.txt")"
+UNICODE_ID="$(printf '%s' "$UNICODE_OUT" | cut -f1)"
+if [[ "$(basename "$(printf '%s' "$UNICODE_OUT" | cut -f2)")" == "$UNICODE_ID-task.md" ]] &&
+  grep -q 'Title yields no usable filename slug' "$TEST_ROOT/slug-unicode.txt"; then
+  echo 'ok 77 - create falls back to a default slug and warns'
+else
+  echo 'not ok 77 - create falls back to a default slug and warns'
+fi
+
+# 78: update --slug renames the task file in place and keeps the ID prefix
+RENAME_OUT="$("$BIN" --root "$README_REPO" update "$SHORT_ID" --slug 'Cache eviction' 2>&1)"
+BAD_RENAME="$("$BIN" --root "$README_REPO" update "$SHORT_ID" --slug 'aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd' 2>&1 || true)"
+if [[ -f "$README_REPO/proj1/tasks/$SHORT_ID-cache-eviction.md" ]] &&
+  [[ ! -f "$README_REPO/proj1/tasks/$SHORT_ID-fix-cache-eviction.md" ]] &&
+  [[ "$RENAME_OUT" == *"[INFO]  Renamed"*"$SHORT_ID-cache-eviction.md"* ]] &&
+  [[ "$BAD_RENAME" == *"taskgo update: --slug too long"* ]] &&
+  grep -q "^# Fix cache eviction$" "$README_REPO/proj1/tasks/$SHORT_ID-cache-eviction.md"; then
+  echo 'ok 78 - update --slug renames the task file and keeps the ID prefix'
+else
+  echo 'not ok 78 - update --slug renames the task file and keeps the ID prefix'
+  echo "# out=$RENAME_OUT"
+fi
+
+# 79: fix preserves a chosen slug while repairing a mismatched filename ID
+SLUG_FIX_REPO="$TEST_ROOT/slug-fix-repo"
+mkdir -p "$SLUG_FIX_REPO/proj/tasks"
+git -C "$SLUG_FIX_REPO" init -q
+printf '%s\n' \
+  '# Agent instructions' \
+  '' \
+  'This repository follows taskgo:' \
+  '<https://github.com/ithinkihaveacat/dotfiles/tree/master/skills/taskgo>.' \
+  >"$SLUG_FIX_REPO/AGENTS.md"
+printf '# Inbox\n' >"$SLUG_FIX_REPO/INBOX.md"
+printf '# Proj\n' >"$SLUG_FIX_REPO/proj/README.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-11111' \
+  'status: todo' \
+  '---' \
+  '' \
+  '# Generate readable task filename slugs with clean length limits' \
+  >"$SLUG_FIX_REPO/proj/tasks/TASK-22222-filename-slugs.md"
+"$BIN" --root "$SLUG_FIX_REPO" fix proj --no-commit >/dev/null 2>&1 || true
+if [[ -f "$SLUG_FIX_REPO/proj/tasks/TASK-11111-filename-slugs.md" ]] &&
+  [[ ! -f "$SLUG_FIX_REPO/proj/tasks/TASK-22222-filename-slugs.md" ]]; then
+  echo 'ok 79 - fix preserves a chosen slug while repairing the filename ID'
+else
+  echo 'not ok 79 - fix preserves a chosen slug while repairing the filename ID'
+  echo "# $(find "$SLUG_FIX_REPO/proj/tasks" -name '*.md')"
 fi


### PR DESCRIPTION
Task filenames were derived entirely from TITLE, so one string served
two purposes: prose for the H1 and STATUS.md, and a filename mnemonic.
No pure function can bridge that gap, because deriving a slug means
compressing prose without knowing which words carry the distinction --
and titles put their generic verbs first, so any prefix-preserving
truncation keeps exactly the wrong words ("Generate readable task
filename slugs with clean length limits" yields
generate-readable-task-filename, where filename-slugs is wanted).

Add an optional --slug to create, normalized through the same slug
rules and rejected with an actionable error when it exceeds 32
characters or contains nothing usable. Encourage it where it is most
likely to be read: every help and documentation example now passes it,
and create emits a [WARN] naming the flag when, and only when, a
derived slug had to be shortened or fell back to a default. Keep it
optional -- short titles already derive ideal slugs, and forcing a
redundant argument would only train callers to pass junk.

Also improve the derivation itself as a safety net rather than a fix:
slugify() now truncates at word boundaries within a 32-character
budget, leaving no trailing hyphens or clipped tokens. Filenames stay
under 46 characters including the TASK-XXXXX- prefix and .md suffix.

Two supporting changes make chosen slugs durable. fix's filename
remediation rebuilt the whole name from the title, silently discarding
a chosen slug whenever it repaired an unrelated ID mismatch; it now
replaces only the ID prefix of an already taskgo-named file, still
deriving a slug for files adopted from other names. update --slug
renames a task file in place, so a bad name is correctable without
hand-run git mv; nothing resolves tasks by filename and STATUS.md
records IDs and titles rather than paths, so a rename needs no
further reconciliation.

Resolves TASK-D3762 and makes its sketch obsolete: word-boundary
truncation alone would have produced clean but less informative
filenames, since the words it preserves are the least distinguishing
ones. Its criteria are met by the fallback path.

Tests 73-79 cover derived truncation and its warning, explicit and
normalized slugs, silence on short titles, rejection of over-long and
unusable values, the unslugifiable-title fallback, update --slug
renames, and slug preservation across a fix ID repair.