### PR TITLE
feat(adb): add -s/--serial device flag to adb skill scripts

### DIFF
--- a/fish/completions/adb-activities.fish
+++ b/fish/completions/adb-activities.fish
@@ -1,6 +1,7 @@
 # Fish completion for adb-activities
 
 complete -c adb-activities -f
+complete -c adb-activities -s s -l serial -r -d 'Target device serial'
 complete -c adb-activities -s h -l help -d "Display help message"
 complete -c adb-activities -l launcher-only -d "List only launcher activities"
 complete -c adb-activities -l home-only -d "List only home/launcher app activities"

--- a/fish/completions/adb-currentfocus.fish
+++ b/fish/completions/adb-currentfocus.fish
@@ -1,5 +1,6 @@
 # completions for adb-currentfocus
 complete -c adb-currentfocus -f
+complete -c adb-currentfocus -s s -l serial -r -d 'Target device serial'
 
 complete -c adb-currentfocus -s p -l packagename -d "Display the package name of the focused application (default)"
 complete -c adb-currentfocus -s a -l activity -d "Display the package and activity name"

--- a/fish/completions/adb-demo.fish
+++ b/fish/completions/adb-demo.fish
@@ -1,5 +1,6 @@
 # completions for adb-demo
 complete -c adb-demo -f
+complete -c adb-demo -s s -l serial -r -d 'Target device serial'
 
 complete -c adb-demo -n "not __fish_seen_subcommand_from on off" -a on -d "Enter demo mode"
 complete -c adb-demo -n "not __fish_seen_subcommand_from on off" -a off -d "Exit demo mode"

--- a/fish/completions/adb-device-properties.fish
+++ b/fish/completions/adb-device-properties.fish
@@ -1,3 +1,4 @@
 # completions for adb-device-properties
 complete -c adb-device-properties -f
+complete -c adb-device-properties -s s -l serial -r -d 'Target device serial'
 complete -c adb-device-properties -s h -l help -d 'Display help'

--- a/fish/completions/adb-fontscale.fish
+++ b/fish/completions/adb-fontscale.fish
@@ -1,5 +1,6 @@
 # completions for adb-fontscale
 complete -c adb-fontscale -f
+complete -c adb-fontscale -s s -l serial -r -d 'Target device serial'
 
 complete -c adb-fontscale -n "not __fish_seen_subcommand_from get set" -a get -d "Print the current font scale"
 complete -c adb-fontscale -n "not __fish_seen_subcommand_from get set" -a set -d "Set the font scale"

--- a/fish/completions/adb-packages.fish
+++ b/fish/completions/adb-packages.fish
@@ -1,5 +1,6 @@
 # Fish completion for adb-packages
 
 complete -c adb-packages -f
+complete -c adb-packages -s s -l serial -r -d 'Target device serial'
 complete -c adb-packages -s h -l help -d "Display help message"
 complete -c adb-packages -l all -d "List all packages (including system apps)"

--- a/fish/completions/adb-theme.fish
+++ b/fish/completions/adb-theme.fish
@@ -1,5 +1,6 @@
 # completions for adb-theme
 complete -c adb-theme -f
+complete -c adb-theme -s s -l serial -r -d 'Target device serial'
 
 complete -c adb-theme -n "not __fish_seen_subcommand_from get set" -a get -d "Get the current theme configuration"
 complete -c adb-theme -n "not __fish_seen_subcommand_from get set" -a set -d "Set the theme to one of the presets"

--- a/fish/completions/adb-tile-add.fish
+++ b/fish/completions/adb-tile-add.fish
@@ -1,5 +1,6 @@
 # completions for adb-tile-add
 complete -c adb-tile-add -f
+complete -c adb-tile-add -s s -l serial -r -d 'Target device serial'
 complete -c adb-tile-add -l no-show -d 'Do not show the tile after adding it'
 complete -c adb-tile-add -l type -d 'Tile type' -r -a 'FULLSCREEN LARGE SMALL'
 complete -c adb-tile-add -s h -l help -d 'Display help'

--- a/fish/completions/adb-tiles.fish
+++ b/fish/completions/adb-tiles.fish
@@ -1,6 +1,7 @@
 # Fish completion for adb-tiles
 
 complete -c adb-tiles -f
