### PR TITLE
docs(taskgo): add handover instructions guidance

### DIFF
--- a/fish/completions/taskgo.fish
+++ b/fish/completions/taskgo.fish
@@ -34,7 +34,7 @@ complete -f -c taskgo -n __fish_use_subcommand -a create -d 'Create a new task'
 complete -f -c taskgo -n __fish_use_subcommand -a update -d 'Update task fields, status, or headings'
 complete -f -c taskgo -n __fish_use_subcommand -a list -d 'List tasks'
 complete -f -c taskgo -n __fish_use_subcommand -a status -d 'Show project status'
-complete -f -c taskgo -n __fish_use_subcommand -a handover -d 'Print handover instructions for a successor'
+complete -f -c taskgo -n __fish_use_subcommand -a dispatch -d 'Print agent instructions for a selected task'
 complete -f -c taskgo -n __fish_use_subcommand -a sync -d 'Update STATUS.md snapshot'
 complete -f -c taskgo -n __fish_use_subcommand -a doctor -d 'Run mechanical checks (read-only)'
 complete -f -c taskgo -n __fish_use_subcommand -a fix -d 'Auto-heal task metadata and snapshots'
@@ -51,7 +51,7 @@ complete -c taskgo -f -s h -l help -d 'Display help message and exit'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create list status sync doctor fix' -a '(__fish_taskgo_projects)' -d Project
 
 # Subcommand arguments (Task IDs for update / history / checkpoint)
-complete -f -c taskgo -n '__fish_seen_subcommand_from update history checkpoint handover' -a '(__fish_taskgo_tasks)' -d 'Task ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update history checkpoint dispatch' -a '(__fish_taskgo_tasks)' -d 'Task ID'
 
 # create options
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l slug -x -d 'Filename mnemonic (max 32 chars)'

--- a/fish/completions/taskgo.fish
+++ b/fish/completions/taskgo.fish
@@ -34,6 +34,7 @@ complete -f -c taskgo -n __fish_use_subcommand -a create -d 'Create a new task'
 complete -f -c taskgo -n __fish_use_subcommand -a update -d 'Update task fields, status, or headings'
 complete -f -c taskgo -n __fish_use_subcommand -a list -d 'List tasks'
 complete -f -c taskgo -n __fish_use_subcommand -a status -d 'Show project status'
+complete -f -c taskgo -n __fish_use_subcommand -a handover -d 'Print handover instructions for a successor'
 complete -f -c taskgo -n __fish_use_subcommand -a sync -d 'Update STATUS.md snapshot'
 complete -f -c taskgo -n __fish_use_subcommand -a doctor -d 'Run mechanical checks (read-only)'
 complete -f -c taskgo -n __fish_use_subcommand -a fix -d 'Auto-heal task metadata and snapshots'
@@ -50,7 +51,7 @@ complete -c taskgo -f -s h -l help -d 'Display help message and exit'
 complete -f -c taskgo -n '__fish_seen_subcommand_from create list status sync doctor fix' -a '(__fish_taskgo_projects)' -d Project
 
 # Subcommand arguments (Task IDs for update / history / checkpoint)
-complete -f -c taskgo -n '__fish_seen_subcommand_from update history checkpoint' -a '(__fish_taskgo_tasks)' -d 'Task ID'
+complete -f -c taskgo -n '__fish_seen_subcommand_from update history checkpoint handover' -a '(__fish_taskgo_tasks)' -d 'Task ID'
 
 # create options
 complete -f -c taskgo -n '__fish_seen_subcommand_from create' -l slug -x -d 'Filename mnemonic (max 32 chars)'

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -491,55 +491,23 @@ execution:
 
 ### Handover Instructions (Successor Agent Handoff)
 
-When the next step of a task passes to another agent that *does* hold the
-control repository — typically a fresh session started right after this one —
-hand over with `taskgo handover TASK_ID` rather than an ejection payload. The
-two are near opposites. An ejection payload is long because the isolated worker
-can read nothing else; handover instructions are three sentences because the
-successor can read everything: the tracker, the artifact repos, and Git history.
+When work passes to a successor that can read the control repository, generate a
+dispatch note with `taskgo handover TASK_ID`. Choose the task deliberately;
+`taskgo list PROJECT --state ready` shows the ready frontier, while `## Next` in
+`STATUS.md` normally identifies the intended next action.
 
-Their purpose is dispatch, not context transfer. A successor told only to "look
-through the control repo, work out what is next, and start on it" will get
-there, but it pays for that scan in wall-clock time and tokens on every handoff.
-The note names the destination, so the successor begins from an answer instead
-of deriving one.
+Use the generated output without embellishment. It projects the task ID,
+project, title, and `Goal` from the task record committed at `HEAD`; facts that
+are missing belong in the task, `STATUS.md`, or `PLAN.md`. The command writes
+the note to stdout and readiness findings to stderr. Repair `[WARN]` or `[FAIL]`
+findings before dispatching. It refuses tasks that are not committed or are
+already `done`/`cancelled`.
 
-Everything in the note is a projection of committed tracker state — the task ID,
-its project, the title, and the `Goal` — which is why it is generated rather
-than written. **Do not hand-author or embellish the output.** A note carrying a
-fact found nowhere in the control repo is a defect in the tracker, not a richer
-handover: write that fact into the task record, `STATUS.md`, or `PLAN.md` under
-the handoff-ready rules above, and regenerate. Choosing *which* task to dispatch
-is the judgment the command does not make; `taskgo list PROJECT --state ready`
-shows the frontier, and `## Next` in `STATUS.md` normally already names it.
-
-The summary exists for the human, not the agent. Handover instructions are
-pasted into the next agent's prompt by a person, and that person is the router:
-before pasting, they need to satisfy themselves that this is the right task and
-the right thing to do next, which a bare `TASK-XXXXX` does not let them check by
-eye. The successor gets the same line as a cross-check rather than as
-instruction — an identifier and a title that agree let it open the task and
-start work instead of first verifying it has the right one, and ones that
-disagree are worth stopping on. Brevity is deliberate beyond that: the successor
-is meant to form its own reading of the problem from the tracker, so the note
-gives the destination, not the route.
-
-`handover` writes the note to stdout and its findings to stderr, so a warning
-never contaminates a pasted note. Treat any `[WARN]` as a handoff-ready defect
-in the tracker and repair it before dispatching — uncommitted project changes
-mean the successor cannot read the state the note describes, a missing `Goal`
-means the summary cannot say what the work is, and an unresolved `blocked_by`
-edge means the task is not ready to start. Dispatching a `done` or `cancelled`
-task is refused outright. Warnings do not fail the command: the note is still
-correct as far as the tracker goes, and the decision to hand over anyway is the
-user's.
-
-Produce handover instructions unprompted. When a session has completed a
-substantial piece of work and some time has passed since the last human
-interaction, close by leaving the repositories handoff-ready and then offering
-handover instructions for the next step, without being asked. The note itself is
-a chat response, never a tracked artifact: committing it would reintroduce the
-journal that `HEAD` exists to avoid.
+When yielding after substantial work with a clear successor task, leave the
+tracker and artifact repositories handoff-ready and include the generated note
+in the final response. The note remains chat output rather than a tracked
+artifact. See [Model & Architecture](references/model.md) for the rationale and
+its relationship to isolated-worker ejection.
 
 ```console
 $ taskgo handover TASK-3A91F

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -370,8 +370,9 @@ artifacts (including code repos) must reflect this state. Ensure that:
    uncommitted).
 
 Handoff-ready is the precondition for the successor handoff described in
-"Handover Instructions" below: that note points at this state and asserts
-nothing beyond it, so anything missing here has nowhere else to be recorded.
+"Handover Instructions" below, and `taskgo handover` checks the mechanical part
+of it: that note projects committed tracker state and asserts nothing beyond it,
+so anything missing here has nowhere else to be recorded.
 
 Examples:
 
@@ -492,77 +493,64 @@ execution:
 
 When the next step of a task passes to another agent that *does* hold the
 control repository — typically a fresh session started right after this one —
-write **handover instructions** rather than an ejection payload. The two are
-near opposites. An ejection payload is long because the isolated worker can read
-nothing else; handover instructions are short because the successor can read
-everything: the tracker, the artifact repos, Git history, and, given a
-conversation identifier, often the prior session transcript.
+hand over with `taskgo handover TASK_ID` rather than an ejection payload. The
+two are near opposites. An ejection payload is long because the isolated worker
+can read nothing else; handover instructions are three sentences because the
+successor can read everything: the tracker, the artifact repos, and Git history.
 
 Their purpose is dispatch, not context transfer. A successor told only to "look
 through the control repo, work out what is next, and start on it" will get
 there, but it pays for that scan in wall-clock time and tokens on every handoff.
-Handover instructions name the destination, so the successor begins from an
-answer instead of deriving one.
+The note names the destination, so the successor begins from an answer instead
+of deriving one.
 
-**The note asserts nothing the tracker does not already record.** It is a
-projection of committed state for dispatch, much as `STATUS.md` is a projection
-of the task records for reading. Anything you find yourself wanting to add — a
-finding, a decision, a caveat — is evidence the tracker is incomplete: write it
-into the task record, `STATUS.md`, or `PLAN.md` under the handoff-ready rules
-above, then point at it. The invariant is what keeps the note short, and it
-makes the note checkable: a handover carrying a fact found nowhere in the
-control repo is a defect in the tracker, not a richer handover.
+Everything in the note is a projection of committed tracker state — the task ID,
+its project, the title, and the `Goal` — which is why it is generated rather
+than written. **Do not hand-author or embellish the output.** A note carrying a
+fact found nowhere in the control repo is a defect in the tracker, not a richer
+handover: write that fact into the task record, `STATUS.md`, or `PLAN.md` under
+the handoff-ready rules above, and regenerate. Choosing *which* task to dispatch
+is the judgment the command does not make; `taskgo list PROJECT --state ready`
+shows the frontier, and `## Next` in `STATUS.md` normally already names it.
 
-Write the summary for the human, not the agent. Handover instructions are pasted
-into the next agent's prompt by a person, and that person is the router: before
-pasting, they need to satisfy themselves that this is the right task and the
-right thing to do next. A bare `TASK-XXXXX` cannot be checked by eye, which is
-the whole reason the summary exists. Phrase it in domain terms the person will
-recognize, not in tracker vocabulary they would have to resolve first.
+The summary exists for the human, not the agent. Handover instructions are
+pasted into the next agent's prompt by a person, and that person is the router:
+before pasting, they need to satisfy themselves that this is the right task and
+the right thing to do next, which a bare `TASK-XXXXX` does not let them check by
+eye. The successor gets the same line as a cross-check rather than as
+instruction — an identifier and a title that agree let it open the task and
+start work instead of first verifying it has the right one, and ones that
+disagree are worth stopping on. Brevity is deliberate beyond that: the successor
+is meant to form its own reading of the problem from the tracker, so the note
+gives the destination, not the route.
 
-The summary earns its place with the successor too, as a cross-check rather than
-as instruction. An identifier and a description that agree let the agent open
-the task and start work instead of first verifying it has the right one; ones
-that disagree are worth stopping on, since a stale or mistyped identifier is
-otherwise caught late. Brevity matters for the same reason: the successor is
-meant to form its own reading of the problem from the tracker, and a detailed
-account of how the previous agent saw it silently substitutes for that. Give the
-destination, not the route.
+`handover` writes the note to stdout and its findings to stderr, so a warning
+never contaminates a pasted note. Treat any `[WARN]` as a handoff-ready defect
+in the tracker and repair it before dispatching — uncommitted project changes
+mean the successor cannot read the state the note describes, a missing `Goal`
+means the summary cannot say what the work is, and an unresolved `blocked_by`
+edge means the task is not ready to start. Dispatching a `done` or `cancelled`
+task is refused outright. Warnings do not fail the command: the note is still
+correct as far as the tracker goes, and the decision to hand over anyway is the
+user's.
 
