### PR TITLE
test(context): match offline assertion to fixture

### DIFF
--- a/skills/agent-tools/tests/test-context
+++ b/skills/agent-tools/tests/test-context
@@ -110,7 +110,7 @@ fi
 # Test 7: A local directory target needs no network, so offline mode must not
 # get in its way.
 if RESPONSE=$(CONTEXT_CACHE_DIR="$CACHE_DIR" AGENT_OFFLINE=1 "$BIN" show "$TMP_DIR"); then
-  if echo "$RESPONSE" | grep -q "Hello World"; then
+  if echo "$RESPONSE" | grep -q "Root file" && echo "$RESPONSE" | grep -q "Subdir file"; then
     echo "ok 7 - Offline mode leaves local directory targets alone"
   else
     echo "not ok 7 - Offline local directory output missing expected content"


### PR DESCRIPTION
## Summary

Fixes the red `test` job on `master`. `skills/agent-tools/tests/test-context` subtest 7 was asserting on fixture content that no longer exists, so it failed unconditionally.

## Cause

`01a17da` ("feat(agent-tools): adopt markdown context layout") rewrote the shared fixture built in test 2:

- before: `file1.txt` containing `Hello World`, plus `file2.txt`
- after: `root.txt` containing `Root file`, plus `subdir/sub.txt` containing `Subdir file`

Test 7 reuses that same `$TMP_DIR` to check that offline mode does not interfere with a local directory target, but it kept grepping for `Hello World` — a string the fixture stopped writing. The assertion could never match, so run #631 failed with `Failed 1/9 subtests`.

This is a stale assertion in the test only. The `context` tool itself is behaving correctly: the offline local-directory path works, and no non-test file is touched.

## Change

`skills/agent-tools/tests/test-context` — assert on the content the fixture actually contains:

```diff
-  if echo "$RESPONSE" | grep -q "Hello World"; then
+  if echo "$RESPONSE" | grep -q "Root file" && echo "$RESPONSE" | grep -q "Subdir file"; then
```

Checking both files keeps test 7 covering the root and subdirectory levels, matching what test 2 already asserts on the same fixture.

## Verification

- `skills/agent-tools/tests/test-context` passes 9/9.
- The workflow's full `lint` job (`shellcheck` and `shfmt -d -i 2 -ci` over every shell script, at the pinned v0.11.0 / v3.10.0) passes clean.
- CI on head `8455c23`: `lint` and `test` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMAAW1ncKTw7enw3BV9CPZ