+complete -c adb-tiles -s s -l serial -r -d 'Target device serial'
 complete -c adb-tiles -s h -l help -d "Display help message"
 complete -c adb-tiles -l tiles-only -d "List only tile services"
 complete -c adb-tiles -l widgets-only -d "List only widget services"

--- a/fish/completions/adb-watchface-set.fish
+++ b/fish/completions/adb-watchface-set.fish
@@ -1,3 +1,4 @@
 # completions for adb-watchface-set
 complete -c adb-watchface-set -f -d 'Watchface component name'
+complete -c adb-watchface-set -s s -l serial -r -d 'Target device serial'
 complete -c adb-watchface-set -s h -l help -d 'Display help'

--- a/fish/completions/packagename.fish
+++ b/fish/completions/packagename.fish
@@ -28,6 +28,7 @@ end
 # Complete subcommands (when no subcommand given)
 # Process/Lifecycle
 complete -c packagename -f -n __fish_packagename_needs_command -a launch -d "Launch an application's main activity"
+complete -c packagename -s s -l serial -r -d 'Target device serial'
 complete -c packagename -f -n __fish_packagename_needs_command -a force-stop -d 'Force stop an application'
 complete -c packagename -f -n __fish_packagename_needs_command -a pid -d 'Get the process ID of a running package'
 complete -c packagename -f -n __fish_packagename_needs_command -a logcat -d "Display logcat filtered by package's PID"

--- a/fish/completions/packagename.fish
+++ b/fish/completions/packagename.fish
@@ -1,23 +1,29 @@
 # Fish completion script for packagename
 
+# Return the subcommand while skipping the global serial option and its value.
+function __fish_packagename_command
+    set -l tokens (commandline -opc)
+    set -e tokens[1]
+
+    while test (count $tokens) -gt 0
+        switch $tokens[1]
+            case -s --serial
+                set -e tokens[1..2]
+            case '*'
+                echo $tokens[1]
+                return 0
+        end
+    end
+end
+
 # Helper function: check if we need a command
 function __fish_packagename_needs_command
-    set -l cmd (commandline -opc)
-    if test (count $cmd) -eq 1
-        return 0
-    end
-    return 1
+    test -z (__fish_packagename_command)
 end
 
 # Helper function: check if using specific command
 function __fish_packagename_using_command
-    set -l cmd (commandline -opc)
-    if test (count $cmd) -gt 1
-        if test $argv[1] = $cmd[2]
-            return 0
-        end
-    end
-    return 1
+    test "$argv[1]" = (__fish_packagename_command)
 end
 
 # Helper function: get list of installed packages

--- a/skills/adb/SKILL.md
+++ b/skills/adb/SKILL.md
@@ -35,8 +35,10 @@ them as reference when building similar functionality.
 
 ## Quick Start
 
-Target specific devices using the `ANDROID_SERIAL` environment variable if
-multiple devices are connected.
+When multiple devices are connected, pass `-s SERIAL` or `--serial SERIAL`
+before other arguments to any skill script except `adb-screenrecord`. The flag
+overrides `ANDROID_SERIAL`; the environment variable remains available for
+persistent or inherited device selection.
 
 ### Highest-Value Commands
 

--- a/skills/adb/references/troubleshooting.md
+++ b/skills/adb/references/troubleshooting.md
@@ -47,7 +47,9 @@ empty. **Solution**:
 ### Multiple Devices Connected
 
 **Symptom**: `error: more than one device/emulator` **Solution**: Use the
-`ANDROID_SERIAL` environment variable to specify the target device.
+`-s SERIAL` or `--serial SERIAL` before other script arguments to select the
+target device. These options override the `ANDROID_SERIAL` environment variable,
+which remains supported for inherited device selection.
 
 1. List devices:
 
@@ -63,9 +65,12 @@ empty. **Solution**:
    1A2B3C4D               device product:pixel_6 model:Pixel_6 device:oriole
    ```
 
-1. Run script with variable:
+1. Select a device with the flag or environment variable:
 
    ```bash