-Include:
+Produce handover instructions unprompted. When a session has completed a
+substantial piece of work and some time has passed since the last human
+interaction, close by leaving the repositories handoff-ready and then offering
+handover instructions for the next step, without being asked. The note itself is
+a chat response, never a tracked artifact: committing it would reintroduce the
+journal that `HEAD` exists to avoid.
 
-1. **Routing:** the verbatim `TASK-XXXXX` identifier and its project. Where the
-   immediate step is one slice of a larger task, say which slice — `## Next` in
-   `STATUS.md` already names it.
-1. **Summary:** one or two sentences on what the work is, drawn from the task
-   title and `Goal`. Enough for a person to recognize the work and judge whether
-   it should happen now.
-1. **Provenance:** the full prior conversation identifier as
-   `[<conversation-id>](<agent>://<conversation-id>)`, so the successor can
-   query the previous session for detail below the granularity the tracker
-   records — how a conclusion was reached, what was tried and discarded. Supply
-   it even when the tracker is complete: it costs a line, and it is
-   unrecoverable later.
+```console
+$ taskgo handover TASK-3A91F
+Next is TASK-3A91F (compiler): Replace the manifest loader with the
+streaming parser.
 
-Handover instructions are a chat response, not a tracked artifact: committing
-them would reintroduce the journal that `HEAD` exists to avoid. They may cite
-conversation identifiers and control repo paths freely, since the successor
-holds the control repo, but the segregation invariant still applies — none of it
-may be pasted into an artifact repository commit.
+Cold start stops scaling with manifest size.
 
-Produce them unprompted. When a session has completed a substantial piece of
-work and some time has passed since the last human interaction, close by leaving
-the repositories handoff-ready and then offering handover instructions for the
-next step, without being asked.
-
-Example:
-
-```text
-Next is TASK-3A91F (compiler): replace the hand-rolled manifest loader with the
-streaming parser, so cold start stops scaling with manifest size. The schema
-work it was blocked on landed last session. Read STATUS.md and the task record
-first and form your own view of the approach. Prior session:
-[<conversation-id>](<agent>://<conversation-id>).
+Read compiler/STATUS.md and the task record
+(compiler/tasks/TASK-3A91F-manifest-loader.md) before acting, and form your
+own view of the approach.
 ```
 
 ### Harbor Task Execution
@@ -651,6 +639,7 @@ taskgo create PROJECT TITLE [--slug SLUG] [--conv ID] [--status STATE] [--proble
 taskgo update TASK_ID [--slug SLUG] [--conv ID] [--status STATE] [--title TITLE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--outcome TEXT] [--findings TEXT] [--next TEXT]
 taskgo list [PROJECT] [--state STATE] [--json]
 taskgo status [PROJECT] [--json]
+taskgo handover TASK_ID
 taskgo sync [PROJECT]
 taskgo doctor [PROJECT]
 taskgo fix [PROJECT] [--dry-run] [--no-commit]
@@ -668,6 +657,13 @@ the initial task record, synchronizes `STATUS.md`, and when the
 automatically. Use `--slug` to name the task file (see "Tasks" above),
 `--no-commit` to keep the created task uncommitted in the working tree, or
 `--dry-run` to preview the task path without creating files.
+
+`handover` prints paste-ready handover instructions dispatching a successor
+agent to `TASK_ID` (see "Handover Instructions" above). It is read-only and
+makes no judgment about which task to dispatch. The note goes to stdout and
+findings to stderr, so warnings never contaminate a pasted note; it exits `1`
+only for an unresolvable task or one already `done`/`cancelled`, and `0` with
+`[WARN]` findings otherwise.
 
 `harbor` commands orchestrate unattended task execution through Harbor.
 `prepare` packages a task into a self-contained trial bundle (with `job.json`,

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -369,10 +369,10 @@ artifacts (including code repos) must reflect this state. Ensure that:
    (e.g. a task is never `done` while its artifact-repo commit remains
    uncommitted).
 
-Handoff-ready is the precondition for the successor handoff described in
-"Handover Instructions" below, and `taskgo handover` checks the mechanical part
-of it: that note projects committed tracker state and asserts nothing beyond it,
-so anything missing here has nowhere else to be recorded.
+Handoff-ready is also the precondition for dispatching another agent to the
+project. `taskgo dispatch` checks the mechanical part of it: the generated note
+projects committed tracker state and asserts nothing beyond it, so anything
+missing here has nowhere else to be recorded.
 
 Examples:
 
@@ -489,12 +489,14 @@ execution:
    and internal reasoning belong strictly in the out-of-band chat response.
    Private metadata must never leak into artifact commits.
 
-### Handover Instructions (Successor Agent Handoff)
+### Agent Dispatch
 
-When work passes to a successor that can read the control repository, generate a
-dispatch note with `taskgo handover TASK_ID`. Choose the task deliberately;
-`taskgo list PROJECT --state ready` shows the ready frontier, while `## Next` in
-`STATUS.md` normally identifies the intended next action.
+When assigning a selected task to an agent that can read the control repository,
+generate its instructions with `taskgo dispatch TASK_ID`. This applies both when
+starting work in a fresh agent session and when transferring work to a
+successor. Choose the task deliberately; `taskgo list PROJECT --state ready`
+shows the ready frontier, while `## Next` in `STATUS.md` normally identifies the
+intended next action.
 
 Use the generated output without embellishment. It projects the task ID,
 project, title, and `Goal` from the task record committed at `HEAD`; facts that
@@ -510,7 +512,7 @@ artifact. See [Model & Architecture](references/model.md) for the rationale and
 its relationship to isolated-worker ejection.
 
 ```console
-$ taskgo handover TASK-3A91F
+$ taskgo dispatch TASK-3A91F
 Next is TASK-3A91F (compiler): Replace the manifest loader with the
 streaming parser.
 
@@ -607,7 +609,7 @@ taskgo create PROJECT TITLE [--slug SLUG] [--conv ID] [--status STATE] [--proble
 taskgo update TASK_ID [--slug SLUG] [--conv ID] [--status STATE] [--title TITLE] [--problem TEXT] [--goal TEXT] [--criteria TEXT] [--sketch TEXT] [--outcome TEXT] [--findings TEXT] [--next TEXT]
 taskgo list [PROJECT] [--state STATE] [--json]
 taskgo status [PROJECT] [--json]
-taskgo handover TASK_ID
+taskgo dispatch TASK_ID
 taskgo sync [PROJECT]
 taskgo doctor [PROJECT]
 taskgo fix [PROJECT] [--dry-run] [--no-commit]
@@ -626,12 +628,12 @@ automatically. Use `--slug` to name the task file (see "Tasks" above),
 `--no-commit` to keep the created task uncommitted in the working tree, or
 `--dry-run` to preview the task path without creating files.
 
-`handover` prints paste-ready handover instructions dispatching a successor
-agent to `TASK_ID` (see "Handover Instructions" above). It is read-only and
-makes no judgment about which task to dispatch. The note goes to stdout and
-findings to stderr, so warnings never contaminate a pasted note; it exits `1`
-only for an unresolvable task or one already `done`/`cancelled`, and `0` with
-`[WARN]` findings otherwise.
+`dispatch` prints paste-ready instructions for assigning an agent to `TASK_ID`
+(see "Agent Dispatch" above). It is read-only and makes no judgment about which
+task to dispatch. The note goes to stdout and findings to stderr, so warnings
+never contaminate a pasted note; it exits `1` only for an unresolvable or
+uncommitted task, or one already `done`/`cancelled`, and `0` with `[WARN]`
+findings otherwise.
 
 `harbor` commands orchestrate unattended task execution through Harbor.
 `prepare` packages a task into a self-contained trial bundle (with `job.json`,

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -369,6 +369,10 @@ artifacts (including code repos) must reflect this state. Ensure that:
    (e.g. a task is never `done` while its artifact-repo commit remains
    uncommitted).
 
+Handoff-ready is the precondition for the successor handoff described in
+"Handover Instructions" below, not a substitute for it: reaching that state is
+what makes the handover note short enough to be worth writing.
+
 Examples:
 
 ```text
@@ -483,6 +487,78 @@ execution:
    in public commit trailers. Branch references, conversation links, telemetry,
    and internal reasoning belong strictly in the out-of-band chat response.
    Private metadata must never leak into artifact commits.
+
+### Handover Instructions (Successor Agent Handoff)
+
+When the next step of a task passes to another agent that *does* hold the
+control repository — typically a fresh session started immediately after this
+one — write **handover instructions** rather than an ejection payload. The two
+are opposites in what they carry. An ejection payload is long because the
+isolated worker can read nothing else; handover instructions are short because
+the successor can read everything: the tracker, the artifact repos, Git history,
+and, given a conversation identifier, often the prior session transcript itself.
+
+The tracker is the handoff; the note is not. Everything durable — state,
+findings, verdicts, next actions — belongs in the task record, `STATUS.md`, and
+`PLAN.md` under the handoff-ready rules above, and the successor will find it
+there. Handover instructions carry only what is true but not yet worth writing
+down as belief: a path already explored and abandoned, a hunch that never
+reached evidence, a warning about something locally surprising. Drafting the
+note is a good moment to notice a durable fact still trapped in the
+conversation; when that happens, write it into the tracker and leave it out of
+the note.
+
+Keep the note to a few sentences. Length is a symptom: a long handover means the
+tracker is not actually handoff-ready, and the repair belongs in the tracker,
+not in the note. Length also does direct harm, because the successor inherits
+framing along with facts. A second agent is meant to form its own reading of the
+problem, and a detailed account of how the first one saw it quietly substitutes
+for that. State hunches as hunches so they stay cheap to discard.
+
+Include, at minimum:
+
+1. **Routing:** the verbatim `TASK-XXXXX` identifier and its project, so the
+   successor knows where to start reading. Name a specific starting document
+   only when it is not the obvious one.
+1. **Provenance:** the full prior conversation identifier as
+   `[<conversation-id>](<agent>://<conversation-id>)`, so the successor can
+   query the previous session for detail that never reached the tracker. Supply
+   it even when the tracker looks complete: it costs one line, and it is
+   unrecoverable once the handover is the only link back.
+1. **Context:** one or two sentences of conversational residue, marked as
+   unverified wherever it is.
+1. **Calibration:** a short factual read on where the work stands — the
+   groundwork is in place, the remaining change is contained, the test suite is
+   fast. This is orientation rather than cheerleading (see the tone rules in the
+   `technical-writing` skill): a successor with no momentum otherwise infers
+   scope from silence, and usually infers too much.
+
+Handover instructions are a chat response to the human, not a tracked artifact.
+They are ephemeral routing, and committing them would reintroduce precisely the
+journal that `HEAD` exists to avoid. They may cite conversation identifiers and
+control repo paths freely, since the successor holds the control repo, but the
+segregation invariant still applies: none of that may be pasted into an artifact
+repository commit.
+
+Produce handover instructions unprompted. When a session has completed a
+substantial piece of work and some time has passed since the last human
+interaction, close by leaving the repositories handoff-ready and then offering
+handover instructions for the next step, without being asked. That is exactly
+the situation where the context worth carrying forward is largest and nearest to
+being lost.
+
+Example:
+
+```text
+Continue TASK-3A91F (compiler). The tracker is current, so read STATUS.md and
+the task record and form your own view before acting. Prior session:
+[<conversation-id>](<agent>://<conversation-id>) — query it for the reasoning
+behind the manifest loader split. Unverified hunch rather than a finding: the
+remaining latency looks like it sits in the loader and not the streaming parser,
+but the session ended before I measured it. The schema work this depends on is
+done and the suite runs in under a minute, so this should be a contained
+change.
+```
 
 ### Harbor Task Execution
 

--- a/skills/taskgo/SKILL.md
+++ b/skills/taskgo/SKILL.md
@@ -370,8 +370,8 @@ artifacts (including code repos) must reflect this state. Ensure that:
    uncommitted).
 
 Handoff-ready is the precondition for the successor handoff described in
