### PR TITLE
feat(fish): add autoloaded opencode wrapper (TASK-02216)

### DIFF
--- a/fish/functions/opencode.fish
+++ b/fish/functions/opencode.fish
@@ -1,0 +1,10 @@
+function opencode --description 'Run opencode from ~/.opencode/bin or PATH'
+    if test -x $HOME/.opencode/bin/opencode
+        $HOME/.opencode/bin/opencode $argv
+    else if type -q -f opencode
+        command opencode $argv
+    else
+        echo 'opencode: command not found (install via https://opencode.ai or place in ~/.opencode/bin)' >&2
+        return 127
+    end
+end


### PR DESCRIPTION
### Motivation
- Provide a repository-local Fish wrapper so `opencode` can be invoked from `~/.opencode/bin` (or via `PATH`) without modifying `fish/config.fish`, meeting TASK-02216's goal of avoiding per-host edits and merge drift.

### Description
- Add `fish/functions/opencode.fish`, an autoloaded Fish function that prefers `$HOME/.opencode/bin/opencode`, falls back to `command opencode` if present in `PATH`, forwards `argv`, and prints an actionable error and returns `127` when neither is available; no change to `fish/config.fish` was needed after verifying there are no legacy hardcoded `fish_add_path` lines.

### Testing
- Ran `fish -n` on the new function and `fish/config.fish`, executed isolated functional checks in a Fish subshell to verify local-executable selection, `PATH` fallback, argument forwarding, and the error/`127` behavior, and ran `git diff --check`; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b3a9263588321ad40b61286b37b07)