+   scripts/adb-screenshot -s 1A2B3C4D
+
+   # Or select the device through the environment
    ANDROID_SERIAL=1A2B3C4D scripts/adb-screenshot
    ```
 

--- a/skills/adb/scripts/adb-activities
+++ b/skills/adb/scripts/adb-activities
@@ -19,6 +19,8 @@ Supported categories:
   S - Settings (android.intent.category.PREFERENCE)
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --launcher-only  List only launcher activities
   --home-only      List only home/launcher app activities
   --tv-only        List only TV/Leanback activities
@@ -28,6 +30,7 @@ Options:
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 EOF
   exit 0
 }
@@ -41,6 +44,14 @@ all_apps=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --launcher-only) launcher_only=1 ;;
     --home-only) home_only=1 ;;
     --tv-only) tv_only=1 ;;

--- a/skills/adb/scripts/adb-activities
+++ b/skills/adb/scripts/adb-activities
@@ -51,6 +51,7 @@ while [[ "$#" -gt 0 ]]; do
       fi
       export ANDROID_SERIAL="$2"
       shift 2
+      continue
       ;;
     --launcher-only) launcher_only=1 ;;
     --home-only) home_only=1 ;;

--- a/skills/adb/scripts/adb-battery-stats
+++ b/skills/adb/scripts/adb-battery-stats
@@ -2,22 +2,40 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0")
+Usage: $(basename "$0") [OPTIONS]
 
 Displays battery-related information and settings from an adb-connected device.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 EOF
   exit 0
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 require() {
   command -v "$1" >/dev/null 2>&1 || {

--- a/skills/adb/scripts/adb-currentfocus
+++ b/skills/adb/scripts/adb-currentfocus
@@ -56,9 +56,9 @@ FRAMEWORK_PREFIXES = (
 )
 
 
-def get_adb_command(args: list[str]) -> list[str]:
+def get_adb_command(args: list[str], serial: str | None = None) -> list[str]:
     cmd = ["adb"]
-    serial = os.environ.get("ANDROID_SERIAL")
+    serial = serial or os.environ.get("ANDROID_SERIAL")
     if serial:
         cmd.extend(["-s", serial])
     cmd.extend(args)
@@ -71,10 +71,10 @@ def check_dependencies():
         sys.exit(127)
 
 
-def verify_device():
+def verify_device(serial: str | None = None):
     try:
         res = subprocess.run(
-            get_adb_command(["get-state"]),
+            get_adb_command(["get-state"], serial),
             capture_output=True,
             text=True,
             check=False,
@@ -409,6 +409,7 @@ def main():
         add_help=False,
         epilog="""Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 
 Examples:
   # Display the focused package name
@@ -422,6 +423,13 @@ Examples:
 
   # Output detailed inspection as JSON
   adb-currentfocus --json""",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--serial",
+        metavar="SERIAL",
+        help="Target device serial; specify before other arguments. Overrides ANDROID_SERIAL",
     )
 
     parser.add_argument(
@@ -464,6 +472,8 @@ Examples:
     )
 
     args = parser.parse_args()
+    if args.serial:
+        os.environ["ANDROID_SERIAL"] = args.serial
 
     check_dependencies()
     verify_device()

--- a/skills/adb/scripts/adb-currentfocus
+++ b/skills/adb/scripts/adb-currentfocus
@@ -56,9 +56,9 @@ FRAMEWORK_PREFIXES = (
 )
 
 
-def get_adb_command(args: list[str], serial: str | None = None) -> list[str]:
+def get_adb_command(args: list[str]) -> list[str]:
     cmd = ["adb"]
-    serial = serial or os.environ.get("ANDROID_SERIAL")
+    serial = os.environ.get("ANDROID_SERIAL")
     if serial:
         cmd.extend(["-s", serial])
     cmd.extend(args)
@@ -71,10 +71,10 @@ def check_dependencies():
         sys.exit(127)
 
 
-def verify_device(serial: str | None = None):
+def verify_device():
     try:
         res = subprocess.run(
-            get_adb_command(["get-state"], serial),
+            get_adb_command(["get-state"]),
             capture_output=True,
             text=True,
             check=False,

--- a/skills/adb/scripts/adb-demo
+++ b/skills/adb/scripts/adb-demo
@@ -74,6 +74,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [[ -z "$1" ]]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-demo
+++ b/skills/adb/scripts/adb-demo
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") COMMAND
+Usage: $(basename "$0") [OPTIONS] COMMAND
 
 Enable or disable demo mode on an adb-connected Android device.
 
@@ -25,10 +25,13 @@ Commands:
                 - Disables Do Not Disturb (Zen Mode: Off)
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") on
@@ -52,9 +55,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ -z "$1" ]]; then
   usage_short

--- a/skills/adb/scripts/adb-device-properties
+++ b/skills/adb/scripts/adb-device-properties
@@ -13,19 +13,35 @@ Shows hardware details, software versions, and display configuration including:
   - Display resolution, density, and calculated dp size
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 EOF
   exit 0
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 require() {
   command -v "$1" >/dev/null 2>&1 || {

--- a/skills/adb/scripts/adb-fontscale
+++ b/skills/adb/scripts/adb-fontscale
@@ -67,6 +67,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [[ -z "$1" ]]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-fontscale
+++ b/skills/adb/scripts/adb-fontscale
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") COMMAND [SCALE]
+Usage: $(basename "$0") [OPTIONS] COMMAND [SCALE]
 
 Get or set the system font scale on an adb-connected Android device.
 
@@ -16,10 +16,13 @@ Scales:
   NUMBER      Any numeric scale factor (e.g. 0.85, 1.5)
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") get
@@ -45,9 +48,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ -z "$1" ]]; then
   usage_short

--- a/skills/adb/scripts/adb-log
+++ b/skills/adb/scripts/adb-log
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") MESSAGE
+Usage: $(basename "$0") [OPTIONS] MESSAGE
 
 Writes a message to the Android system log on an adb-connected device.
 
@@ -10,10 +10,13 @@ Arguments:
   MESSAGE     The message string to log.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") "Starting test sequence"
@@ -35,9 +38,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ -z "$1" ]; then
   usage_short

--- a/skills/adb/scripts/adb-log
+++ b/skills/adb/scripts/adb-log
@@ -57,6 +57,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z "$1" ]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-packages
+++ b/skills/adb/scripts/adb-packages
@@ -8,11 +8,14 @@ Lists installed packages on the connected device.
 By default, lists only user-installed (third-party) packages.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --all       List all packages (including system apps)
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 EOF
   exit 0
 }
@@ -22,6 +25,14 @@ all_apps=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --all) all_apps=1 ;;
     --help | -h) usage ;;
     *)

--- a/skills/adb/scripts/adb-packages
+++ b/skills/adb/scripts/adb-packages
@@ -32,6 +32,7 @@ while [[ "$#" -gt 0 ]]; do
       fi
       export ANDROID_SERIAL="$2"
       shift 2
+      continue
       ;;
     --all) all_apps=1 ;;
     --help | -h) usage ;;

--- a/skills/adb/scripts/adb-screenshot
+++ b/skills/adb/scripts/adb-screenshot
@@ -99,6 +99,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede FILE" >&2
+      exit 1
+      ;;
+  esac
+done
+
 require() {
   command -v "$1" >/dev/null 2>&1 || {
     echo >&2 "$(basename "$0"): $1 not found"

--- a/skills/adb/scripts/adb-screenshot
+++ b/skills/adb/scripts/adb-screenshot
@@ -17,6 +17,8 @@ Arguments:
                     (defaults to 'adb-screenshot-YYYYMMDDHHMMSS.png')
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   -o, --output FILE The path to save the screenshot to.
   --preview         Display a preview of the image using chafa
   --no-preview      Disable preview (default)
@@ -26,8 +28,7 @@ Options:
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   # Save screenshot to a timestamped file in the current directory
@@ -46,6 +47,14 @@ COPY=false
 # Manual parsing for options, compatible with macOS getopt
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --help | -h)
       usage
       ;;

--- a/skills/adb/scripts/adb-settings-theme
+++ b/skills/adb/scripts/adb-settings-theme
@@ -2,25 +2,41 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0")
+Usage: $(basename "$0") [OPTIONS]
 
 Opens the system theme settings on the connected Android device (Wear OS).
 Requires a debuggable build (userdebug/eng) with adb root access.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 EOF
   exit 0
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 require() {
   command -v "$1" >/dev/null 2>&1 || {

--- a/skills/adb/scripts/adb-theme
+++ b/skills/adb/scripts/adb-theme
@@ -75,6 +75,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 require adb
 require jq
 

--- a/skills/adb/scripts/adb-theme
+++ b/skills/adb/scripts/adb-theme
@@ -8,7 +8,7 @@ fi
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") COMMAND [THEME]
+Usage: $(basename "$0") [OPTIONS] COMMAND [THEME]
 
 Get or set the Android system theme customization via ADB.
 
@@ -33,7 +33,13 @@ Themes:
   none        Static grey (reset)
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
+
+Environment:
+  ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") get
@@ -50,9 +56,24 @@ require() {
   }
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 require adb
 require jq

--- a/skills/adb/scripts/adb-tile-add
+++ b/skills/adb/scripts/adb-tile-add
@@ -20,6 +20,8 @@ Arguments:
                   com.example.wear.tiles/com.example.wear.tiles.PreviewTileService
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --type TYPE     Tile type: FULLSCREEN, LARGE (default), or SMALL. Only applies
                   to tiles supporting the BIND_WIDGET_PROVIDER intent (e.g.,
                   Glance-based tiles).
@@ -30,8 +32,7 @@ Options:
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") com.google.android.wearable.shell/.weather.WeatherTileService
@@ -65,6 +66,18 @@ TYPE_INT=1 # Default to LARGE
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
+    -s | --serial)
+      if [[ -n "${COMPONENT_NAME:-}" ]]; then
+        echo "$(basename "$0"): $1 must precede COMPONENT_NAME" >&2
+        exit 1
+      fi
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --no-show)
       SHOW=false
       shift

--- a/skills/adb/scripts/adb-tile-remove
+++ b/skills/adb/scripts/adb-tile-remove
@@ -59,6 +59,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z "$1" ]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-tile-remove
+++ b/skills/adb/scripts/adb-tile-remove
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") COMPONENT_NAME
+Usage: $(basename "$0") [OPTIONS] COMPONENT_NAME
 
 Removes all tile instances on the carousel associated with COMPONENT_NAME.
 
@@ -12,12 +12,13 @@ Arguments:
                   com.example.wear.tiles/com.example.wear.tiles.PreviewTileService
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help          Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") com.google.android.wearable.shell/.weather.WeatherTileService
@@ -39,9 +40,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ -z "$1" ]; then
   usage_short

--- a/skills/adb/scripts/adb-tile-switch
+++ b/skills/adb/scripts/adb-tile-switch
@@ -63,6 +63,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z "$1" ]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-tile-switch
+++ b/skills/adb/scripts/adb-tile-switch
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") TILE_INDEX
+Usage: $(basename "$0") [OPTIONS] TILE_INDEX
 
 Activates a tile at the specified index. The tile must already have been added
 to the carousel (e.g., via 'adb-tile-add').
@@ -14,12 +14,13 @@ Arguments:
   TILE_INDEX  The index of the tile to activate.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help      Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0") 0
@@ -43,9 +44,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ -z "$1" ]; then
   usage_short

--- a/skills/adb/scripts/adb-tiles
+++ b/skills/adb/scripts/adb-tiles
@@ -21,6 +21,8 @@ Output format:
   Carousel: C or space
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --tiles-only     List only tile services
   --widgets-only   List only widget services
   --user-only      List only services from user-installed apps
@@ -30,8 +32,7 @@ Options:
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $(basename "$0")
@@ -50,6 +51,14 @@ carousel_only=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --tiles-only) tiles_only=1 ;;
     --widgets-only) widgets_only=1 ;;
     --user-only) user_only=1 ;;

--- a/skills/adb/scripts/adb-tiles
+++ b/skills/adb/scripts/adb-tiles
@@ -58,6 +58,7 @@ while [[ "$#" -gt 0 ]]; do
       fi
       export ANDROID_SERIAL="$2"
       shift 2
+      continue
       ;;
     --tiles-only) tiles_only=1 ;;
     --widgets-only) widgets_only=1 ;;

--- a/skills/adb/scripts/adb-uihierarchy
+++ b/skills/adb/scripts/adb-uihierarchy
@@ -16,14 +16,15 @@ Arguments:
                     If '-', the hierarchy is written to stdout.
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   -o, --output FILE The path to save the hierarchy to.
                     If '-', the hierarchy is written to stdout.
   --help            Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   # Save hierarchy to a timestamped file in the current directory
@@ -42,10 +43,23 @@ EOF
 }
 
 OUTPUT_FILE=""
+POSITIONAL_SEEN=false
 
 # Manual parsing for --output, compatible with macOS getopt
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -s | --serial)
+      if $POSITIONAL_SEEN; then
+        echo "$(basename "$0"): $1 must precede FILE" >&2
+        exit 1
+      fi
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
     --help | -h)
       usage
       ;;
@@ -63,6 +77,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       OUTPUT_FILE="$1"
+      POSITIONAL_SEEN=true
       shift
       ;;
   esac

--- a/skills/adb/scripts/adb-uihierarchy
+++ b/skills/adb/scripts/adb-uihierarchy
@@ -43,13 +43,13 @@ EOF
 }
 
 OUTPUT_FILE=""
-POSITIONAL_SEEN=false
+ARGUMENT_SEEN=false
 
 # Manual parsing for --output, compatible with macOS getopt
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -s | --serial)
-      if $POSITIONAL_SEEN; then
+      if $ARGUMENT_SEEN; then
         echo "$(basename "$0"): $1 must precede FILE" >&2
         exit 1
       fi
@@ -69,6 +69,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       OUTPUT_FILE="$2"
+      ARGUMENT_SEEN=true
       shift 2
       ;;
     *)
@@ -77,7 +78,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       OUTPUT_FILE="$1"
-      POSITIONAL_SEEN=true
+      ARGUMENT_SEEN=true
       shift
       ;;
   esac

--- a/skills/adb/scripts/adb-watchface-set
+++ b/skills/adb/scripts/adb-watchface-set
@@ -63,6 +63,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+for arg in "${@:2}"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$(basename "$0"): $arg must precede arguments or commands" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z "$1" ]; then
   usage_short
 fi

--- a/skills/adb/scripts/adb-watchface-set
+++ b/skills/adb/scripts/adb-watchface-set
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") COMPONENT_NAME
+Usage: $(basename "$0") [OPTIONS] COMPONENT_NAME
 
 Sets the current watch face on a Wear OS device.
 
@@ -15,12 +15,13 @@ Arguments:
                   (e.g., com.google.android.wearable.app/.watchfaces.GoogleWatchFace)
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help          Display this help message and exit
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $(basename "$0")
+                  The --serial option takes precedence when both are set.
 
 Examples:
   # Set a specific watch face
@@ -43,9 +44,24 @@ EOF
   exit 1
 }
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-  usage
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$(basename "$0"): $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ -z "$1" ]; then
   usage_short

--- a/skills/adb/scripts/packagename
+++ b/skills/adb/scripts/packagename
@@ -319,7 +319,7 @@ COMMANDS=(
 
 usage() {
   cat <<EOF
-Usage: $SCRIPT_NAME <command> [arguments]
+Usage: $SCRIPT_NAME [OPTIONS] <command> [arguments]
 
 Android package management utilities via adb.
 
@@ -368,13 +368,14 @@ EOF
   cat <<EOF
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help        Display this help message and exit
   --list        List available commands (names only)
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> $SCRIPT_NAME <command> ...
+                  The --serial option takes precedence when both are set.
 
 Examples:
   $SCRIPT_NAME launch com.android.systemui
@@ -395,6 +396,22 @@ list_commands() {
 # =============================================================================
 # MAIN
 # =============================================================================
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s | --serial)
+      if [[ -z "${2:-}" ]]; then
+        echo "$SCRIPT_NAME: $1 option requires an argument" >&2
+        exit 1
+      fi
+      export ANDROID_SERIAL="$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ $# -lt 1 ]]; then
   usage 1 >&2

--- a/skills/adb/scripts/packagename
+++ b/skills/adb/scripts/packagename
@@ -434,6 +434,15 @@ case "$1" in
     ;;
 esac
 
+for arg in "$@"; do
+  case "$arg" in
+    -s | --serial)
+      echo "$SCRIPT_NAME: $arg must precede the command" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Check dependency
 require adb
 

--- a/skills/coding-standards/references/cli-tools.md
+++ b/skills/coding-standards/references/cli-tools.md
@@ -280,7 +280,7 @@ The first argument must be a verb; the `[Instance]` may be omitted, as in
 <!-- generated: ../../../bin/packagename --help -->
 
 ```text