-"Handover Instructions" below, not a substitute for it: reaching that state is
-what makes the handover note short enough to be worth writing.
+"Handover Instructions" below: that note points at this state and asserts
+nothing beyond it, so anything missing here has nowhere else to be recorded.
 
 Examples:
 
@@ -491,73 +491,78 @@ execution:
 ### Handover Instructions (Successor Agent Handoff)
 
 When the next step of a task passes to another agent that *does* hold the
-control repository — typically a fresh session started immediately after this
-one — write **handover instructions** rather than an ejection payload. The two
-are opposites in what they carry. An ejection payload is long because the
-isolated worker can read nothing else; handover instructions are short because
-the successor can read everything: the tracker, the artifact repos, Git history,
-and, given a conversation identifier, often the prior session transcript itself.
+control repository — typically a fresh session started right after this one —
+write **handover instructions** rather than an ejection payload. The two are
+near opposites. An ejection payload is long because the isolated worker can read
+nothing else; handover instructions are short because the successor can read
+everything: the tracker, the artifact repos, Git history, and, given a
+conversation identifier, often the prior session transcript.
 
-The tracker is the handoff; the note is not. Everything durable — state,
-findings, verdicts, next actions — belongs in the task record, `STATUS.md`, and
-`PLAN.md` under the handoff-ready rules above, and the successor will find it
-there. Handover instructions carry only what is true but not yet worth writing
-down as belief: a path already explored and abandoned, a hunch that never
-reached evidence, a warning about something locally surprising. Drafting the
-note is a good moment to notice a durable fact still trapped in the
-conversation; when that happens, write it into the tracker and leave it out of
-the note.
+Their purpose is dispatch, not context transfer. A successor told only to "look
+through the control repo, work out what is next, and start on it" will get
+there, but it pays for that scan in wall-clock time and tokens on every handoff.
+Handover instructions name the destination, so the successor begins from an
+answer instead of deriving one.
 
-Keep the note to a few sentences. Length is a symptom: a long handover means the
-tracker is not actually handoff-ready, and the repair belongs in the tracker,
-not in the note. Length also does direct harm, because the successor inherits
-framing along with facts. A second agent is meant to form its own reading of the
-problem, and a detailed account of how the first one saw it quietly substitutes
-for that. State hunches as hunches so they stay cheap to discard.
+**The note asserts nothing the tracker does not already record.** It is a
+projection of committed state for dispatch, much as `STATUS.md` is a projection
+of the task records for reading. Anything you find yourself wanting to add — a
+finding, a decision, a caveat — is evidence the tracker is incomplete: write it
+into the task record, `STATUS.md`, or `PLAN.md` under the handoff-ready rules
+above, then point at it. The invariant is what keeps the note short, and it
+makes the note checkable: a handover carrying a fact found nowhere in the
+control repo is a defect in the tracker, not a richer handover.
 
-Include, at minimum:
+Write the summary for the human, not the agent. Handover instructions are pasted
+into the next agent's prompt by a person, and that person is the router: before
+pasting, they need to satisfy themselves that this is the right task and the
+right thing to do next. A bare `TASK-XXXXX` cannot be checked by eye, which is
+the whole reason the summary exists. Phrase it in domain terms the person will
+recognize, not in tracker vocabulary they would have to resolve first.
 
-1. **Routing:** the verbatim `TASK-XXXXX` identifier and its project, so the
-   successor knows where to start reading. Name a specific starting document
-   only when it is not the obvious one.
+The summary earns its place with the successor too, as a cross-check rather than
+as instruction. An identifier and a description that agree let the agent open
+the task and start work instead of first verifying it has the right one; ones
+that disagree are worth stopping on, since a stale or mistyped identifier is
+otherwise caught late. Brevity matters for the same reason: the successor is
+meant to form its own reading of the problem from the tracker, and a detailed
+account of how the previous agent saw it silently substitutes for that. Give the
+destination, not the route.
+
+Include:
+
+1. **Routing:** the verbatim `TASK-XXXXX` identifier and its project. Where the
+   immediate step is one slice of a larger task, say which slice — `## Next` in
+   `STATUS.md` already names it.
+1. **Summary:** one or two sentences on what the work is, drawn from the task
+   title and `Goal`. Enough for a person to recognize the work and judge whether
+   it should happen now.
 1. **Provenance:** the full prior conversation identifier as
    `[<conversation-id>](<agent>://<conversation-id>)`, so the successor can
-   query the previous session for detail that never reached the tracker. Supply
-   it even when the tracker looks complete: it costs one line, and it is
-   unrecoverable once the handover is the only link back.
-1. **Context:** one or two sentences of conversational residue, marked as
-   unverified wherever it is.
-1. **Calibration:** a short factual read on where the work stands — the
-   groundwork is in place, the remaining change is contained, the test suite is
-   fast. This is orientation rather than cheerleading (see the tone rules in the
-   `technical-writing` skill): a successor with no momentum otherwise infers
-   scope from silence, and usually infers too much.
+   query the previous session for detail below the granularity the tracker
+   records — how a conclusion was reached, what was tried and discarded. Supply
+   it even when the tracker is complete: it costs a line, and it is
+   unrecoverable later.
 
-Handover instructions are a chat response to the human, not a tracked artifact.
-They are ephemeral routing, and committing them would reintroduce precisely the
-journal that `HEAD` exists to avoid. They may cite conversation identifiers and
-control repo paths freely, since the successor holds the control repo, but the
-segregation invariant still applies: none of that may be pasted into an artifact
-repository commit.
+Handover instructions are a chat response, not a tracked artifact: committing
+them would reintroduce the journal that `HEAD` exists to avoid. They may cite
+conversation identifiers and control repo paths freely, since the successor
+holds the control repo, but the segregation invariant still applies — none of it
+may be pasted into an artifact repository commit.
 
-Produce handover instructions unprompted. When a session has completed a
-substantial piece of work and some time has passed since the last human
-interaction, close by leaving the repositories handoff-ready and then offering
-handover instructions for the next step, without being asked. That is exactly
-the situation where the context worth carrying forward is largest and nearest to
-being lost.
+Produce them unprompted. When a session has completed a substantial piece of
+work and some time has passed since the last human interaction, close by leaving
+the repositories handoff-ready and then offering handover instructions for the
+next step, without being asked.
 
 Example:
 
 ```text
-Continue TASK-3A91F (compiler). The tracker is current, so read STATUS.md and
-the task record and form your own view before acting. Prior session:
-[<conversation-id>](<agent>://<conversation-id>) — query it for the reasoning
-behind the manifest loader split. Unverified hunch rather than a finding: the
-remaining latency looks like it sits in the loader and not the streaming parser,
-but the session ended before I measured it. The schema work this depends on is
-done and the suite runs in under a minute, so this should be a contained
-change.
+Next is TASK-3A91F (compiler): replace the hand-rolled manifest loader with the
+streaming parser, so cold start stops scaling with manifest size. The schema
+work it was blocked on landed last session. Read STATUS.md and the task record
+first and form your own view of the approach. Prior session:
+[<conversation-id>](<agent>://<conversation-id>).
 ```
 
 ### Harbor Task Execution

--- a/skills/taskgo/references/model.md
+++ b/skills/taskgo/references/model.md
@@ -87,7 +87,7 @@ actively iterating in uncommitted working trees before forming a checkpoint).
 agents must prioritize the Markdown files as current state and Git as the
 historical record.
 
-## Unified AuditEngine Architecture (`doctor`, `fix`, and `handover`)
+## Unified AuditEngine Architecture (`doctor`, `fix`, and `dispatch`)
 
 To eliminate diagnostic and repair drift, `scripts/taskgo` uses a single shared
 `AuditEngine` (`audit_workspace()`):
@@ -102,31 +102,32 @@ To eliminate diagnostic and repair drift, `scripts/taskgo` uses a single shared
   `COMMIT_SHA` output on `stdout`. Use `--dry-run` to preview changes without
   modifying files or committing, or `--no-commit` to apply repairs on disk
   without committing.
-- **`handover` (Committed-State Projection):** Uses the audit engine's project
-  findings alongside handover-specific checks, then emits a dispatch note from
+- **`dispatch` (Committed-State Projection):** Uses the audit engine's project
+  findings alongside dispatch-specific checks, then emits a dispatch note from
   the selected task record at `HEAD`. Findings describe working-tree or tracker
   defects on stderr without changing the committed note on stdout.
 
-## Successor Handover
+## Agent Dispatch
 
-Successor handover and isolated-worker ejection solve different problems. An
+Agent dispatch and isolated-worker ejection solve different problems. An
 isolated worker cannot read the control repository, so an ejection payload must
-inline the task specification and its dependencies. A successor agent with the
-control repository can read the tracker, artifact repositories, and Git history;
-it needs a destination rather than duplicated context.
+inline the task specification and its dependencies. An agent with the control
+repository can read the tracker, artifact repositories, and Git history; it
+needs a destination rather than duplicated context. This is true both at the
+start of a fresh agent session and when work passes to a successor.
 
-`taskgo handover TASK_ID` therefore generates a short dispatch note containing
+`taskgo dispatch TASK_ID` therefore generates a short dispatch note containing
 only the task ID, project, title, `Goal`, and paths to the project status and
 task record. These values come from the task record committed at `HEAD`, which
 keeps the note reproducible even when the working tree is dirty. The human
-transferring the note remains the router: its summary lets that person verify
-the selected task before pasting it, while the successor uses the identifier and
-title as a cross-check before reading the tracker and choosing an approach.
+dispatching the note remains the router: its summary lets that person verify the
+selected task before pasting it, while the receiving agent uses the identifier
+and title as a cross-check before reading the tracker and choosing an approach.
 
 The command does not select work. `taskgo list PROJECT --state ready` exposes
 the ready frontier, and `STATUS.md` records the intended immediate direction. A
-long handover or one requiring extra facts indicates that the tracker is not
-handoff-ready; repair the durable state instead of expanding the note.
+long dispatch note or one requiring extra facts indicates that the tracker is
+not handoff-ready; repair the durable state instead of expanding the note.
 
 ## Command Vocabulary
 
@@ -142,9 +143,8 @@ unhyphenated verbs:
   JSON format.
 - `taskgo status [PROJECT] [--json]`: Display operational status or
   multi-project summary.
-- `taskgo handover TASK_ID`: Generate successor dispatch instructions from the
-  selected task record committed at `HEAD` and report readiness findings on
-  stderr.
+- `taskgo dispatch TASK_ID`: Generate agent instructions from the selected task
+  record committed at `HEAD` and report readiness findings on stderr.
 - `taskgo sync [PROJECT]`: Synchronize `STATUS.md` snapshot block.
 - `taskgo doctor [PROJECT]`: Diagnostic health check (read-only).
 - `taskgo fix [PROJECT] [--dry-run] [--no-commit]`: Auto-heal task metadata,

