### PR TITLE
feat(context): send Accept and Accept-Language headers on requests

### DIFF
--- a/skills/agent-tools/scripts/context
+++ b/skills/agent-tools/scripts/context
@@ -32,6 +32,14 @@ CONTEXT_BASE_DIR = os.path.join(
     "context",
 )
 
+# Sent on every outbound HTTP request: Accept names the preferred response
+# format, Accept-Language names a locale plus a preferred programming
+# language for docs/examples that vary by language.
+REQUEST_HEADERS = {
+    "Accept": "text/markdown",
+    "Accept-Language": "en-US, python",
+}
+
 IGNORED_DIRS = {
     ".git",
     "node_modules",
@@ -121,7 +129,7 @@ def _clean_notebook_data(data):
 def entry_url(fetch_url, web_url=None):
     display_cmd = _make_display_cmd(fetch_url, web_url)
     try:
-        response = requests.get(fetch_url)
+        response = requests.get(fetch_url, headers=REQUEST_HEADERS)
         response.raise_for_status()
         _emit_entry(display_cmd, response.text)
     except Exception as e:
@@ -158,7 +166,7 @@ def fetch(url):
 
     print(f"[local] Fetching {archive_url}", file=sys.stderr)
     try:
-        response = requests.get(archive_url, stream=True)
+        response = requests.get(archive_url, stream=True, headers=REQUEST_HEADERS)
         response.raise_for_status()
     except Exception as e:
         print(f"context: fetch: failed to download {archive_url}: {e}", file=sys.stderr)
@@ -216,7 +224,7 @@ def handle_url_target(url):
 
     print(f"[local] Fetching {archive_url}", file=sys.stderr)
     try:
-        response = requests.get(archive_url, stream=True)
+        response = requests.get(archive_url, stream=True, headers=REQUEST_HEADERS)
         response.raise_for_status()
     except Exception as e:
         print(f"context: fetch: failed to download {archive_url}: {e}", file=sys.stderr)
@@ -926,7 +934,7 @@ def entry_prompting():
     try:
         raw_url = "https://raw.githubusercontent.com/openai/openai-cookbook/main/examples/gpt-5/gpt-5_prompting_guide.ipynb"
         print(f"[local] Fetching {raw_url}", file=sys.stderr)
-        response = requests.get(raw_url)
+        response = requests.get(raw_url, headers=REQUEST_HEADERS)
         response.raise_for_status()
         data = response.json()
 


### PR DESCRIPTION
## Summary
- `skills/agent-tools/scripts/context` fetches URLs, GitHub archives, and notebooks via bare `requests.get()` calls with no headers at all.
- Adds a shared `REQUEST_HEADERS` dict (`Accept: text/markdown`, `Accept-Language: en-US, python`) and passes it to all four `requests.get()` call sites (`entry_url`, `fetch`, `handle_url_target`, and the OpenAI cookbook notebook fetch in `entry_prompting`).

## Test plan
- [x] `bin/python-format skills/agent-tools/scripts/context` — ruff lint/format clean
- [x] `AGENT_OFFLINE=1 prove skills/agent-tools/tests/test-context` — all 9 tests pass offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K4S7FtGrvibdGH2s7FL4G

---
_Generated by [Claude Code](https://claude.ai/code/session_011K4S7FtGrvibdGH2s7FL4G)_