-Usage: packagename <command> [arguments]
+Usage: packagename [OPTIONS] <command> [arguments]
 
 Android package management utilities via adb.
 
@@ -316,13 +316,14 @@ Commands:
     settings             Open the settings page
 
 Options:
+  -s, --serial SERIAL
+                  Target device serial; must precede arguments or commands.
   --help        Display this help message and exit
   --list        List available commands (names only)
 
 Environment:
   ANDROID_SERIAL  Serial number of device to connect to (see 'adb devices -l').
-                  To target a specific device, use:
-                    env ANDROID_SERIAL=<serial> packagename <command> ...
+                  The --serial option takes precedence when both are set.
 
 Examples:
   packagename launch com.android.systemui


### PR DESCRIPTION
### Motivation

- Make device selection consistent with raw `adb` by accepting `-s SERIAL` / `--serial SERIAL` in every adb wrapper script so callers can select a device without relying only on `ANDROID_SERIAL`.
- Preserve existing workflows: the new flag must precede positional args/subcommands and must override an inherited `ANDROID_SERIAL` value, while leaving single-device and no-device behavior unchanged.
- Keep `adb-screenrecord` untouched because its device-selection behavior is out of scope and handled by scrcpy.

### Description

- Added `-s, --serial SERIAL` parsing to the 18 in-scope scripts under `skills/adb/scripts/` (Bash scripts now validate the option argument and `export ANDROID_SERIAL` immediately so existing `adb` calls downstream behave unchanged). 
- Updated the Python tool `skills/adb/scripts/adb-currentfocus` to accept `-s/--serial` via `argparse` and set `ANDROID_SERIAL` when provided, and adjusted its `adb` helper to preserve existing `-s` usage when a serial is present.
- Updated `packagename` to accept `-s/--serial` before the subcommand (pre-parse loop), changed usage lines to include `[OPTIONS]`, and documented the precedence rule in its help text and the CLI reference block.
- Added `-s` completions to the affected Fish completion files for the listed scripts, updated `skills/adb/SKILL.md` Quick Start and `skills/adb/references/troubleshooting.md` to document the flag alongside `ANDROID_SERIAL`, and refreshed generated command-index blocks in `skills/coding-standards/references/cli-tools.md`.
- Enforced the pinned rules: the `-s` branch is parsed before positional consumption in each script, missing-value cases produce a clear error, and `adb-screenrecord` was not modified.

### Testing

- Formatted and lint-checked changed shell scripts with `bin/shell-format` and verified formatting (shfmt/shellcheck installed during the rollout); these checks passed.
- Validated Fish completions with `fish_indent -w` and `fish -n` for the updated completion files; validation passed.
- Verified Python changes by running `python3 -m py_compile skills/adb/scripts/adb-currentfocus`; byte-compile succeeded.
- Refreshed and checked generated help blocks with `bin/command-index-sync --all` and `bin/command-index-sync --check --all`; checks passed with no drift.
- Ran repository checks: `git diff --check` passed and `bin/command-index-sync` produced expected updates.
- Performed a device-free verification using a stub `adb` placed earlier on `PATH` that logs invocations to confirm: `script -s FOO` results in calls using `FOO`, `ANDROID_SERIAL=BAR script -s FOO` honors `FOO` (flag wins), invoking scripts without `-s` leaves behavior unchanged, and invoking `-s` without a value fails with a helpful error; all stub-based assertions succeeded.

No new automated test suites were added as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cbd6096f88321b4eb13bed3e0ba7b)