--- a/skills/taskgo/references/model.md
+++ b/skills/taskgo/references/model.md
@@ -87,7 +87,7 @@ actively iterating in uncommitted working trees before forming a checkpoint).
 agents must prioritize the Markdown files as current state and Git as the
 historical record.
 
-## Unified AuditEngine Architecture (`doctor` & `fix`)
+## Unified AuditEngine Architecture (`doctor`, `fix`, and `handover`)
 
 To eliminate diagnostic and repair drift, `scripts/taskgo` uses a single shared
 `AuditEngine` (`audit_workspace()`):
@@ -102,6 +102,31 @@ To eliminate diagnostic and repair drift, `scripts/taskgo` uses a single shared
   `COMMIT_SHA` output on `stdout`. Use `--dry-run` to preview changes without
   modifying files or committing, or `--no-commit` to apply repairs on disk
   without committing.
+- **`handover` (Committed-State Projection):** Uses the audit engine's project
+  findings alongside handover-specific checks, then emits a dispatch note from
+  the selected task record at `HEAD`. Findings describe working-tree or tracker
+  defects on stderr without changing the committed note on stdout.
+
+## Successor Handover
+
+Successor handover and isolated-worker ejection solve different problems. An
+isolated worker cannot read the control repository, so an ejection payload must
+inline the task specification and its dependencies. A successor agent with the
+control repository can read the tracker, artifact repositories, and Git history;
+it needs a destination rather than duplicated context.
+
+`taskgo handover TASK_ID` therefore generates a short dispatch note containing
+only the task ID, project, title, `Goal`, and paths to the project status and
+task record. These values come from the task record committed at `HEAD`, which
+keeps the note reproducible even when the working tree is dirty. The human
+transferring the note remains the router: its summary lets that person verify
+the selected task before pasting it, while the successor uses the identifier and
+title as a cross-check before reading the tracker and choosing an approach.
+
+The command does not select work. `taskgo list PROJECT --state ready` exposes
+the ready frontier, and `STATUS.md` records the intended immediate direction. A
+long handover or one requiring extra facts indicates that the tracker is not
+handoff-ready; repair the durable state instead of expanding the note.
 
 ## Command Vocabulary
 
@@ -117,6 +142,9 @@ unhyphenated verbs:
   JSON format.
 - `taskgo status [PROJECT] [--json]`: Display operational status or
   multi-project summary.
+- `taskgo handover TASK_ID`: Generate successor dispatch instructions from the
+  selected task record committed at `HEAD` and report readiness findings on
+  stderr.
 - `taskgo sync [PROJECT]`: Synchronize `STATUS.md` snapshot block.
 - `taskgo doctor [PROJECT]`: Diagnostic health check (read-only).
 - `taskgo fix [PROJECT] [--dry-run] [--no-commit]`: Auto-heal task metadata,

--- a/skills/taskgo/scripts/taskgo
+++ b/skills/taskgo/scripts/taskgo
@@ -2246,8 +2246,8 @@ def list_projects(root: Path) -> list[str]:
     return [p.name for p in sorted(root.iterdir()) if is_project_dir(p)]
 
 
-def cmd_handover(task_id: str) -> None:
-    """Emit paste-ready handover instructions dispatching a successor to TASK_ID."""
+def cmd_dispatch(task_id: str) -> None:
+    """Emit instructions dispatching an agent to TASK_ID."""
     root = get_repo_root()
     target_path = resolve_target(root, task_id)
     rel_path = Path(str(target_path.relative_to(root))).as_posix()
@@ -2256,7 +2256,7 @@ def cmd_handover(task_id: str) -> None:
     committed = run_git(["show", f"HEAD:{rel_path}"], check=False)
     if committed.returncode != 0:
         die_scoped(
-            f"{rel_path} is not committed at HEAD; commit it before handing over"
+            f"{rel_path} is not committed at HEAD; commit the task before dispatching it"
         )
     content = committed.stdout
 
@@ -2267,10 +2267,10 @@ def cmd_handover(task_id: str) -> None:
     title = extract_title(content)
     goal = extract_runin(content, "Goal")
 
-    # Handing over finished work is a mis-dispatch, not a thin note: refuse it.
+    # Dispatching finished work is a selection error, so refuse it.
     if status in RESOLVED_STATES:
         die_scoped(
-            f"{resolved_id} is {status}; handover dispatches unfinished work "
+            f"{resolved_id} is {status}; dispatch accepts only unfinished work "
             f"(see 'taskgo list {project_name} --state ready')"
         )
 
@@ -2308,8 +2308,8 @@ def cmd_handover(task_id: str) -> None:
                 )
             )
 
-    # A handover points at committed state. Uncommitted project files mean the
-    # successor cannot see what this note describes.
+    # A dispatch note points at committed state. Uncommitted project files mean
+    # the receiving agent cannot see every current workspace change.
     dirty = run_git(
         ["status", "--porcelain", "--", project_name], check=False
     ).stdout.strip()
@@ -3046,7 +3046,7 @@ Commands:
   update TASK_ID [OPTIONS]         Update task fields, status, or headings
   list [PROJECT] [OPTIONS]         List tasks (--state ready for the frontier)
   status [PROJECT] [--json]        Show project status
-  handover TASK_ID                 Print handover instructions for a successor
+  dispatch TASK_ID                 Print agent instructions for a selected task
   sync [PROJECT]                   Update STATUS.md snapshot
   doctor [PROJECT]                 Run mechanical checks (read-only)
   fix [PROJECT] [OPTIONS]          Auto-heal IDs, statuses, and snapshots
@@ -3070,7 +3070,7 @@ Examples:
   taskgo create my-project "Diagnose intermittent disconnects" --slug disconnects
   taskgo create my-project "Add cache layer" --slug cache-layer --problem "High latency"
   taskgo update TASK-3A91F --status in-progress --sketch "Use in-memory dict"
-  taskgo handover TASK-3A91F
+  taskgo dispatch TASK-3A91F
   taskgo sync my-project
   taskgo fix my-project
   taskgo checkpoint TASK-3A91F "project: start diagnosis" --all"""
@@ -3269,30 +3269,30 @@ than a few words.""",
         help="Output machine-readable JSON",
     )
 
-    # handover
-    p_handover = subparsers.add_parser(
-        "handover",
-        help="Print handover instructions dispatching a successor to a task",
-        description="Print handover instructions dispatching a successor to a task.",
+    # dispatch
+    p_dispatch = subparsers.add_parser(
+        "dispatch",
+        help="Print agent instructions for a selected task",
+        description="Print instructions dispatching an agent to a selected task.",
         formatter_class=HouseStyleHelpFormatter,
         add_help=False,
         epilog="""Examples:
-  taskgo handover TASK-3A91F
-  taskgo --root ~/projects handover TASK-3A91F
+  taskgo dispatch TASK-3A91F
+  taskgo --root ~/projects dispatch TASK-3A91F
 
 The note is generated from the task record committed at HEAD. Findings about
 working-tree or tracker readiness are written to stderr.""",
     )
-    p_handover.add_argument(
+    p_dispatch.add_argument(
         "--help",
         "-h",
         action="help",
         help="Display this help message and exit",
     )
-    p_handover.add_argument(
+    p_dispatch.add_argument(
         "task_id",
         metavar="TASK_ID",
-        help="Task to dispatch the successor to",
+        help="Task to assign to the agent",
     )
 
     # sync
@@ -3705,8 +3705,8 @@ def main(argv: list[str] | None = None) -> None:
             project=args.project,
             as_json=args.as_json,
         )
-    elif args.command == "handover":
-        cmd_handover(task_id=args.task_id)
+    elif args.command == "dispatch":
+        cmd_dispatch(task_id=args.task_id)
     elif args.command == "sync":
         cmd_sync(project=args.project)
     elif args.command == "doctor":

--- a/skills/taskgo/scripts/taskgo
+++ b/skills/taskgo/scripts/taskgo
@@ -2253,12 +2253,16 @@ def cmd_handover(task_id: str) -> None:
     rel_path = Path(str(target_path.relative_to(root))).as_posix()
     project_name = rel_path.split("/")[0]
 
-    try:
-        content = target_path.read_text(encoding="utf-8")
-    except OSError as e:
-        die_scoped(f"cannot read task file {rel_path}: {e}")
+    committed = run_git(["show", f"HEAD:{rel_path}"], check=False)
+    if committed.returncode != 0:
+        die_scoped(
+            f"{rel_path} is not committed at HEAD; commit it before handing over"
+        )
+    content = committed.stdout
 
-    resolved_id = extract_frontmatter_field(content, "id") or task_id.upper()
+    resolved_id = extract_frontmatter_field(content, "id")
+    if not ID_PATTERN.match(resolved_id):
+        die_scoped(f"{rel_path} has no valid committed task ID")
     status = extract_frontmatter_field(content, "status")
     title = extract_title(content)
     goal = extract_runin(content, "Goal")
@@ -2270,26 +2274,38 @@ def cmd_handover(task_id: str) -> None:
             f"(see 'taskgo list {project_name} --state ready')"
         )
 
-    warnings: list[str] = []
+    findings: list[tuple[Literal["WARN", "FAIL"], str]] = []
     if not title:
-        warnings.append(
-            f"{resolved_id} has no title heading; the note names only its ID"
+        findings.append(
+            ("WARN", f"{resolved_id} has no title heading; the note names only its ID")
         )
     if not goal:
-        warnings.append(
-            f"{resolved_id} has no '**Goal:**'; the summary cannot say what the work is"
+        findings.append(
+            (
+                "WARN",
+                f"{resolved_id} has no '**Goal:**'; the summary cannot say what the work is",
+            )
         )
-    if status and status not in STANDARD_STATES:
-        warnings.append(f"{resolved_id} has a nonstandard status: {status}")
+
+    findings.extend(
+        (finding.severity, finding.message)
+        for finding in audit_workspace(root, project_name)
+        if finding.severity in {"WARN", "FAIL"}
+    )
 
     rows = get_task_rows(root, project_name)
     row = next((r for r in rows if r.task_id == resolved_id), None)
     if row is not None:
         blockers = unresolved_blockers(row, status_index(root))
         if blockers:
-            warnings.append(
-                f"{resolved_id} is still blocked by {', '.join(blockers)}; "
-                "it is not ready to dispatch"
+            findings.append(
+                (
+                    "WARN",
+                    (
+                        f"{resolved_id} is still blocked by {', '.join(blockers)}; "
+                        "it is not ready to dispatch"
+                    ),
+                )
             )
 
     # A handover points at committed state. Uncommitted project files mean the
@@ -2298,13 +2314,18 @@ def cmd_handover(task_id: str) -> None:
         ["status", "--porcelain", "--", project_name], check=False
     ).stdout.strip()
     if dirty:
-        warnings.append(
-            f"{project_name} has uncommitted changes; the note points at state "
-            "the successor cannot read (commit before handing over)"
+        findings.append(
+            (
+                "WARN",
+                (
+                    f"{project_name} has uncommitted changes; the note describes "
+                    "committed state only"
+                ),
+            )
         )
 
-    for w in warnings:
-        print(_tagged(f"[WARN]  {w}", sys.stderr), file=sys.stderr)
+    for severity, message in findings:
+        print(_tagged(f"[{severity}]  {message}", sys.stderr), file=sys.stderr)
 
     headline = f"Next is {resolved_id} ({project_name})"
     if title:
@@ -2999,6 +3020,18 @@ def cmd_harbor(args: argparse.Namespace) -> None:
         sys.exit(code)
 
 
+class HouseStyleHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """Capitalizes argparse's fixed help headings to match the CLI house style."""
+
+    def format_help(self) -> str:
+        rendered = super().format_help()
+        return (
+            rendered.replace("usage:", "Usage:", 1)
+            .replace("positional arguments:", "Arguments:", 1)
+            .replace("options:", "Options:", 1)
+        )
+
+
 def help_text() -> str:
     """Renders top-level help, including the resolved control repository root."""
     root_dir, source = resolve_root_candidate()
@@ -3241,7 +3274,20 @@ than a few words.""",
         "handover",
         help="Print handover instructions dispatching a successor to a task",
         description="Print handover instructions dispatching a successor to a task.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=HouseStyleHelpFormatter,
+        add_help=False,
+        epilog="""Examples:
+  taskgo handover TASK-3A91F
+  taskgo --root ~/projects handover TASK-3A91F
+
+The note is generated from the task record committed at HEAD. Findings about
+working-tree or tracker readiness are written to stderr.""",
+    )
+    p_handover.add_argument(
+        "--help",
+        "-h",
+        action="help",
+        help="Display this help message and exit",
     )
     p_handover.add_argument(
         "task_id",

--- a/skills/taskgo/scripts/taskgo
+++ b/skills/taskgo/scripts/taskgo
@@ -809,6 +809,24 @@ def extract_title(content: str) -> str:
     return ""
 
 
+def extract_runin(content: str, label: str) -> str:
+    """Extracts the text of a bold run-in label (e.g. '**Goal:** ...') from a task body.
+
+    Returns the label's prose with internal newlines collapsed, or '' when the
+    label is absent. Mirrors the run-in layout written by 'create'/'update'.
+    """
+    _, body = parse_frontmatter(content)
+    body = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+    m = re.search(
+        rf"\*\*{re.escape(label)}:\*\*(.*?)(?=(\n\n\*\*|\n\n#|\Z))",
+        body,
+        re.DOTALL,
+    )
+    if not m:
+        return ""
+    return " ".join(m.group(1).split())
+
+
 def normalize_slug(value: str) -> str:
     """Normalizes VALUE into slug form (lowercase, hyphen-separated, no truncation)."""
     s = value.lower()
@@ -2228,6 +2246,92 @@ def list_projects(root: Path) -> list[str]:
     return [p.name for p in sorted(root.iterdir()) if is_project_dir(p)]
 
 
+def cmd_handover(task_id: str) -> None:
+    """Emit paste-ready handover instructions dispatching a successor to TASK_ID."""
+    root = get_repo_root()
+    target_path = resolve_target(root, task_id)
+    rel_path = Path(str(target_path.relative_to(root))).as_posix()
+    project_name = rel_path.split("/")[0]
+
+    try:
+        content = target_path.read_text(encoding="utf-8")
+    except OSError as e:
+        die_scoped(f"cannot read task file {rel_path}: {e}")
+
+    resolved_id = extract_frontmatter_field(content, "id") or task_id.upper()
+    status = extract_frontmatter_field(content, "status")
+    title = extract_title(content)
+    goal = extract_runin(content, "Goal")
+
+    # Handing over finished work is a mis-dispatch, not a thin note: refuse it.
+    if status in RESOLVED_STATES:
+        die_scoped(
+            f"{resolved_id} is {status}; handover dispatches unfinished work "
+            f"(see 'taskgo list {project_name} --state ready')"
+        )
+
+    warnings: list[str] = []
+    if not title:
+        warnings.append(
+            f"{resolved_id} has no title heading; the note names only its ID"
+        )
+    if not goal:
+        warnings.append(
+            f"{resolved_id} has no '**Goal:**'; the summary cannot say what the work is"
+        )
+    if status and status not in STANDARD_STATES:
+        warnings.append(f"{resolved_id} has a nonstandard status: {status}")
+
+    rows = get_task_rows(root, project_name)
+    row = next((r for r in rows if r.task_id == resolved_id), None)
+    if row is not None:
+        blockers = unresolved_blockers(row, status_index(root))
+        if blockers:
+            warnings.append(
+                f"{resolved_id} is still blocked by {', '.join(blockers)}; "
+                "it is not ready to dispatch"
+            )
+
+    # A handover points at committed state. Uncommitted project files mean the
+    # successor cannot see what this note describes.
+    dirty = run_git(
+        ["status", "--porcelain", "--", project_name], check=False
+    ).stdout.strip()
+    if dirty:
+        warnings.append(
+            f"{project_name} has uncommitted changes; the note points at state "
+            "the successor cannot read (commit before handing over)"
+        )
+
+    for w in warnings:
+        print(_tagged(f"[WARN]  {w}", sys.stderr), file=sys.stderr)
+
+    headline = f"Next is {resolved_id} ({project_name})"
+    if title:
+        headline += f": {title}"
+        if title[-1] not in ".?!":
+            headline += "."
+    else:
+        headline += "."
+
+    status_md = f"{project_name}/STATUS.md"
+    paragraphs = [headline]
+    if goal:
+        paragraphs.append(goal)
+    paragraphs.append(
+        f"Read {status_md} and the task record ({rel_path}) before acting, and "
+        "form your own view of the approach."
+    )
+    # Never break inside a path or hyphenated identifier: the note is pasted and
+    # its file references must stay greppable.
+    print(
+        "\n\n".join(
+            textwrap.fill(p, width=76, break_long_words=False, break_on_hyphens=False)
+            for p in paragraphs
+        )
+    )
+
+
 def cmd_sync(
     project: str | None = None,
 ) -> None:
@@ -2909,6 +3013,7 @@ Commands:
   update TASK_ID [OPTIONS]         Update task fields, status, or headings
   list [PROJECT] [OPTIONS]         List tasks (--state ready for the frontier)
   status [PROJECT] [--json]        Show project status
+  handover TASK_ID                 Print handover instructions for a successor
   sync [PROJECT]                   Update STATUS.md snapshot
   doctor [PROJECT]                 Run mechanical checks (read-only)
   fix [PROJECT] [OPTIONS]          Auto-heal IDs, statuses, and snapshots
@@ -2932,6 +3037,7 @@ Examples:
   taskgo create my-project "Diagnose intermittent disconnects" --slug disconnects
   taskgo create my-project "Add cache layer" --slug cache-layer --problem "High latency"
   taskgo update TASK-3A91F --status in-progress --sketch "Use in-memory dict"
+  taskgo handover TASK-3A91F
   taskgo sync my-project
   taskgo fix my-project
   taskgo checkpoint TASK-3A91F "project: start diagnosis" --all"""
@@ -3128,6 +3234,19 @@ than a few words.""",
         dest="as_json",
         action="store_true",
         help="Output machine-readable JSON",
+    )
+
+    # handover
+    p_handover = subparsers.add_parser(
+        "handover",
+        help="Print handover instructions dispatching a successor to a task",
+        description="Print handover instructions dispatching a successor to a task.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_handover.add_argument(
+        "task_id",
+        metavar="TASK_ID",
+        help="Task to dispatch the successor to",
     )
 
     # sync
@@ -3540,6 +3659,8 @@ def main(argv: list[str] | None = None) -> None:
             project=args.project,
             as_json=args.as_json,
         )
+    elif args.command == "handover":
+        cmd_handover(task_id=args.task_id)
     elif args.command == "sync":
         cmd_sync(project=args.project)
     elif args.command == "doctor":

--- a/skills/taskgo/tests/test-taskgo
+++ b/skills/taskgo/tests/test-taskgo
@@ -45,7 +45,7 @@ printf '%s\n' \
   '# Confirm generated status formatting' \
   >"$REPO/example/tasks/TASK-A1B2C-confirm-status.md"
 
-echo '1..117'
+echo '1..122'
 
 if ("$BIN" --root "$REPO" sync example) &&
   "$MARKDOWN_FORMAT" --check "$REPO/example/STATUS.md" >/dev/null; then
@@ -1943,10 +1943,10 @@ printf '\nNew content\n' >>"$AGENT_REPO/proj/tasks/TASK-A6E01-agent-task.md"
 (AI_AGENT="claude-code_2-1-267_agent" CLAUDE_CODE_SESSION_ID="11112222-3333-4444-5555-666677778888" "$BIN" --root "$AGENT_REPO" checkpoint TASK-A6E01 "chore(proj): diagnose runner timeouts" --all)
 AGENT_FM="$(cat "$AGENT_REPO/proj/tasks/TASK-A6E01-agent-task.md")"
 AGENT_LOG="$(git -C "$AGENT_REPO" log -1 --pretty=%B)"
-if echo "$AGENT_FM" | grep -q 'claude://11112222-3333-4444-5555-666677778888' && \
-   ! echo "$AGENT_FM" | grep -q '(' && \
-   ! echo "$AGENT_FM" | grep -q 'claude-code' && \
-   echo "$AGENT_LOG" | grep -q "Conversation: claude://11112222-3333-4444-5555-666677778888"; then
+if echo "$AGENT_FM" | grep -q 'claude://11112222-3333-4444-5555-666677778888' &&
+  ! echo "$AGENT_FM" | grep -q '(' &&
+  ! echo "$AGENT_FM" | grep -q 'claude-code' &&
+  echo "$AGENT_LOG" | grep -q "Conversation: claude://11112222-3333-4444-5555-666677778888"; then
   echo 'ok 107 - Claude Code env vars map to canonical claude scheme without annotations'
 else
   echo 'not ok 107 - Claude Code env vars map to canonical claude scheme without annotations'
@@ -2003,11 +2003,11 @@ set -e
 (AI_AGENT=claude "$BIN" --root "$TOL_REPO" update TASK-A1B2C --status in-progress --conv "afb6245a-b957-464c-934e-9d09ee099e97" >/dev/null)
 UPGRADED_FM="$(cat "$TOL_REPO/proj/tasks/TASK-A1B2C-tol-task.md")"
 
-if [ "$TOL_EXIT" -eq 0 ] && \
-   echo "$TOL_DR_OUT" | grep -q '\[INFO\]  proj/tasks/TASK-A1B2C-tol-task.md: unparseable conversation entry' && \
-   ! echo "$TOL_DR_OUT" | grep -q 'claude.ai' && \
-   echo "$UPGRADED_FM" | grep -q 'claude://afb6245a-b957-464c-934e-9d09ee099e97' && \
-   ! echo "$UPGRADED_FM" | grep -q 'conversation://afb6245a-b957-464c-934e-9d09ee099e97'; then
+if [ "$TOL_EXIT" -eq 0 ] &&
+  echo "$TOL_DR_OUT" | grep -q '\[INFO\]  proj/tasks/TASK-A1B2C-tol-task.md: unparseable conversation entry' &&
+  ! echo "$TOL_DR_OUT" | grep -q 'claude.ai' &&
+  echo "$UPGRADED_FM" | grep -q 'claude://afb6245a-b957-464c-934e-9d09ee099e97' &&
+  ! echo "$UPGRADED_FM" | grep -q 'conversation://afb6245a-b957-464c-934e-9d09ee099e97'; then
   echo 'ok 109 - legacy conversation upgrades to agent scheme, web URLs accepted, non-blocking INFO on malformed'
 else
   echo 'not ok 109 - legacy conversation upgrades to agent scheme, web URLs accepted, non-blocking INFO on malformed'
@@ -2044,12 +2044,12 @@ DR_VAL_OUT="$("$BIN" --root "$VAL_REPO" doctor proj 2>&1)"
 DR_VAL_EXIT=$?
 set -e
 
-if [ "$SHORT_URI_EXIT" -ne 0 ] && \
-   echo "$SHORT_URI_OUT" | grep -q "invalid conversation ID 'x://b'" && \
-   [ "$MALFORMED_URI_EXIT" -ne 0 ] && \
-   echo "$MALFORMED_URI_OUT" | grep -q "invalid conversation ID 'claude://aaaabbbbcccc1111 (a: b: c)'" && \
-   [ "$DR_VAL_EXIT" -eq 0 ] && \
-   ! echo "$DR_VAL_OUT" | grep -q "invalid YAML"; then
+if [ "$SHORT_URI_EXIT" -ne 0 ] &&
+  echo "$SHORT_URI_OUT" | grep -q "invalid conversation ID 'x://b'" &&
+  [ "$MALFORMED_URI_EXIT" -ne 0 ] &&
+  echo "$MALFORMED_URI_OUT" | grep -q "invalid conversation ID 'claude://aaaabbbbcccc1111 (a: b: c)'" &&
+  [ "$DR_VAL_EXIT" -eq 0 ] &&
+  ! echo "$DR_VAL_OUT" | grep -q "invalid YAML"; then
   echo 'ok 110 - remainder validation rejects short/malformed URIs, and render_task_file quotes YAML cleanly'
 else
   echo 'not ok 110 - remainder validation rejects short/malformed URIs, and render_task_file quotes YAML cleanly'
@@ -2110,6 +2110,26 @@ printf '%s\n' \
   '' \
   '# Freeze the schema' \
   >"$HO_REPO/proj/tasks/TASK-44444-freeze.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-55555' \
+  'status: blocked' \
+  '---' \
+  '' \
+  '# Wait for an external release' \
+  '' \
+  '**Goal:** Adopt the release after it ships.' \
+  >"$HO_REPO/proj/tasks/TASK-55555-blocked.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-66666' \
+  '---' \
+  '' \
+  '# Classify the task' \
+  '' \
+  '**Goal:** Give the task a valid state.' \
+  >"$HO_REPO/proj/tasks/TASK-66666-missing-status.md"
+("$BIN" --root "$HO_REPO" sync proj >/dev/null)
 git -C "$HO_REPO" add -A
 git -C "$HO_REPO" commit -qm 'init handover fixture'
 
@@ -2196,4 +2216,72 @@ if [[ "$HO_CLEAN" != *"[WARN]"* ]] && [[ "$HO_CLEAN" != *"blocked by"* ]]; then
   echo 'ok 117 - handover keeps diagnostics off stdout'
 else
   echo 'not ok 117 - handover keeps diagnostics off stdout'
+fi
+
+# Test 118: dirty task prose cannot leak into the committed-state projection
+sed -i.bak 's/Cold start stops scaling with manifest size/Use a replacement goal from the working tree/' \
+  "$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md"
+set +e
+HO_DIRTY_TASK_ERR="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>&1 >/dev/null)"
+HO_DIRTY_TASK_EXIT=$?
+set -e
+HO_DIRTY_TASK_OUT="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
+git -C "$HO_REPO" checkout -q -- proj/tasks/TASK-11111-manifest-loader.md
+rm -f "$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md.bak"
+if [ "$HO_DIRTY_TASK_EXIT" -eq 0 ] &&
+  [[ "$HO_DIRTY_TASK_ERR" == *"uncommitted changes"* ]] &&
+  [[ "$HO_DIRTY_TASK_OUT" == *"Cold start stops scaling with manifest size."* ]] &&
+  [[ "$HO_DIRTY_TASK_OUT" != *"replacement goal"* ]]; then
+  echo 'ok 118 - handover projects committed task prose when the working tree is dirty'
+else
+  echo 'not ok 118 - handover projects committed task prose when the working tree is dirty'
+fi
+
+# Test 119: explicit blocked state warns even without a blocked_by edge
+HO_STATUS_BLOCKED_ERR="$("$BIN" --root "$HO_REPO" handover TASK-55555 2>&1 >/dev/null)"
+if [[ "$HO_STATUS_BLOCKED_ERR" == *"status is blocked but no blocked_by edges"* ]]; then
+  echo 'ok 119 - handover reports explicit blocked status through the shared audit'
+else
+  echo 'not ok 119 - handover reports explicit blocked status through the shared audit'
+fi
+
+# Test 120: missing task status is reported through the shared audit
+HO_MISSING_STATUS_ERR="$("$BIN" --root "$HO_REPO" handover TASK-66666 2>&1 >/dev/null)"
+if [[ "$HO_MISSING_STATUS_ERR" == *"non-standard status ''"* ]]; then
+  echo 'ok 120 - handover reports a missing status through the shared audit'
+else
+  echo 'not ok 120 - handover reports a missing status through the shared audit'
+fi
+
+# Test 121: an uncommitted task cannot produce a handover note
+printf '%s\n' \
+  '---' \
+  'id: TASK-77777' \
+  'status: todo' \
+  '---' \
+  '' \
+  '# Dispatch an uncommitted task' \
+  '' \
+  '**Goal:** Keep the note reproducible.' \
+  >"$HO_REPO/proj/tasks/TASK-77777-uncommitted.md"
+set +e
+HO_UNCOMMITTED_OUT="$("$BIN" --root "$HO_REPO" handover TASK-77777 2>&1)"
+HO_UNCOMMITTED_EXIT=$?
+set -e
+if [ "$HO_UNCOMMITTED_EXIT" -ne 0 ] &&
+  [[ "$HO_UNCOMMITTED_OUT" == *"is not committed at HEAD"* ]]; then
+  echo 'ok 121 - handover refuses task records absent from HEAD'
+else
+  echo 'not ok 121 - handover refuses task records absent from HEAD'
+fi
+
+# Test 122: handover help follows the CLI house structure
+HO_HELP="$("$BIN" handover --help)"
+if [[ "$HO_HELP" == Usage:* ]] &&
+  [[ "$HO_HELP" == *"Arguments:"* ]] &&
+  [[ "$HO_HELP" == *"Options:"* ]] &&
+  [[ "$HO_HELP" == *"Examples:"* ]]; then
+  echo 'ok 122 - handover help follows the CLI house structure'
+else
+  echo 'not ok 122 - handover help follows the CLI house structure'
 fi

--- a/skills/taskgo/tests/test-taskgo
+++ b/skills/taskgo/tests/test-taskgo
@@ -45,7 +45,7 @@ printf '%s\n' \
   '# Confirm generated status formatting' \
   >"$REPO/example/tasks/TASK-A1B2C-confirm-status.md"
 
-echo '1..110'
+echo '1..117'
 
 if ("$BIN" --root "$REPO" sync example) &&
   "$MARKDOWN_FORMAT" --check "$REPO/example/STATUS.md" >/dev/null; then
@@ -2053,4 +2053,147 @@ if [ "$SHORT_URI_EXIT" -ne 0 ] && \
   echo 'ok 110 - remainder validation rejects short/malformed URIs, and render_task_file quotes YAML cleanly'
 else
   echo 'not ok 110 - remainder validation rejects short/malformed URIs, and render_task_file quotes YAML cleanly'
+fi
+
+# --- handover ---------------------------------------------------------------
+
+HO_REPO="$TEST_ROOT/ho-repo"
+mkdir -p "$HO_REPO/proj/tasks"
+git -C "$HO_REPO" init -q
+printf '%s\n' \
+  '# Agent instructions' \
+  '' \
+  'This repository follows taskgo:' \
+  '<https://github.com/ithinkihaveacat/dotfiles/tree/master/skills/taskgo>.' \
+  >"$HO_REPO/AGENTS.md"
+printf '# Inbox\n' >"$HO_REPO/INBOX.md"
+printf '# Proj\n' >"$HO_REPO/proj/README.md"
+printf '# Status\n' >"$HO_REPO/proj/STATUS.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-11111' \
+  'status: todo' \
+  '---' \
+  '' \
+  '# Replace the manifest loader with the streaming parser' \
+  '' \
+  '**Problem:** The loader buffers the whole manifest.' \
+  '' \
+  '**Goal:** Cold start stops scaling with manifest size.' \
+  '' \
+  '**Criteria:** Cold start is flat across manifest sizes.' \
+  >"$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-22222' \
+  'status: done' \
+  '---' \
+  '' \
+  '# Land the schema' \
+  >"$HO_REPO/proj/tasks/TASK-22222-schema.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-33333' \
+  'status: todo' \
+  'blocked_by: [TASK-44444]' \
+  '---' \
+  '' \
+  '# Wire the export pipeline' \
+  '' \
+  '**Goal:** Exports run end to end.' \
+  >"$HO_REPO/proj/tasks/TASK-33333-export.md"
+printf '%s\n' \
+  '---' \
+  'id: TASK-44444' \
+  'status: todo' \
+  '---' \
+  '' \
+  '# Freeze the schema' \
+  >"$HO_REPO/proj/tasks/TASK-44444-freeze.md"
+git -C "$HO_REPO" add -A
+git -C "$HO_REPO" commit -qm 'init handover fixture'
+
+# Test 111: the note projects committed tracker state and asserts nothing else
+HO_OUT="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
+# Compare against a single-line rendering: the note is hard-wrapped for pasting.
+HO_FLAT="$(printf '%s' "$HO_OUT" | tr '\n' ' ' | tr -s ' ')"
+if [[ "$HO_FLAT" == *"Next is TASK-11111 (proj): Replace the manifest loader with the streaming parser."* ]] &&
+  [[ "$HO_FLAT" == *"Cold start stops scaling with manifest size."* ]] &&
+  [[ "$HO_FLAT" == *"proj/STATUS.md"* ]] &&
+  [[ "$HO_FLAT" == *"proj/tasks/TASK-11111-manifest-loader.md"* ]] &&
+  [[ "$HO_FLAT" == *"form your own view of the approach."* ]] &&
+  [[ "$HO_FLAT" != *"buffers the whole manifest"* ]] &&
+  [[ "$HO_FLAT" != *"Criteria"* ]]; then
+  echo 'ok 111 - handover emits ID, project, title, and Goal without other task prose'
+else
+  echo 'not ok 111 - handover emits ID, project, title, and Goal without other task prose'
+fi
+
+# Test 112: file references survive wrapping unbroken
+HO_LONG="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
+if [[ "$HO_LONG" == *"(proj/tasks/TASK-11111-manifest-loader.md)"* ]]; then
+  echo 'ok 112 - handover never wraps a path mid-token'
+else
+  echo 'not ok 112 - handover never wraps a path mid-token'
+fi
+
+# Test 113: dispatching finished work is refused
+set +e
+HO_DONE_OUT="$("$BIN" --root "$HO_REPO" handover TASK-22222 2>&1)"
+HO_DONE_EXIT=$?
+set -e
+if [ "$HO_DONE_EXIT" -ne 0 ] &&
+  [[ "$HO_DONE_OUT" == *"taskgo handover: TASK-22222 is done"* ]] &&
+  [[ "$HO_DONE_OUT" == *"--state ready"* ]]; then
+  echo 'ok 113 - handover refuses a done task and points at the ready frontier'
+else
+  echo 'not ok 113 - handover refuses a done task and points at the ready frontier'
+fi
+
+# Test 114: unresolved blockers warn on stderr but still emit a note
+set +e
+HO_BLK_ERR="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>&1 >/dev/null)"
+HO_BLK_EXIT=$?
+set -e
+HO_BLK_OUT="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>/dev/null)"
+if [ "$HO_BLK_EXIT" -eq 0 ] &&
+  [[ "$HO_BLK_ERR" == *"[WARN]"* ]] &&
+  [[ "$HO_BLK_ERR" == *"still blocked by TASK-44444"* ]] &&
+  [[ "$HO_BLK_OUT" == *"Next is TASK-33333"* ]]; then
+  echo 'ok 114 - handover warns on unresolved blockers without failing'
+else
+  echo 'not ok 114 - handover warns on unresolved blockers without failing'
+fi
+
+# Test 115: a missing Goal is reported rather than silently producing a thin note
+set +e
+HO_NG_ERR="$("$BIN" --root "$HO_REPO" handover TASK-44444 2>&1 >/dev/null)"
+set -e
+if [[ "$HO_NG_ERR" == *"[WARN]"* ]] && [[ "$HO_NG_ERR" == *"has no '**Goal:**'"* ]]; then
+  echo 'ok 115 - handover warns when the task states no Goal'
+else
+  echo 'not ok 115 - handover warns when the task states no Goal'
+fi
+
+# Test 116: uncommitted project state is reported (handoff-ready precondition)
+printf 'scratch\n' >>"$HO_REPO/proj/STATUS.md"
+set +e
+HO_DIRTY_ERR="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>&1 >/dev/null)"
+HO_DIRTY_EXIT=$?
+set -e
+git -C "$HO_REPO" checkout -q -- proj/STATUS.md
+if [ "$HO_DIRTY_EXIT" -eq 0 ] &&
+  [[ "$HO_DIRTY_ERR" == *"[WARN]"* ]] &&
+  [[ "$HO_DIRTY_ERR" == *"uncommitted changes"* ]]; then
+  echo 'ok 116 - handover warns when the project has uncommitted changes'
+else
+  echo 'not ok 116 - handover warns when the project has uncommitted changes'
+fi
+
+# Test 117: warnings never contaminate the paste-ready note on stdout
+HO_CLEAN="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>/dev/null)"
+if [[ "$HO_CLEAN" != *"[WARN]"* ]] && [[ "$HO_CLEAN" != *"blocked by"* ]]; then
+  echo 'ok 117 - handover keeps diagnostics off stdout'
+else
+  echo 'not ok 117 - handover keeps diagnostics off stdout'
 fi

--- a/skills/taskgo/tests/test-taskgo
+++ b/skills/taskgo/tests/test-taskgo
@@ -2055,20 +2055,20 @@ else
   echo 'not ok 110 - remainder validation rejects short/malformed URIs, and render_task_file quotes YAML cleanly'
 fi
 
-# --- handover ---------------------------------------------------------------
+# --- dispatch ---------------------------------------------------------------
 
-HO_REPO="$TEST_ROOT/ho-repo"
-mkdir -p "$HO_REPO/proj/tasks"
-git -C "$HO_REPO" init -q
+DISPATCH_REPO="$TEST_ROOT/dispatch-repo"
+mkdir -p "$DISPATCH_REPO/proj/tasks"
+git -C "$DISPATCH_REPO" init -q
 printf '%s\n' \
   '# Agent instructions' \
   '' \
   'This repository follows taskgo:' \
   '<https://github.com/ithinkihaveacat/dotfiles/tree/master/skills/taskgo>.' \
-  >"$HO_REPO/AGENTS.md"
-printf '# Inbox\n' >"$HO_REPO/INBOX.md"
-printf '# Proj\n' >"$HO_REPO/proj/README.md"
-printf '# Status\n' >"$HO_REPO/proj/STATUS.md"
+  >"$DISPATCH_REPO/AGENTS.md"
+printf '# Inbox\n' >"$DISPATCH_REPO/INBOX.md"
+printf '# Proj\n' >"$DISPATCH_REPO/proj/README.md"
+printf '# Status\n' >"$DISPATCH_REPO/proj/STATUS.md"
 printf '%s\n' \
   '---' \
   'id: TASK-11111' \
@@ -2082,7 +2082,7 @@ printf '%s\n' \
   '**Goal:** Cold start stops scaling with manifest size.' \
   '' \
   '**Criteria:** Cold start is flat across manifest sizes.' \
-  >"$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-11111-manifest-loader.md"
 printf '%s\n' \
   '---' \
   'id: TASK-22222' \
@@ -2090,7 +2090,7 @@ printf '%s\n' \
   '---' \
   '' \
   '# Land the schema' \
-  >"$HO_REPO/proj/tasks/TASK-22222-schema.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-22222-schema.md"
 printf '%s\n' \
   '---' \
   'id: TASK-33333' \
@@ -2101,7 +2101,7 @@ printf '%s\n' \
   '# Wire the export pipeline' \
   '' \
   '**Goal:** Exports run end to end.' \
-  >"$HO_REPO/proj/tasks/TASK-33333-export.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-33333-export.md"
 printf '%s\n' \
   '---' \
   'id: TASK-44444' \
@@ -2109,7 +2109,7 @@ printf '%s\n' \
   '---' \
   '' \
   '# Freeze the schema' \
-  >"$HO_REPO/proj/tasks/TASK-44444-freeze.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-44444-freeze.md"
 printf '%s\n' \
   '---' \
   'id: TASK-55555' \
@@ -2119,7 +2119,7 @@ printf '%s\n' \
   '# Wait for an external release' \
   '' \
   '**Goal:** Adopt the release after it ships.' \
-  >"$HO_REPO/proj/tasks/TASK-55555-blocked.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-55555-blocked.md"
 printf '%s\n' \
   '---' \
   'id: TASK-66666' \
@@ -2128,132 +2128,132 @@ printf '%s\n' \
   '# Classify the task' \
   '' \
   '**Goal:** Give the task a valid state.' \
-  >"$HO_REPO/proj/tasks/TASK-66666-missing-status.md"
-("$BIN" --root "$HO_REPO" sync proj >/dev/null)
-git -C "$HO_REPO" add -A
-git -C "$HO_REPO" commit -qm 'init handover fixture'
+  >"$DISPATCH_REPO/proj/tasks/TASK-66666-missing-status.md"
+("$BIN" --root "$DISPATCH_REPO" sync proj >/dev/null)
+git -C "$DISPATCH_REPO" add -A
+git -C "$DISPATCH_REPO" commit -qm 'init dispatch fixture'
 
 # Test 111: the note projects committed tracker state and asserts nothing else
-HO_OUT="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
+DISPATCH_OUT="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-11111 2>/dev/null)"
 # Compare against a single-line rendering: the note is hard-wrapped for pasting.
-HO_FLAT="$(printf '%s' "$HO_OUT" | tr '\n' ' ' | tr -s ' ')"
-if [[ "$HO_FLAT" == *"Next is TASK-11111 (proj): Replace the manifest loader with the streaming parser."* ]] &&
-  [[ "$HO_FLAT" == *"Cold start stops scaling with manifest size."* ]] &&
-  [[ "$HO_FLAT" == *"proj/STATUS.md"* ]] &&
-  [[ "$HO_FLAT" == *"proj/tasks/TASK-11111-manifest-loader.md"* ]] &&
-  [[ "$HO_FLAT" == *"form your own view of the approach."* ]] &&
-  [[ "$HO_FLAT" != *"buffers the whole manifest"* ]] &&
-  [[ "$HO_FLAT" != *"Criteria"* ]]; then
-  echo 'ok 111 - handover emits ID, project, title, and Goal without other task prose'
+DISPATCH_FLAT="$(printf '%s' "$DISPATCH_OUT" | tr '\n' ' ' | tr -s ' ')"
+if [[ "$DISPATCH_FLAT" == *"Next is TASK-11111 (proj): Replace the manifest loader with the streaming parser."* ]] &&
+  [[ "$DISPATCH_FLAT" == *"Cold start stops scaling with manifest size."* ]] &&
+  [[ "$DISPATCH_FLAT" == *"proj/STATUS.md"* ]] &&
+  [[ "$DISPATCH_FLAT" == *"proj/tasks/TASK-11111-manifest-loader.md"* ]] &&
+  [[ "$DISPATCH_FLAT" == *"form your own view of the approach."* ]] &&
+  [[ "$DISPATCH_FLAT" != *"buffers the whole manifest"* ]] &&
+  [[ "$DISPATCH_FLAT" != *"Criteria"* ]]; then
+  echo 'ok 111 - dispatch emits ID, project, title, and Goal without other task prose'
 else
-  echo 'not ok 111 - handover emits ID, project, title, and Goal without other task prose'
+  echo 'not ok 111 - dispatch emits ID, project, title, and Goal without other task prose'
 fi
 
 # Test 112: file references survive wrapping unbroken
-HO_LONG="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
-if [[ "$HO_LONG" == *"(proj/tasks/TASK-11111-manifest-loader.md)"* ]]; then
-  echo 'ok 112 - handover never wraps a path mid-token'
+DISPATCH_LONG="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-11111 2>/dev/null)"
+if [[ "$DISPATCH_LONG" == *"(proj/tasks/TASK-11111-manifest-loader.md)"* ]]; then
+  echo 'ok 112 - dispatch never wraps a path mid-token'
 else
-  echo 'not ok 112 - handover never wraps a path mid-token'
+  echo 'not ok 112 - dispatch never wraps a path mid-token'
 fi
 
 # Test 113: dispatching finished work is refused
 set +e
-HO_DONE_OUT="$("$BIN" --root "$HO_REPO" handover TASK-22222 2>&1)"
-HO_DONE_EXIT=$?
+DISPATCH_DONE_OUT="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-22222 2>&1)"
+DISPATCH_DONE_EXIT=$?
 set -e
-if [ "$HO_DONE_EXIT" -ne 0 ] &&
-  [[ "$HO_DONE_OUT" == *"taskgo handover: TASK-22222 is done"* ]] &&
-  [[ "$HO_DONE_OUT" == *"--state ready"* ]]; then
-  echo 'ok 113 - handover refuses a done task and points at the ready frontier'
+if [ "$DISPATCH_DONE_EXIT" -ne 0 ] &&
+  [[ "$DISPATCH_DONE_OUT" == *"taskgo dispatch: TASK-22222 is done"* ]] &&
+  [[ "$DISPATCH_DONE_OUT" == *"--state ready"* ]]; then
+  echo 'ok 113 - dispatch refuses a done task and points at the ready frontier'
 else
-  echo 'not ok 113 - handover refuses a done task and points at the ready frontier'
+  echo 'not ok 113 - dispatch refuses a done task and points at the ready frontier'
 fi
 
 # Test 114: unresolved blockers warn on stderr but still emit a note
 set +e
-HO_BLK_ERR="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>&1 >/dev/null)"
-HO_BLK_EXIT=$?
+DISPATCH_BLOCKED_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-33333 2>&1 >/dev/null)"
+DISPATCH_BLOCKED_EXIT=$?
 set -e
-HO_BLK_OUT="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>/dev/null)"
-if [ "$HO_BLK_EXIT" -eq 0 ] &&
-  [[ "$HO_BLK_ERR" == *"[WARN]"* ]] &&
-  [[ "$HO_BLK_ERR" == *"still blocked by TASK-44444"* ]] &&
-  [[ "$HO_BLK_OUT" == *"Next is TASK-33333"* ]]; then
-  echo 'ok 114 - handover warns on unresolved blockers without failing'
+DISPATCH_BLOCKED_OUT="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-33333 2>/dev/null)"
+if [ "$DISPATCH_BLOCKED_EXIT" -eq 0 ] &&
+  [[ "$DISPATCH_BLOCKED_ERR" == *"[WARN]"* ]] &&
+  [[ "$DISPATCH_BLOCKED_ERR" == *"still blocked by TASK-44444"* ]] &&
+  [[ "$DISPATCH_BLOCKED_OUT" == *"Next is TASK-33333"* ]]; then
+  echo 'ok 114 - dispatch warns on unresolved blockers without failing'
 else
-  echo 'not ok 114 - handover warns on unresolved blockers without failing'
+  echo 'not ok 114 - dispatch warns on unresolved blockers without failing'
 fi
 
 # Test 115: a missing Goal is reported rather than silently producing a thin note
 set +e
-HO_NG_ERR="$("$BIN" --root "$HO_REPO" handover TASK-44444 2>&1 >/dev/null)"
+DISPATCH_NO_GOAL_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-44444 2>&1 >/dev/null)"
 set -e
-if [[ "$HO_NG_ERR" == *"[WARN]"* ]] && [[ "$HO_NG_ERR" == *"has no '**Goal:**'"* ]]; then
-  echo 'ok 115 - handover warns when the task states no Goal'
+if [[ "$DISPATCH_NO_GOAL_ERR" == *"[WARN]"* ]] && [[ "$DISPATCH_NO_GOAL_ERR" == *"has no '**Goal:**'"* ]]; then
+  echo 'ok 115 - dispatch warns when the task states no Goal'
 else
-  echo 'not ok 115 - handover warns when the task states no Goal'
+  echo 'not ok 115 - dispatch warns when the task states no Goal'
 fi
 
 # Test 116: uncommitted project state is reported (handoff-ready precondition)
-printf 'scratch\n' >>"$HO_REPO/proj/STATUS.md"
+printf 'scratch\n' >>"$DISPATCH_REPO/proj/STATUS.md"
 set +e
-HO_DIRTY_ERR="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>&1 >/dev/null)"
-HO_DIRTY_EXIT=$?
+DISPATCH_DIRTY_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-11111 2>&1 >/dev/null)"
+DISPATCH_DIRTY_EXIT=$?
 set -e
-git -C "$HO_REPO" checkout -q -- proj/STATUS.md
-if [ "$HO_DIRTY_EXIT" -eq 0 ] &&
-  [[ "$HO_DIRTY_ERR" == *"[WARN]"* ]] &&
-  [[ "$HO_DIRTY_ERR" == *"uncommitted changes"* ]]; then
-  echo 'ok 116 - handover warns when the project has uncommitted changes'
+git -C "$DISPATCH_REPO" checkout -q -- proj/STATUS.md
+if [ "$DISPATCH_DIRTY_EXIT" -eq 0 ] &&
+  [[ "$DISPATCH_DIRTY_ERR" == *"[WARN]"* ]] &&
+  [[ "$DISPATCH_DIRTY_ERR" == *"uncommitted changes"* ]]; then
+  echo 'ok 116 - dispatch warns when the project has uncommitted changes'
 else
-  echo 'not ok 116 - handover warns when the project has uncommitted changes'
+  echo 'not ok 116 - dispatch warns when the project has uncommitted changes'
 fi
 
 # Test 117: warnings never contaminate the paste-ready note on stdout
-HO_CLEAN="$("$BIN" --root "$HO_REPO" handover TASK-33333 2>/dev/null)"
-if [[ "$HO_CLEAN" != *"[WARN]"* ]] && [[ "$HO_CLEAN" != *"blocked by"* ]]; then
-  echo 'ok 117 - handover keeps diagnostics off stdout'
+DISPATCH_CLEAN="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-33333 2>/dev/null)"
+if [[ "$DISPATCH_CLEAN" != *"[WARN]"* ]] && [[ "$DISPATCH_CLEAN" != *"blocked by"* ]]; then
+  echo 'ok 117 - dispatch keeps diagnostics off stdout'
 else
-  echo 'not ok 117 - handover keeps diagnostics off stdout'
+  echo 'not ok 117 - dispatch keeps diagnostics off stdout'
 fi
 
 # Test 118: dirty task prose cannot leak into the committed-state projection
 sed -i.bak 's/Cold start stops scaling with manifest size/Use a replacement goal from the working tree/' \
-  "$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md"
+  "$DISPATCH_REPO/proj/tasks/TASK-11111-manifest-loader.md"
 set +e
-HO_DIRTY_TASK_ERR="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>&1 >/dev/null)"
-HO_DIRTY_TASK_EXIT=$?
+DISPATCH_DIRTY_TASK_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-11111 2>&1 >/dev/null)"
+DISPATCH_DIRTY_TASK_EXIT=$?
 set -e
-HO_DIRTY_TASK_OUT="$("$BIN" --root "$HO_REPO" handover TASK-11111 2>/dev/null)"
-git -C "$HO_REPO" checkout -q -- proj/tasks/TASK-11111-manifest-loader.md
-rm -f "$HO_REPO/proj/tasks/TASK-11111-manifest-loader.md.bak"
-if [ "$HO_DIRTY_TASK_EXIT" -eq 0 ] &&
-  [[ "$HO_DIRTY_TASK_ERR" == *"uncommitted changes"* ]] &&
-  [[ "$HO_DIRTY_TASK_OUT" == *"Cold start stops scaling with manifest size."* ]] &&
-  [[ "$HO_DIRTY_TASK_OUT" != *"replacement goal"* ]]; then
-  echo 'ok 118 - handover projects committed task prose when the working tree is dirty'
+DISPATCH_DIRTY_TASK_OUT="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-11111 2>/dev/null)"
+git -C "$DISPATCH_REPO" checkout -q -- proj/tasks/TASK-11111-manifest-loader.md
+rm -f "$DISPATCH_REPO/proj/tasks/TASK-11111-manifest-loader.md.bak"
+if [ "$DISPATCH_DIRTY_TASK_EXIT" -eq 0 ] &&
+  [[ "$DISPATCH_DIRTY_TASK_ERR" == *"uncommitted changes"* ]] &&
+  [[ "$DISPATCH_DIRTY_TASK_OUT" == *"Cold start stops scaling with manifest size."* ]] &&
+  [[ "$DISPATCH_DIRTY_TASK_OUT" != *"replacement goal"* ]]; then
+  echo 'ok 118 - dispatch projects committed task prose when the working tree is dirty'
 else
-  echo 'not ok 118 - handover projects committed task prose when the working tree is dirty'
+  echo 'not ok 118 - dispatch projects committed task prose when the working tree is dirty'
 fi
 
 # Test 119: explicit blocked state warns even without a blocked_by edge
-HO_STATUS_BLOCKED_ERR="$("$BIN" --root "$HO_REPO" handover TASK-55555 2>&1 >/dev/null)"
-if [[ "$HO_STATUS_BLOCKED_ERR" == *"status is blocked but no blocked_by edges"* ]]; then
-  echo 'ok 119 - handover reports explicit blocked status through the shared audit'
+DISPATCH_STATUS_BLOCKED_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-55555 2>&1 >/dev/null)"
+if [[ "$DISPATCH_STATUS_BLOCKED_ERR" == *"status is blocked but no blocked_by edges"* ]]; then
+  echo 'ok 119 - dispatch reports explicit blocked status through the shared audit'
 else
-  echo 'not ok 119 - handover reports explicit blocked status through the shared audit'
+  echo 'not ok 119 - dispatch reports explicit blocked status through the shared audit'
 fi
 
 # Test 120: missing task status is reported through the shared audit
-HO_MISSING_STATUS_ERR="$("$BIN" --root "$HO_REPO" handover TASK-66666 2>&1 >/dev/null)"
-if [[ "$HO_MISSING_STATUS_ERR" == *"non-standard status ''"* ]]; then
-  echo 'ok 120 - handover reports a missing status through the shared audit'
+DISPATCH_MISSING_STATUS_ERR="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-66666 2>&1 >/dev/null)"
+if [[ "$DISPATCH_MISSING_STATUS_ERR" == *"non-standard status ''"* ]]; then
+  echo 'ok 120 - dispatch reports a missing status through the shared audit'
 else
-  echo 'not ok 120 - handover reports a missing status through the shared audit'
+  echo 'not ok 120 - dispatch reports a missing status through the shared audit'
 fi
 
-# Test 121: an uncommitted task cannot produce a handover note
+# Test 121: an uncommitted task cannot produce a dispatch note
 printf '%s\n' \
   '---' \
   'id: TASK-77777' \
@@ -2263,25 +2263,28 @@ printf '%s\n' \
   '# Dispatch an uncommitted task' \
   '' \
   '**Goal:** Keep the note reproducible.' \
-  >"$HO_REPO/proj/tasks/TASK-77777-uncommitted.md"
+  >"$DISPATCH_REPO/proj/tasks/TASK-77777-uncommitted.md"
 set +e
-HO_UNCOMMITTED_OUT="$("$BIN" --root "$HO_REPO" handover TASK-77777 2>&1)"
-HO_UNCOMMITTED_EXIT=$?
+DISPATCH_UNCOMMITTED_OUT="$("$BIN" --root "$DISPATCH_REPO" dispatch TASK-77777 2>&1)"
+DISPATCH_UNCOMMITTED_EXIT=$?
 set -e
-if [ "$HO_UNCOMMITTED_EXIT" -ne 0 ] &&
-  [[ "$HO_UNCOMMITTED_OUT" == *"is not committed at HEAD"* ]]; then
-  echo 'ok 121 - handover refuses task records absent from HEAD'
+if [ "$DISPATCH_UNCOMMITTED_EXIT" -ne 0 ] &&
+  [[ "$DISPATCH_UNCOMMITTED_OUT" == *"is not committed at HEAD"* ]]; then
+  echo 'ok 121 - dispatch refuses task records absent from HEAD'
 else
-  echo 'not ok 121 - handover refuses task records absent from HEAD'
+  echo 'not ok 121 - dispatch refuses task records absent from HEAD'
 fi
 
-# Test 122: handover help follows the CLI house structure
-HO_HELP="$("$BIN" handover --help)"
-if [[ "$HO_HELP" == Usage:* ]] &&
-  [[ "$HO_HELP" == *"Arguments:"* ]] &&
-  [[ "$HO_HELP" == *"Options:"* ]] &&
-  [[ "$HO_HELP" == *"Examples:"* ]]; then
-  echo 'ok 122 - handover help follows the CLI house structure'
+# Test 122: dispatch help follows the CLI house structure
+DISPATCH_HELP="$("$BIN" dispatch --help)"
+DISPATCH_TOP_HELP="$("$BIN" --help)"
+if [[ "$DISPATCH_HELP" == Usage:* ]] &&
+  [[ "$DISPATCH_HELP" == *"Arguments:"* ]] &&
+  [[ "$DISPATCH_HELP" == *"Options:"* ]] &&
+  [[ "$DISPATCH_HELP" == *"Examples:"* ]] &&
+  [[ "$DISPATCH_TOP_HELP" == *"dispatch TASK_ID"* ]] &&
+  [[ "$DISPATCH_TOP_HELP" != *"handover TASK_ID"* ]]; then
+  echo 'ok 122 - dispatch help follows the CLI house structure'
 else
-  echo 'not ok 122 - handover help follows the CLI house structure'
+  echo 'not ok 122 - dispatch help follows the CLI house structure'
 fi


### PR DESCRIPTION
Ejection covers handing a task to an isolated worker with no control
repo. It does not cover the commoner case of handing off to a successor
agent that does hold the control repo, usually started immediately after
the previous session ended.

The two are opposites in what they carry. An ejection payload is long
because the worker can read nothing else; a handover note is short
because the successor can read the tracker, the artifact repos, history,
and often the prior session transcript. So the note carries only
conversational residue that is true but not yet worth recording as
belief, plus the task ID and the prior conversation identifier for
provenance.

A long handover is documented as a symptom rather than a style: it means
the tracker is not handoff-ready and the repair belongs there. Length
also biases the successor, which is supposed to form its own reading of
the problem. Notes stay in the chat response rather than being
committed, so HEAD does not reacquire a journal.

Also states the calibration element as orientation rather than
cheerleading, which the technical-writing tone rules otherwise forbid,
and directs agents to offer a handover unprompted after substantial work
with no recent human interaction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRLQxV4sSE1v61XXUiGcoU